### PR TITLE
Prevent `Subscriber.seq` data race and slow replay emits from filling subscriber outbox

### DIFF
--- a/cmd/jetstream/main.go
+++ b/cmd/jetstream/main.go
@@ -88,6 +88,12 @@ func main() {
 			Value:   5_000,
 			EnvVars: []string{"JETSTREAM_MAX_SUB_RATE"},
 		},
+		&cli.BoolFlag{
+			Name:     "per-ip-limit",
+			Usage:    "share max-sub-rate limit by client IP",
+			Value:    true,
+			EnvVars:  []string{"JETSTREAM_PER_IP_LIMIT"},
+		},
 		&cli.Int64Flag{
 			Name:    "override-relay-cursor",
 			Usage:   "override cursor to start from, if not set will start from the last cursor in the database, if no cursor in the database will start from live",
@@ -124,7 +130,7 @@ func Jetstream(cctx *cli.Context) error {
 		return fmt.Errorf("failed to parse ws-url: %w", err)
 	}
 
-	s, err := server.NewServer(cctx.Float64("max-sub-rate"))
+	s, err := server.NewServer(cctx.Float64("max-sub-rate"), cctx.Bool("per-ip-limit"))
 	if err != nil {
 		return fmt.Errorf("failed to create server: %w", err)
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -310,7 +310,7 @@ func (s *Server) Emit(ctx context.Context, e *models.Event, asJSON, compBytes []
 			defer sub.lk.Unlock()
 
 			// Don't emit events to subscribers that are replaying and are too far behind
-			if sub.cursor != nil && sub.seq < e.TimeUS-cutoverThresholdUS || sub.tearingDown {
+			if sub.cursor != nil && sub.seq.Load() < e.TimeUS-cutoverThresholdUS || sub.tearingDown {
 				return
 			}
 

--- a/pkg/server/subscriber.go
+++ b/pkg/server/subscriber.go
@@ -221,7 +221,9 @@ func (s *Server) AddSubscriber(ws *websocket.Conn, realIP string, opts *Subscrib
 	lim := s.perIPLimiters[realIP]
 	if lim == nil {
 		lim = rate.NewLimiter(rate.Limit(s.maxSubRate), int(s.maxSubRate))
-		s.perIPLimiters[realIP] = lim
+		if s.limitPerIP {
+			s.perIPLimiters[realIP] = lim
+		}
 	}
 
 	sub := Subscriber{

--- a/pkg/server/subscriber.go
+++ b/pkg/server/subscriber.go
@@ -89,6 +89,9 @@ func emitToSubscriber(ctx context.Context, log *slog.Logger, sub *Subscriber, ti
 			moreCurrentSeq := sub.seq.Swap(timeUS)
 			if moreCurrentSeq != currentSeq {
 				log.Warn("subscriber sequence updated while we were using it", "warning", "emit collision", "subscriber", sub.id, "playback", playback)
+				if moreCurrentSeq > timeUS { // it's possible that it didn't lead to out-of-order events this time
+					log.Error("emitted to subscriber out of order", "error", "emitted out of order", "subscriber", sub.id, "playback", playback)
+				}
 			}
 			sub.deliveredCounter.Inc()
 			sub.bytesCounter.Add(float64(len(evtBytes)))
@@ -108,6 +111,9 @@ func emitToSubscriber(ctx context.Context, log *slog.Logger, sub *Subscriber, ti
 			moreCurrentSeq := sub.seq.Swap(timeUS)
 			if moreCurrentSeq != currentSeq {
 				log.Warn("subscriber sequence updated while we were using it", "warning", "emit collision", "subscriber", sub.id, "playback", playback)
+				if moreCurrentSeq > timeUS { // it's possible that it didn't lead to out-of-order events this time
+					log.Error("emitted to subscriber out of order", "error", "emitted out of order", "subscriber", sub.id, "playback", playback)
+				}
 			}
 			sub.deliveredCounter.Inc()
 			sub.bytesCounter.Add(float64(len(evtBytes)))


### PR DESCRIPTION
#43 without (hopefully) its potentially-livetail-blocking side-effect.

During a small window around cutover from replay to live-tail, both goroutines are concurrently pushing messages to the subscriber's outbox, and read-modify-write'ing the subscriber's `seq` as part of that. This data race [can be detected with golang's race detector](https://github.com/bluesky-social/jetstream/issues/42#issuecomment-2666884989), so jetstream currently has some undefined behaviour.

This change swaps the racing `int64` for its atomic counterpart. It's probably disappointing. It doesn't fix the _logical_ data race (we still read-modify-write concurrently) but does address the undefined behaviour in the binary. Plus, atomics let us write with a `Swap`, so we can actually detect when the race happens and at least know about it.

As a result, the race detector no longer complains. Out-of-order events are still reproducible for me locally with the repro from #43, and made slightly easier to test by adding a `--per-ip-limit=0` flag for local dev, so that multiple websockets from localhost are not combined into a single ratelimiter. (by default the current per-ip limiting behaviour is retained)

Finally, in an attempt to reduce the problems reported in #27 and #31, the subscriber outbox is monitored when emitting during replay to slow down if it reaches 1/3 of its capacity. Since replay uses blocking sends, we don't really need to use the full outbox capacity, and this gives the client a better chance of surviving cutover since it will hopefully make it unlikely that their outbox is near-full at that time. (more detail in the last commit)