### PR TITLE
Fix MaxSize query parameter name

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -99,7 +99,7 @@ func (c *Client) ConnectAndRead(ctx context.Context, cursor *int64) error {
 	}
 
 	if c.config.MaxSize > 0 {
-		params = append(params, fmt.Sprintf("maxSize=%d", c.config.MaxSize))
+		params = append(params, fmt.Sprintf("maxMessageSizeBytes=%d", c.config.MaxSize))
 	}
 
 	if len(params) > 0 {


### PR DESCRIPTION
It looks like that `maxSize` is an outdated query parameter name.
It should be `maxMessageSizeBytes`.

I verified this by testing from `cmd/client/main.go` with
serverAddr = "wss://jetstream2.us-west.bsky.network/subscribe" and setting
config.MaxSize = 200, which worked as expected.