### PR TITLE
Add subscriber options update to client

### DIFF
--- a/pkg/models/message.go
+++ b/pkg/models/message.go
@@ -1,0 +1,18 @@
+package models
+
+import (
+	"encoding/json"
+)
+
+var SubMessageOptionsUpdate = "options_update"
+
+type SubscriberSourcedMessage struct {
+	Type    string          `json:"type"`
+	Payload json.RawMessage `json:"payload"`
+}
+
+type SubscriberOptionsUpdatePayload struct {
+	WantedCollections   []string `json:"wantedCollections"`
+	WantedDIDs          []string `json:"wantedDids"`
+	MaxMessageSizeBytes int      `json:"maxMessageSizeBytes"`
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -151,7 +151,7 @@ func (s *Server) HandleSubscribe(c echo.Context) error {
 				log.Info("received text message from client, parsing as subscriber options update")
 				log.Debug("text message from client content", "msg", string(msgBytes))
 
-				var subMessage SubscriberSourcedMessage
+				var subMessage models.SubscriberSourcedMessage
 				if err := json.Unmarshal(msgBytes, &subMessage); err != nil {
 					log.Error("failed to unmarshal subscriber sourced message", "error", err, "msg", string(msgBytes))
 					sub.Terminate(fmt.Sprintf("failed to unmarshal subscriber sourced message: %v", err))
@@ -160,8 +160,8 @@ func (s *Server) HandleSubscribe(c echo.Context) error {
 				}
 
 				switch subMessage.Type {
-				case SubMessageOptionsUpdate:
-					var subOptsUpdate SubscriberOptionsUpdatePayload
+				case models.SubMessageOptionsUpdate:
+					var subOptsUpdate models.SubscriberOptionsUpdatePayload
 					if err := json.Unmarshal(subMessage.Payload, &subOptsUpdate); err != nil {
 						log.Error("failed to unmarshal subscriber options update", "error", err, "msg", string(msgBytes))
 						sub.Terminate(fmt.Sprintf("failed to unmarshal subscriber options update: %v", err))

--- a/pkg/server/subscriber.go
+++ b/pkg/server/subscriber.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -120,19 +119,6 @@ func emitToSubscriber(ctx context.Context, log *slog.Logger, sub *Subscriber, ti
 	}
 
 	return nil
-}
-
-var SubMessageOptionsUpdate = "options_update"
-
-type SubscriberSourcedMessage struct {
-	Type    string          `json:"type"`
-	Payload json.RawMessage `json:"payload"`
-}
-
-type SubscriberOptionsUpdatePayload struct {
-	WantedCollections   []string `json:"wantedCollections"`
-	WantedDIDs          []string `json:"wantedDids"`
-	MaxMessageSizeBytes int      `json:"maxMessageSizeBytes"`
 }
 
 type SubscriberOptions struct {

--- a/pkg/server/subscriber_test.go
+++ b/pkg/server/subscriber_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/bluesky-social/jetstream/pkg/models"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -91,12 +92,12 @@ func TestParseSubscriberOptions(t *testing.T) {
 	testCases := []struct {
 		name     string
 		data     []byte
-		expected SubscriberOptionsUpdatePayload
+		expected models.SubscriberOptionsUpdatePayload
 	}{
 		{
 			name: "empty",
 			data: []byte(`{}`),
-			expected: SubscriberOptionsUpdatePayload{
+			expected: models.SubscriberOptionsUpdatePayload{
 				WantedCollections:   nil,
 				WantedDIDs:          nil,
 				MaxMessageSizeBytes: 0,
@@ -105,7 +106,7 @@ func TestParseSubscriberOptions(t *testing.T) {
 		{
 			name: "collection",
 			data: []byte(`{"wantedCollections":["foo"]}`),
-			expected: SubscriberOptionsUpdatePayload{
+			expected: models.SubscriberOptionsUpdatePayload{
 				WantedCollections:   []string{"foo"},
 				WantedDIDs:          nil,
 				MaxMessageSizeBytes: 0,
@@ -114,7 +115,7 @@ func TestParseSubscriberOptions(t *testing.T) {
 		{
 			name: "small",
 			data: []byte(`{"maxMessageSizeBytes":1000}`),
-			expected: SubscriberOptionsUpdatePayload{
+			expected: models.SubscriberOptionsUpdatePayload{
 				WantedCollections:   nil,
 				WantedDIDs:          nil,
 				MaxMessageSizeBytes: 1000,
@@ -124,7 +125,7 @@ func TestParseSubscriberOptions(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			var subOptsUpdate SubscriberOptionsUpdatePayload
+			var subOptsUpdate models.SubscriberOptionsUpdatePayload
 			if err := json.Unmarshal(testCase.data, &subOptsUpdate); err != nil {
 				t.Errorf("failed to unmarshal subscriber options update: %v", err)
 			}


### PR DESCRIPTION
This PR gives users of the jetstream Go client implementation the ability to send dynamic subscriber option updates back to the server. Also included is support for the `requireHello` parameter.

The implementation of this functionality is straightforward as it consists of a simple single call to the underlying connection.

To avoid introducing a large dependency to the `client` package, the definitions of `SubscriberSourcedMessage` and `SubscriberOptionsUpdateMsg` are relocated from the `server` package to the `model` package.

Because this relocation would break compatibility with external code that references the definitions, this PR is separated into multiple commits. The first commit adds the new functionality without modifying any existing interfaces; the second refactors existing code to use the shared definitions.