### PR TITLE
Fix race when emitting to replaying subscribers

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -221,6 +221,8 @@ func (s *Server) HandleSubscribe(c echo.Context) error {
 		go func() {
 			for {
 				lastSeq, err := s.Consumer.ReplayEvents(ctx, sub.compress, *sub.cursor, playbackRateLimit, func(ctx context.Context, timeUS int64, did, collection string, getEventBytes func() []byte) error {
+					sub.lk.Lock()
+					defer sub.lk.Unlock()
 					return emitToSubscriber(ctx, log, sub, timeUS, did, collection, true, getEventBytes)
 				})
 				if err != nil {

--- a/pkg/server/subscriber.go
+++ b/pkg/server/subscriber.go
@@ -108,9 +108,10 @@ func emitToSubscriber(ctx context.Context, log *slog.Logger, sub *Subscriber, ti
 			// Drop slow subscribers if they're live tailing and fall too far behind
 			log.Error("failed to send event to subscriber, dropping", "error", "buffer full", "subscriber", sub.id)
 
-			// Tearing down a subscriber can block, so do it in a goroutine
+			// We must set tearingDown while we have the lock
+			sub.tearingDown = true
+			// Closing a subscriber can block, so do it in a goroutine
 			go func() {
-				sub.tearingDown = true
 				// Don't send a close message cause they won't get it (the socket is backed up)
 				err := sub.ws.Close()
 				if err != nil {


### PR DESCRIPTION
This fixes (what I believe is) a race when a subscriber is playing back.

Looking at the race report, what is happening is that we check for
`sub.cursor != nil` in `Server.Emit` while we set `sub.seq` in
`emitToSubscriber`.

This doesn't happen for normal emissions because when `emitToSubscriber`
is called in `Server.Emit` (as opposed to in `ReplayEvents`), we are
still holding the subscriber's lock.

This _shouldn't_ affect production environments because reading outdated
values isn't a TOCTOU or something.

Though the second fix to do `tearingDown` while holding the lock could
have some impact to cause us writing and closing at the same time but
that seems unlikely?

Anyway, this fixes our test and no longer causes it to report a race.

## Example report

See https://github.com/furrylist/bsky-furry-feed/actions/runs/24005991988/job/70009682457#step:5:631.

```
WARNING: DATA RACE
Read at 0x00c000b1e3e8 by goroutine 1155:
  github.com/bluesky-social/jetstream/pkg/server.(*Server).Emit.func4()
      /home/runner/work/bsky-furry-feed/bsky-furry-feed/vendored/jetstream/pkg/server/server.go:330 +0x191
  github.com/bluesky-social/jetstream/pkg/server.(*Server).Emit.gowrap2()
      /home/runner/work/bsky-furry-feed/bsky-furry-feed/vendored/jetstream/pkg/server/server.go:341 +0x41

Previous write at 0x00c000b1e3e8 by goroutine 1154:
  github.com/bluesky-social/jetstream/pkg/server.emitToSubscriber()
      /home/runner/work/bsky-furry-feed/bsky-furry-feed/vendored/jetstream/pkg/server/subscriber.go:88 +0x47a
  github.com/bluesky-social/jetstream/pkg/server.(*Server).HandleSubscribe.func2.1()
      /home/runner/work/bsky-furry-feed/bsky-furry-feed/vendored/jetstream/pkg/server/server.go:224 +0xc8
  github.com/bluesky-social/jetstream/pkg/consumer.(*Consumer).ReplayEvents()
      /home/runner/work/bsky-furry-feed/bsky-furry-feed/vendored/jetstream/pkg/consumer/persist.go:212 +0x772
  github.com/bluesky-social/jetstream/pkg/server.(*Server).HandleSubscribe.func2()
      /home/runner/work/bsky-furry-feed/bsky-furry-feed/vendored/jetstream/pkg/server/server.go:223 +0x204

Goroutine 1155 (running) created at:
  github.com/bluesky-social/jetstream/pkg/server.(*Server).Emit()
      /home/runner/work/bsky-furry-feed/bsky-furry-feed/vendored/jetstream/pkg/server/server.go:324 +0x733
  github.com/bluesky-social/jetstream/pkg/server.(*Server).Emit-fm()
      <autogenerated>:1 +0xd3
  github.com/bluesky-social/jetstream/pkg/consumer.(*Consumer).RunSequencer.func1()
      /home/runner/work/bsky-furry-feed/bsky-furry-feed/vendored/jetstream/pkg/consumer/consumer.go:373 +0x3c5

Goroutine 1154 (running) created at:
  github.com/bluesky-social/jetstream/pkg/server.(*Server).HandleSubscribe()
      /home/runner/work/bsky-furry-feed/bsky-furry-feed/vendored/jetstream/pkg/server/server.go:221 +0x13bc
  github.com/bluesky-social/jetstream/pkg/server.(*Server).HandleSubscribe-fm()
      <autogenerated>:1 +0x47
  github.com/labstack/echo/v4.(*Echo).add.func1()
      /home/runner/go/pkg/mod/github.com/labstack/echo/v4@v4.11.3/echo.go:582 +0x76
  github.com/labstack/echo/v4.(*Echo).ServeHTTP()
      /home/runner/go/pkg/mod/github.com/labstack/echo/v4@v4.11.3/echo.go:669 +0x7e5
  net/http.serverHandler.ServeHTTP()
      /opt/hostedtoolcache/go/1.25.6/x64/src/net/http/server.go:3340 +0x2a1
  net/http.(*conn).serve()
      /opt/hostedtoolcache/go/1.25.6/x64/src/net/http/server.go:2109 +0xda4
  net/http.(*Server).Serve.gowrap3()
      /opt/hostedtoolcache/go/1.25.6/x64/src/net/http/server.go:3493 +0x4f
```