### PR TITLE
Fix client doesn't close after context is canceled

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/bluesky-social/jetstream/pkg/models"
 	"github.com/goccy/go-json"
@@ -141,48 +142,53 @@ func (c *Client) readLoop(ctx context.Context) error {
 	bytesRead := bytesRead.WithLabelValues(c.config.WebsocketURL)
 	eventsRead := eventsRead.WithLabelValues(c.config.WebsocketURL)
 
-	for {
+	go func() {
 		select {
 		case <-ctx.Done():
+			_ = c.con.SetReadDeadline(time.Now())
 			c.logger.Info("shutting down read loop on context completion")
-			return nil
 		case s := <-c.shutdown:
+			_ = c.con.SetReadDeadline(time.Now())
 			c.logger.Info("shutting down read loop on shutdown signal")
 			s <- struct{}{}
-			return nil
-		default:
-			_, msg, err := c.con.ReadMessage()
+		}
+	}()
+
+	for {
+		_, msg, err := c.con.ReadMessage()
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			c.logger.Error("failed to read message from websocket", "error", err)
+			return fmt.Errorf("failed to read message from websocket: %w", err)
+		}
+
+		bytesRead.Add(float64(len(msg)))
+		eventsRead.Inc()
+		c.BytesRead.Add(int64(len(msg)))
+		c.EventsRead.Inc()
+
+		// Decompress the message if necessary
+		if c.decoder != nil && c.config.Compress {
+			m, err := c.decoder.DecodeAll(msg, nil)
 			if err != nil {
-				c.logger.Error("failed to read message from websocket", "error", err)
-				return fmt.Errorf("failed to read message from websocket: %w", err)
+				c.logger.Error("failed to decompress message", "error", err)
+				return fmt.Errorf("failed to decompress message: %w", err)
 			}
+			msg = m
+		}
 
-			bytesRead.Add(float64(len(msg)))
-			eventsRead.Inc()
-			c.BytesRead.Add(int64(len(msg)))
-			c.EventsRead.Inc()
+		// Unpack the message and pass it to the handler
+		var event models.Event
+		if err := json.Unmarshal(msg, &event); err != nil {
+			c.logger.Error("failed to unmarshal event", "error", err)
+			return fmt.Errorf("failed to unmarshal event: %w", err)
+		}
 
-			// Decompress the message if necessary
-			if c.decoder != nil && c.config.Compress {
-				m, err := c.decoder.DecodeAll(msg, nil)
-				if err != nil {
-					c.logger.Error("failed to decompress message", "error", err)
-					return fmt.Errorf("failed to decompress message: %w", err)
-				}
-				msg = m
-			}
-
-			// Unpack the message and pass it to the handler
-			var event models.Event
-			if err := json.Unmarshal(msg, &event); err != nil {
-				c.logger.Error("failed to unmarshal event", "error", err)
-				return fmt.Errorf("failed to unmarshal event: %w", err)
-			}
-
-			if err := c.Scheduler.AddWork(ctx, event.Did, &event); err != nil {
-				c.logger.Error("failed to add work to scheduler", "error", err)
-				return fmt.Errorf("failed to add work to scheduler: %w", err)
-			}
+		if err := c.Scheduler.AddWork(ctx, event.Did, &event); err != nil {
+			c.logger.Error("failed to add work to scheduler", "error", err)
+			return fmt.Errorf("failed to add work to scheduler: %w", err)
 		}
 	}
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1,0 +1,61 @@
+package client
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/bluesky-social/jetstream/pkg/models"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+)
+
+var upgrader = websocket.Upgrader{
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+}
+
+type noopScheduler struct{}
+
+func (*noopScheduler) AddWork(ctx context.Context, repo string, evt *models.Event) error { return nil }
+func (*noopScheduler) Shutdown()                                                         {}
+
+func TestClient_ExitsWhenContextIsCanceled(t *testing.T) {
+	listener, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+
+	t.Cleanup(func() { listener.Close() })
+
+	go func() {
+		err := http.Serve(listener, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, err := upgrader.Upgrade(w, r, nil)
+			require.NoError(t, err)
+			ch := make(chan struct{})
+			t.Cleanup(func() { close(ch) })
+			<-ch
+		}))
+		require.NoError(t, err)
+	}()
+
+	client, err := NewClient(&ClientConfig{WebsocketURL: "ws://" + listener.Addr().String()}, slog.New(slog.DiscardHandler), &noopScheduler{})
+	require.NoError(t, err)
+	var cursor int64
+	ctx, cancel := context.WithCancel(context.Background())
+	waitForClientExit := make(chan struct{})
+	go func() {
+		err = client.ConnectAndRead(ctx, &cursor)
+		require.NoError(t, err)
+		waitForClientExit <- struct{}{}
+	}()
+	time.Sleep(time.Millisecond * 10)
+	cancel()
+
+	select {
+	case <-time.After(time.Millisecond * 500):
+		require.FailNow(t, "timed out waiting for client to exit")
+	case <-waitForClientExit:
+	}
+}


### PR DESCRIPTION
This fixes a bug where the client hangs after the context is canceled.

The bug is caused by `ReadMessage` not being aware of the context, so we just hang indefinitely and never check the shutdown or done channel.

This also adds a test that makes sure that the client exits timely without error when the context is canceled. The test doesn't pass on `main`.

We noticed this in https://github.com/furrylist/bsky-furry-feed/pull/151 where having too many tests likely causes a race, where we no longer cancel while the websocket is reading, so we always time out and never exit the Jetstream client.
