### PR TITLE
per-subscriber outbox size config

### DIFF
--- a/cmd/jetstream/main.go
+++ b/cmd/jetstream/main.go
@@ -89,6 +89,12 @@ func main() {
 			EnvVars: []string{"JETSTREAM_MAX_SUB_RATE"},
 		},
 		&cli.Int64Flag{
+			Name:    "sub-outbox-size",
+			Usage:   "channel depth (event count) per subscriber",
+			Value:   50_000,
+			EnvVars: []string{"JETSTREAM_SUB_OUTBOX_SIZE"},
+		},
+		&cli.Int64Flag{
 			Name:    "override-relay-cursor",
 			Usage:   "override cursor to start from, if not set will start from the last cursor in the database, if no cursor in the database will start from live",
 			Value:   -1,
@@ -124,7 +130,7 @@ func Jetstream(cctx *cli.Context) error {
 		return fmt.Errorf("failed to parse ws-url: %w", err)
 	}
 
-	s, err := server.NewServer(cctx.Float64("max-sub-rate"))
+	s, err := server.NewServer(cctx.Float64("max-sub-rate"), cctx.Int64("sub-outbox-size"))
 	if err != nil {
 		return fmt.Errorf("failed to create server: %w", err)
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -26,6 +26,7 @@ type Server struct {
 	nextSub       int64
 	Consumer      *consumer.Consumer
 	maxSubRate    float64
+	subOutboxSize int64
 	seq           int64
 	perIPLimiters map[string]*rate.Limiter
 }
@@ -40,10 +41,11 @@ var maxConcurrentEmits = int64(100)
 var cutoverThresholdUS = int64(1_000_000)
 var tracer = otel.Tracer("jetstream-server")
 
-func NewServer(maxSubRate float64) (*Server, error) {
+func NewServer(maxSubRate float64, subOutboxSize int64) (*Server, error) {
 	s := Server{
 		Subscribers:   make(map[int64]*Subscriber),
 		maxSubRate:    maxSubRate,
+		subOutboxSize: subOutboxSize,
 		perIPLimiters: make(map[string]*rate.Limiter),
 	}
 

--- a/pkg/server/subscriber.go
+++ b/pkg/server/subscriber.go
@@ -214,7 +214,7 @@ func (s *Server) AddSubscriber(ws *websocket.Conn, realIP string, opts *Subscrib
 	sub := Subscriber{
 		ws:                  ws,
 		realIP:              realIP,
-		outbox:              make(chan *[]byte, 50_000),
+		outbox:              make(chan *[]byte, s.subOutboxSize),
 		hello:               make(chan struct{}),
 		id:                  s.nextSub,
 		wantedCollections:   opts.WantedCollections,


### PR DESCRIPTION
I suspect this is one of the main contributors to RAM consumption (which has caused OOM looping on some instances).

This PR both makes this value configurable, ~and lowers the default from 50k to 20k~. If events are 1 KByte on average, then they could have been consuming 50 MByte per subscriber, or 10 GByte of RAM for 200 subscribers.

Downside is resilience of connections when subscriber does slow processing or there are network glitches.

(updated to only add config, not drop the default)