### PR TITLE
backfill: batch repo completion durability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ We track work as **GitHub issues in this repo** (`gh issue ...`). This is an ope
 - *Definition of done* — the observable outcome that closes the issue (behaviour, test, metric).
 - *Notes* — open questions, alternatives considered, or follow-ups to split out later (kaizen: record out-of-scope problems as their own issues rather than scope-creeping this one).
 
-**Labels** — use the existing defaults; don't invent a taxonomy without discussion. `bug` (incorrect behaviour), `enhancement` (new capability), `documentation` (docs/comments), `question`, `help wanted`, `good first issue`. Apply at most one type label plus any meta labels that fit.
+**Labels** — use the existing labels; don't invent a taxonomy without discussion.
 
 **Status & linking** — the worklog lives in the issue:
 - Post a comment when meaningfully starting or when state changes (blocked, approach changed, finding). These comments are the persistent log — favour a short comment over silence.

--- a/internal/ingest/async_flush.go
+++ b/internal/ingest/async_flush.go
@@ -211,14 +211,13 @@ func (w *Writer) closeAsync() error {
 		return flushErr
 	}
 	closeErr := w.active.Close()
-	saveErr := saveNextSeq(w.cfg.Store, w.cfg.SeqKey, w.nextSeq)
 	if flushErr != nil {
 		return flushErr
 	}
 	if closeErr != nil {
 		return fmt.Errorf("ingest: close active segment: %w", closeErr)
 	}
-	return saveErr
+	return w.commitTerminalDurableBatchLocked()
 }
 
 func (w *Writer) sealActiveAndCloseAsync() error {
@@ -248,7 +247,7 @@ func (w *Writer) sealActiveAndCloseAsync() error {
 		}
 		return fmt.Errorf("ingest: seal active segment: %w", err)
 	}
-	if err := saveNextSeq(w.cfg.Store, w.cfg.SeqKey, w.nextSeq); err != nil {
+	if err := w.commitTerminalDurableBatchLocked(); err != nil {
 		return err
 	}
 	sealedIdx := w.activeIdx

--- a/internal/ingest/async_flush.go
+++ b/internal/ingest/async_flush.go
@@ -158,7 +158,7 @@ func (w *Writer) commitAsyncFlush(ctx context.Context, job *asyncFlushJob, frame
 		}
 		w.cfg.Metrics.incBlocksFlushed()
 
-		if err := saveNextSeq(w.cfg.Store, w.cfg.SeqKey, job.nextSeq); err != nil {
+		if err := w.commitDurableBatchLocked(ctx, job.nextSeq, false); err != nil {
 			return err
 		}
 

--- a/internal/ingest/async_flush.go
+++ b/internal/ingest/async_flush.go
@@ -120,14 +120,17 @@ func (w *Writer) prepareAsyncFlushLocked() (*asyncFlushJob, error) {
 	return job, nil
 }
 
-func (w *Writer) waitAsyncFlushes(jobs []*asyncFlushJob) error {
-	var firstErr error
+func (w *Writer) submitAsyncFlushes(jobs []*asyncFlushJob) {
 	for _, job := range jobs {
 		if job == nil {
 			continue
 		}
 		w.async.jobs <- job
 	}
+}
+
+func (w *Writer) waitSubmittedAsyncFlushes(jobs []*asyncFlushJob) error {
+	var firstErr error
 	for _, job := range jobs {
 		if job == nil {
 			continue
@@ -180,19 +183,25 @@ func (w *Writer) commitAsyncFlush(ctx context.Context, job *asyncFlushJob, frame
 }
 
 func (w *Writer) closeAsync() error {
+	w.drainMu.Lock()
 	w.mu.Lock()
 	if w.closed {
 		w.mu.Unlock()
+		w.drainMu.Unlock()
 		return nil
 	}
 	job, err := w.prepareAsyncFlushLocked()
 	w.closed = true
 	w.mu.Unlock()
+	if err == nil {
+		w.submitAsyncFlushes([]*asyncFlushJob{job})
+	}
+	w.drainMu.Unlock()
 	if err != nil {
 		return err
 	}
 
-	flushErr := w.waitAsyncFlushes([]*asyncFlushJob{job})
+	flushErr := w.waitSubmittedAsyncFlushes([]*asyncFlushJob{job})
 	w.asyncJobs.Wait()
 	w.async.close()
 

--- a/internal/ingest/backfill/completion_batcher.go
+++ b/internal/ingest/backfill/completion_batcher.go
@@ -1,0 +1,148 @@
+package backfill
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/jcalabro/atmos"
+	"github.com/jcalabro/atmos/repo"
+)
+
+type completionBatcher struct {
+	mu         sync.Mutex
+	store      *Store
+	metrics    *Metrics
+	watermarks map[atmos.DID]completionWatermark
+	queued     []queuedCompletion
+}
+
+type completionWatermark struct {
+	lastSeq  uint64
+	appended bool
+}
+
+type queuedCompletion struct {
+	did       atmos.DID
+	commit    *repo.Commit
+	completed time.Time
+	watermark completionWatermark
+}
+
+func NewCompletionBatcher(st *Store, m *Metrics) *completionBatcher {
+	return &completionBatcher{
+		store:      st,
+		metrics:    m,
+		watermarks: make(map[atmos.DID]completionWatermark),
+	}
+}
+
+func (b *completionBatcher) RecordWatermark(did atmos.DID, lastSeq uint64, appended bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.watermarks[did] = completionWatermark{lastSeq: lastSeq, appended: appended}
+}
+
+func (b *completionBatcher) QueueComplete(ctx context.Context, did atmos.DID, commit *repo.Commit) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	var queuedCommit *repo.Commit
+	if commit != nil {
+		commitCopy := *commit
+		queuedCommit = &commitCopy
+	}
+	watermark, ok := b.watermarks[did]
+	if !ok {
+		return fmt.Errorf("backfill: queue complete %s: missing watermark", did)
+	}
+	delete(b.watermarks, did)
+	completion := queuedCompletion{
+		did:       did,
+		commit:    queuedCommit,
+		completed: timeNow(),
+		watermark: watermark,
+	}
+	for i := range b.queued {
+		if b.queued[i].did == did {
+			b.queued[i] = completion
+			return nil
+		}
+	}
+	b.queued = append(b.queued, completion)
+	return nil
+}
+
+func (b *completionBatcher) StageDurable(ctx context.Context, batch *pebble.Batch, nextSeq uint64, force bool) (func(), func(error), error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
+
+	b.mu.Lock()
+	staged := make([]queuedCompletion, 0, len(b.queued))
+	for _, completion := range b.queued {
+		if !completion.watermark.appended || completion.watermark.lastSeq < nextSeq {
+			staged = append(staged, completion)
+		}
+	}
+	b.mu.Unlock()
+
+	if len(staged) == 0 {
+		return nil, nil, nil
+	}
+	afterDone, err := b.store.stageCompleteBatch(ctx, batch, staged)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			b.mu.Lock()
+			b.queued = removeQueuedCompletions(b.queued, staged)
+			b.mu.Unlock()
+
+			for range staged {
+				b.metrics.incCompleted()
+			}
+		})
+	}, afterDone, nil
+}
+
+func removeQueuedCompletions(queued, staged []queuedCompletion) []queuedCompletion {
+	if len(staged) == 0 {
+		return queued
+	}
+	out := queued[:0]
+	for _, completion := range queued {
+		if removeFirstQueuedCompletion(&staged, completion) {
+			continue
+		}
+		out = append(out, completion)
+	}
+	return out
+}
+
+func removeFirstQueuedCompletion(staged *[]queuedCompletion, completion queuedCompletion) bool {
+	for i, candidate := range *staged {
+		if queuedCompletionEqual(candidate, completion) {
+			*staged = append((*staged)[:i], (*staged)[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+func queuedCompletionEqual(a, b queuedCompletion) bool {
+	return a.did == b.did &&
+		a.commit == b.commit &&
+		a.completed.Equal(b.completed) &&
+		a.watermark == b.watermark
+}

--- a/internal/ingest/backfill/completion_batcher.go
+++ b/internal/ingest/backfill/completion_batcher.go
@@ -73,10 +73,14 @@ func (b *completionBatcher) QueueComplete(ctx context.Context, did atmos.DID, co
 	for i := range b.queued {
 		if b.queued[i].did == did {
 			b.queued[i] = completion
+			b.metrics.incCompletionQueued()
+			b.metrics.setCompletionQueueDepth(len(b.queued))
 			return nil
 		}
 	}
 	b.queued = append(b.queued, completion)
+	b.metrics.incCompletionQueued()
+	b.metrics.setCompletionQueueDepth(len(b.queued))
 	return nil
 }
 
@@ -99,6 +103,7 @@ func (b *completionBatcher) StageDurable(ctx context.Context, batch *pebble.Batc
 	}
 	afterDone, err := b.store.stageCompleteBatch(ctx, batch, staged)
 	if err != nil {
+		b.metrics.incCompletionStageErrors()
 		return nil, nil, err
 	}
 
@@ -107,8 +112,10 @@ func (b *completionBatcher) StageDurable(ctx context.Context, batch *pebble.Batc
 		once.Do(func() {
 			b.mu.Lock()
 			b.queued = removeQueuedCompletions(b.queued, staged)
+			b.metrics.setCompletionQueueDepth(len(b.queued))
 			b.mu.Unlock()
 
+			b.metrics.observeCompletionDurableBatch(len(staged))
 			for range staged {
 				b.metrics.incCompleted()
 			}

--- a/internal/ingest/backfill/completion_batcher.go
+++ b/internal/ingest/backfill/completion_batcher.go
@@ -94,6 +94,21 @@ func (b *completionBatcher) StageDurable(ctx context.Context, batch *pebble.Batc
 	for _, completion := range b.queued {
 		if !completion.watermark.appended || completion.watermark.lastSeq < nextSeq {
 			staged = append(staged, completion)
+			continue
+		}
+		// force=true is the drain/terminal commit: the writer has already
+		// flushed every pending block and waited for in-flight async jobs,
+		// so nextSeq must cover every appended event. An event-backed
+		// completion excluded here means its final event is not durable at
+		// a forced checkpoint — which would let saveBatchCursor advance the
+		// listRepos cursor past a non-durable completion (silent data loss).
+		// Crash rather than corrupt (AGENTS.md / DESIGN.md §3.1.1 ordering).
+		if force {
+			b.mu.Unlock()
+			b.metrics.incCompletionStageErrors()
+			return nil, nil, fmt.Errorf(
+				"backfill: forced durable batch at seq %d excludes appended completion %s with lastSeq %d (events not durable)",
+				nextSeq, completion.did, completion.watermark.lastSeq)
 		}
 	}
 	b.mu.Unlock()
@@ -116,35 +131,38 @@ func (b *completionBatcher) StageDurable(ctx context.Context, batch *pebble.Batc
 			b.mu.Unlock()
 
 			b.metrics.observeCompletionDurableBatch(len(staged))
-			for range staged {
+			now := timeNow()
+			for _, c := range staged {
+				b.metrics.observeCompletionQueueWait(now.Sub(c.completed))
 				b.metrics.incCompleted()
 			}
 		})
 	}, afterDone, nil
 }
 
+// removeQueuedCompletions drops from queued exactly the entries that were
+// staged, leaving any entry re-queued for the same DID after staging (a newer
+// commit/watermark) in place. Both slices are DID-unique because QueueComplete
+// dedupes by DID in place, so a single map keyed by DID gives an O(len(queued))
+// filter; the full-identity queuedCompletionEqual check preserves the
+// replaced-after-stage invariant (a re-queued entry differs in commit pointer,
+// completed time, or watermark and therefore survives).
 func removeQueuedCompletions(queued, staged []queuedCompletion) []queuedCompletion {
 	if len(staged) == 0 {
 		return queued
 	}
+	stagedByDID := make(map[atmos.DID]queuedCompletion, len(staged))
+	for _, completion := range staged {
+		stagedByDID[completion.did] = completion
+	}
 	out := queued[:0]
 	for _, completion := range queued {
-		if removeFirstQueuedCompletion(&staged, completion) {
+		if candidate, ok := stagedByDID[completion.did]; ok && queuedCompletionEqual(candidate, completion) {
 			continue
 		}
 		out = append(out, completion)
 	}
 	return out
-}
-
-func removeFirstQueuedCompletion(staged *[]queuedCompletion, completion queuedCompletion) bool {
-	for i, candidate := range *staged {
-		if queuedCompletionEqual(candidate, completion) {
-			*staged = append((*staged)[:i], (*staged)[i+1:]...)
-			return true
-		}
-	}
-	return false
 }
 
 func queuedCompletionEqual(a, b queuedCompletion) bool {

--- a/internal/ingest/backfill/completion_batcher_test.go
+++ b/internal/ingest/backfill/completion_batcher_test.go
@@ -10,6 +10,8 @@ import (
 	atmosbackfill "github.com/jcalabro/atmos/backfill"
 	"github.com/jcalabro/atmos/repo"
 	atmossync "github.com/jcalabro/atmos/sync"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -310,6 +312,51 @@ func TestCompletionBatcherAfterCommitRemovesOnlyStagedCompletions(t *testing.T) 
 	afterDone(nil)
 	require.NoError(t, b.Close())
 	require.Empty(t, cb.queued)
+}
+
+func TestCompletionBatcherRecordsQueueAndDurableBatchMetrics(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	st, err := store.Open(dir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	metrics := NewMetrics(prometheus.NewRegistry())
+	bs := NewStore(st, metrics)
+	ready := atmos.DID("did:plc:completebatch-metrics-ready")
+	pending := atmos.DID("did:plc:completebatch-metrics-pending")
+	require.NoError(t, bs.OnDiscover(t.Context(), testListReposEntry(ready)))
+	require.NoError(t, bs.OnDiscover(t.Context(), testListReposEntry(pending)))
+
+	cb := NewCompletionBatcher(bs, metrics)
+	cb.RecordWatermark(ready, 41, true)
+	require.NoError(t, cb.QueueComplete(t.Context(), ready, &repo.Commit{DID: string(ready), Rev: "rev-ready"}))
+	cb.RecordWatermark(pending, 50, true)
+	require.NoError(t, cb.QueueComplete(t.Context(), pending, &repo.Commit{DID: string(pending), Rev: "rev-pending"}))
+	require.InDelta(t, 2.0, testutil.ToFloat64(metrics.CompletionQueued), 0)
+	require.InDelta(t, 2.0, testutil.ToFloat64(metrics.CompletionQueueDepth), 0)
+
+	b := st.NewBatch()
+	afterCommit, afterDone, err := cb.StageDurable(t.Context(), b, 42, false)
+	require.NoError(t, err)
+	require.NotNil(t, afterCommit)
+	require.NotNil(t, afterDone)
+
+	commitErr := st.Commit(b, store.SyncWrites)
+	if commitErr != nil {
+		afterDone(commitErr)
+		require.NoError(t, commitErr)
+	}
+	afterCommit()
+	afterDone(nil)
+	require.NoError(t, b.Close())
+
+	require.InDelta(t, 1.0, testutil.ToFloat64(metrics.CompletionDurableBatches), 0)
+	require.InDelta(t, 1.0, testutil.ToFloat64(metrics.CompletionDurableRepos), 0)
+	require.InDelta(t, 1.0, testutil.ToFloat64(metrics.CompletionQueueDepth), 0)
+	require.InDelta(t, 1.0, testutil.ToFloat64(metrics.Completed), 0)
+	require.InDelta(t, 0.0, testutil.ToFloat64(metrics.CompletionStageErrors), 0)
 }
 
 func TestCompletionBatcherCommitFailureKeepsStagedCompletionQueued(t *testing.T) {

--- a/internal/ingest/backfill/completion_batcher_test.go
+++ b/internal/ingest/backfill/completion_batcher_test.go
@@ -1,0 +1,433 @@
+package backfill
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/bluesky-social/jetstream-v2/internal/store"
+	"github.com/jcalabro/atmos"
+	atmosbackfill "github.com/jcalabro/atmos/backfill"
+	"github.com/jcalabro/atmos/repo"
+	atmossync "github.com/jcalabro/atmos/sync"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompletionBatcherStagesCompletionAtDurableSeq(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	st, err := store.Open(dir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	bs := NewStore(st, nil)
+	did := atmos.DID("did:plc:completebatch")
+	require.NoError(t, bs.OnDiscover(t.Context(), testListReposEntry(did)))
+
+	cb := NewCompletionBatcher(bs, nil)
+	cb.RecordWatermark(did, 41, true)
+	require.NoError(t, cb.QueueComplete(t.Context(), did, &repo.Commit{DID: string(did), Rev: "rev1"}))
+
+	b := st.NewBatch()
+	afterCommit, afterDone, err := cb.StageDurable(t.Context(), b, 42, false)
+	require.NoError(t, err)
+	require.NotNil(t, afterCommit)
+	require.NotNil(t, afterDone)
+	requireLookupState(t, bs, did, atmosbackfill.StateDiscovered)
+
+	commitErr := st.Commit(b, store.SyncWrites)
+	if commitErr != nil {
+		afterDone(commitErr)
+		require.NoError(t, commitErr)
+	}
+	requireLookupState(t, bs, did, atmosbackfill.StateComplete)
+
+	require.Len(t, cb.queued, 1)
+	require.Equal(t, did, cb.queued[0].did)
+
+	afterCommit()
+	afterDone(nil)
+	require.NoError(t, b.Close())
+	require.Empty(t, cb.queued)
+}
+
+func TestCompletionBatcherDoesNotStageCompletionAtEqualDurableSeq(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	st, err := store.Open(dir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	bs := NewStore(st, nil)
+	did := atmos.DID("did:plc:completebatch-equal")
+	require.NoError(t, bs.OnDiscover(t.Context(), testListReposEntry(did)))
+
+	cb := NewCompletionBatcher(bs, nil)
+	cb.RecordWatermark(did, 42, true)
+	require.NoError(t, cb.QueueComplete(t.Context(), did, &repo.Commit{DID: string(did), Rev: "rev-equal"}))
+
+	b := st.NewBatch()
+	afterCommit, afterDone, err := cb.StageDurable(t.Context(), b, 42, false)
+	require.NoError(t, err)
+	require.Nil(t, afterCommit)
+	require.Nil(t, afterDone)
+	requireLookupState(t, bs, did, atmosbackfill.StateDiscovered)
+	require.Len(t, cb.queued, 1)
+	require.NoError(t, b.Close())
+
+	b = st.NewBatch()
+	afterCommit, afterDone, err = cb.StageDurable(t.Context(), b, 43, false)
+	require.NoError(t, err)
+	require.NotNil(t, afterCommit)
+	require.NotNil(t, afterDone)
+
+	commitErr := st.Commit(b, store.SyncWrites)
+	if commitErr != nil {
+		afterDone(commitErr)
+		require.NoError(t, commitErr)
+	}
+	requireLookupState(t, bs, did, atmosbackfill.StateComplete)
+
+	afterCommit()
+	afterDone(nil)
+	require.NoError(t, b.Close())
+	require.Empty(t, cb.queued)
+}
+
+func TestCompletionBatcherQueueCompleteRequiresWatermark(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	st, err := store.Open(dir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	bs := NewStore(st, nil)
+	did := atmos.DID("did:plc:completebatch-missing-watermark")
+	require.NoError(t, bs.OnDiscover(t.Context(), testListReposEntry(did)))
+
+	cb := NewCompletionBatcher(bs, nil)
+	err = cb.QueueComplete(t.Context(), did, &repo.Commit{DID: string(did), Rev: "rev-missing"})
+	require.ErrorContains(t, err, "missing watermark")
+	require.Empty(t, cb.queued)
+}
+
+func TestCompletionBatcherStagesExplicitEmptyRepoCompletion(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	st, err := store.Open(dir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	bs := NewStore(st, nil)
+	did := atmos.DID("did:plc:completebatch-empty")
+	require.NoError(t, bs.OnDiscover(t.Context(), testListReposEntry(did)))
+
+	cb := NewCompletionBatcher(bs, nil)
+	cb.RecordWatermark(did, 0, false)
+	require.NoError(t, cb.QueueComplete(t.Context(), did, &repo.Commit{DID: string(did), Rev: "rev-empty"}))
+
+	b := st.NewBatch()
+	afterCommit, afterDone, err := cb.StageDurable(t.Context(), b, 0, false)
+	require.NoError(t, err)
+	require.NotNil(t, afterCommit)
+	require.NotNil(t, afterDone)
+
+	commitErr := st.Commit(b, store.SyncWrites)
+	if commitErr != nil {
+		afterDone(commitErr)
+		require.NoError(t, commitErr)
+	}
+	requireLookupState(t, bs, did, atmosbackfill.StateComplete)
+
+	afterCommit()
+	afterDone(nil)
+	require.NoError(t, b.Close())
+	require.Empty(t, cb.queued)
+}
+
+func TestCompletionBatcherQueueCompleteReplacesDuplicateDID(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	st, err := store.Open(dir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	bs := NewStore(st, nil)
+	did := atmos.DID("did:plc:completebatch-duplicate")
+	require.NoError(t, bs.OnDiscover(t.Context(), testListReposEntry(did)))
+
+	cb := NewCompletionBatcher(bs, nil)
+	cb.RecordWatermark(did, 41, true)
+	require.NoError(t, cb.QueueComplete(t.Context(), did, &repo.Commit{DID: string(did), Rev: "rev-old"}))
+	cb.RecordWatermark(did, 42, true)
+	require.NoError(t, cb.QueueComplete(t.Context(), did, &repo.Commit{DID: string(did), Rev: "rev-new"}))
+	require.Len(t, cb.queued, 1)
+	require.Equal(t, "rev-new", cb.queued[0].commit.Rev)
+	require.Equal(t, completionWatermark{lastSeq: 42, appended: true}, cb.queued[0].watermark)
+
+	b := st.NewBatch()
+	afterCommit, afterDone, err := cb.StageDurable(t.Context(), b, 43, false)
+	require.NoError(t, err)
+	require.NotNil(t, afterCommit)
+	require.NotNil(t, afterDone)
+
+	commitErr := st.Commit(b, store.SyncWrites)
+	if commitErr != nil {
+		afterDone(commitErr)
+		require.NoError(t, commitErr)
+	}
+	afterCommit()
+	afterDone(nil)
+	require.NoError(t, b.Close())
+	require.Empty(t, cb.queued)
+
+	rs, err := bs.readRepoStatus(did)
+	require.NoError(t, err)
+	require.NotNil(t, rs)
+	require.Equal(t, "rev-new", rs.Backfill.Rev)
+	require.Equal(t, "rev-new", rs.Rev)
+}
+
+func TestCompletionBatcherHoldsCountsLockUntilAfterDone(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	st, err := store.Open(dir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	bs := NewStore(st, nil)
+	ready := atmos.DID("did:plc:completebatch-lock-ready")
+	discovered := atmos.DID("did:plc:completebatch-lock-discovered")
+	require.NoError(t, bs.OnDiscover(t.Context(), testListReposEntry(ready)))
+
+	cb := NewCompletionBatcher(bs, nil)
+	cb.RecordWatermark(ready, 41, true)
+	require.NoError(t, cb.QueueComplete(t.Context(), ready, &repo.Commit{DID: string(ready), Rev: "rev-ready"}))
+
+	b := st.NewBatch()
+	defer func() { _ = b.Close() }()
+	afterCommit, afterDone, err := cb.StageDurable(t.Context(), b, 42, false)
+	require.NoError(t, err)
+	require.NotNil(t, afterCommit)
+	require.NotNil(t, afterDone)
+
+	discoverDone := make(chan error, 1)
+	go func() {
+		discoverDone <- bs.OnDiscover(t.Context(), testListReposEntry(discovered))
+	}()
+
+	select {
+	case err := <-discoverDone:
+		afterDone(err)
+		require.Failf(t, "OnDiscover completed before afterDone", "err: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	commitErr := st.Commit(b, store.SyncWrites)
+	if commitErr != nil {
+		afterDone(commitErr)
+		require.NoError(t, commitErr)
+	}
+	afterCommit()
+	afterDone(nil)
+
+	select {
+	case err := <-discoverDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		require.Fail(t, "OnDiscover remained blocked after afterDone")
+	}
+	requireLookupState(t, bs, ready, atmosbackfill.StateComplete)
+	requireLookupState(t, bs, discovered, atmosbackfill.StateDiscovered)
+}
+
+func TestCompletionBatcherAfterCommitRemovesOnlyStagedCompletions(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	st, err := store.Open(dir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	bs := NewStore(st, nil)
+	ready := atmos.DID("did:plc:completebatch-ready")
+	pending := atmos.DID("did:plc:completebatch-pending")
+	require.NoError(t, bs.OnDiscover(t.Context(), testListReposEntry(ready)))
+	require.NoError(t, bs.OnDiscover(t.Context(), testListReposEntry(pending)))
+
+	cb := NewCompletionBatcher(bs, nil)
+	cb.RecordWatermark(ready, 41, true)
+	require.NoError(t, cb.QueueComplete(t.Context(), ready, &repo.Commit{DID: string(ready), Rev: "rev-ready"}))
+	cb.RecordWatermark(pending, 50, true)
+	require.NoError(t, cb.QueueComplete(t.Context(), pending, &repo.Commit{DID: string(pending), Rev: "rev-pending"}))
+
+	b := st.NewBatch()
+	afterCommit, afterDone, err := cb.StageDurable(t.Context(), b, 42, false)
+	require.NoError(t, err)
+	require.NotNil(t, afterCommit)
+	require.NotNil(t, afterDone)
+	require.Len(t, cb.queued, 2)
+	requireLookupState(t, bs, ready, atmosbackfill.StateDiscovered)
+	requireLookupState(t, bs, pending, atmosbackfill.StateDiscovered)
+
+	commitErr := st.Commit(b, store.SyncWrites)
+	if commitErr != nil {
+		afterDone(commitErr)
+		require.NoError(t, commitErr)
+	}
+	requireLookupState(t, bs, ready, atmosbackfill.StateComplete)
+	requireLookupState(t, bs, pending, atmosbackfill.StateDiscovered)
+	require.Len(t, cb.queued, 2)
+
+	afterCommit()
+	afterDone(nil)
+	require.NoError(t, b.Close())
+	require.Len(t, cb.queued, 1)
+	require.Equal(t, pending, cb.queued[0].did)
+
+	b = st.NewBatch()
+	afterCommit, afterDone, err = cb.StageDurable(t.Context(), b, 51, false)
+	require.NoError(t, err)
+	require.NotNil(t, afterCommit)
+	require.NotNil(t, afterDone)
+	require.Len(t, cb.queued, 1)
+
+	commitErr = st.Commit(b, store.SyncWrites)
+	if commitErr != nil {
+		afterDone(commitErr)
+		require.NoError(t, commitErr)
+	}
+	requireLookupState(t, bs, pending, atmosbackfill.StateComplete)
+	require.Len(t, cb.queued, 1)
+
+	afterCommit()
+	afterDone(nil)
+	require.NoError(t, b.Close())
+	require.Empty(t, cb.queued)
+}
+
+func TestCompletionBatcherCommitFailureKeepsStagedCompletionQueued(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	st, err := store.Open(dir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	bs := NewStore(st, nil)
+	did := atmos.DID("did:plc:completebatch-retry")
+	require.NoError(t, bs.OnDiscover(t.Context(), testListReposEntry(did)))
+
+	cb := NewCompletionBatcher(bs, nil)
+	cb.RecordWatermark(did, 41, true)
+	require.NoError(t, cb.QueueComplete(t.Context(), did, &repo.Commit{DID: string(did), Rev: "rev-retry"}))
+
+	b := st.NewBatch()
+	afterCommit, afterDone, err := cb.StageDurable(t.Context(), b, 42, false)
+	require.NoError(t, err)
+	require.NotNil(t, afterCommit)
+	require.NotNil(t, afterDone)
+	require.Len(t, cb.queued, 1)
+
+	afterDone(errors.New("synthetic commit failure"))
+	require.NoError(t, b.Close())
+	require.Len(t, cb.queued, 1)
+	require.Equal(t, did, cb.queued[0].did)
+	requireLookupState(t, bs, did, atmosbackfill.StateDiscovered)
+
+	b = st.NewBatch()
+	afterCommit, afterDone, err = cb.StageDurable(t.Context(), b, 42, false)
+	require.NoError(t, err)
+	require.NotNil(t, afterCommit)
+	require.NotNil(t, afterDone)
+
+	commitErr := st.Commit(b, store.SyncWrites)
+	if commitErr != nil {
+		afterDone(commitErr)
+		require.NoError(t, commitErr)
+	}
+	requireLookupState(t, bs, did, atmosbackfill.StateComplete)
+	require.Len(t, cb.queued, 1)
+
+	afterCommit()
+	afterDone(nil)
+	require.NoError(t, b.Close())
+	require.Empty(t, cb.queued)
+}
+
+func TestCompletionBatcherOldAfterCommitDoesNotRemoveNewerQueuedCompletion(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	st, err := store.Open(dir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	bs := NewStore(st, nil)
+	did := atmos.DID("did:plc:completebatch-replaced-after-stage")
+	require.NoError(t, bs.OnDiscover(t.Context(), testListReposEntry(did)))
+
+	cb := NewCompletionBatcher(bs, nil)
+	cb.RecordWatermark(did, 41, true)
+	require.NoError(t, cb.QueueComplete(t.Context(), did, &repo.Commit{DID: string(did), Rev: "rev-old"}))
+
+	b := st.NewBatch()
+	afterCommit, afterDone, err := cb.StageDurable(t.Context(), b, 42, false)
+	require.NoError(t, err)
+	require.NotNil(t, afterCommit)
+	require.NotNil(t, afterDone)
+
+	cb.RecordWatermark(did, 42, true)
+	require.NoError(t, cb.QueueComplete(t.Context(), did, &repo.Commit{DID: string(did), Rev: "rev-new"}))
+	require.Len(t, cb.queued, 1)
+	require.Equal(t, "rev-new", cb.queued[0].commit.Rev)
+
+	commitErr := st.Commit(b, store.SyncWrites)
+	if commitErr != nil {
+		afterDone(commitErr)
+		require.NoError(t, commitErr)
+	}
+	afterCommit()
+	afterDone(nil)
+	require.NoError(t, b.Close())
+	require.Len(t, cb.queued, 1)
+	require.Equal(t, "rev-new", cb.queued[0].commit.Rev)
+
+	b = st.NewBatch()
+	afterCommit, afterDone, err = cb.StageDurable(t.Context(), b, 43, false)
+	require.NoError(t, err)
+	require.NotNil(t, afterCommit)
+	require.NotNil(t, afterDone)
+	commitErr = st.Commit(b, store.SyncWrites)
+	if commitErr != nil {
+		afterDone(commitErr)
+		require.NoError(t, commitErr)
+	}
+	afterCommit()
+	afterDone(nil)
+	require.NoError(t, b.Close())
+	require.Empty(t, cb.queued)
+
+	rs, err := bs.readRepoStatus(did)
+	require.NoError(t, err)
+	require.NotNil(t, rs)
+	require.Equal(t, "rev-new", rs.Backfill.Rev)
+}
+
+func testListReposEntry(did atmos.DID) atmossync.ListReposEntry {
+	return atmossync.ListReposEntry{DID: did, Active: true}
+}
+
+func requireLookupState(t *testing.T, bs *Store, did atmos.DID, want atmosbackfill.State) {
+	t.Helper()
+
+	got, err := bs.Lookup(t.Context(), did)
+	require.NoError(t, err)
+	require.Equal(t, want, got.State)
+}

--- a/internal/ingest/backfill/completion_batcher_test.go
+++ b/internal/ingest/backfill/completion_batcher_test.go
@@ -151,6 +151,114 @@ func TestCompletionBatcherStagesExplicitEmptyRepoCompletion(t *testing.T) {
 	require.Empty(t, cb.queued)
 }
 
+// TestCompletionBatcherCommitsMultipleCompletionsInOneBatch covers the spec
+// testing checklist item "multiple repos completed in one block are committed
+// in one durability batch" — the core amortization the change exists for. Two
+// repos whose final events are both durable below nextSeq must stage together
+// and land their repo rows + the shared counts row in a single commit.
+func TestCompletionBatcherCommitsMultipleCompletionsInOneBatch(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	st, err := store.Open(dir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	metrics := NewMetrics(prometheus.NewRegistry())
+	bs := NewStore(st, metrics)
+	first := atmos.DID("did:plc:completebatch-multi-first")
+	second := atmos.DID("did:plc:completebatch-multi-second")
+	require.NoError(t, bs.OnDiscover(t.Context(), testListReposEntry(first)))
+	require.NoError(t, bs.OnDiscover(t.Context(), testListReposEntry(second)))
+
+	cb := NewCompletionBatcher(bs, metrics)
+	cb.RecordWatermark(first, 40, true)
+	require.NoError(t, cb.QueueComplete(t.Context(), first, &repo.Commit{DID: string(first), Rev: "rev-first"}))
+	cb.RecordWatermark(second, 41, true)
+	require.NoError(t, cb.QueueComplete(t.Context(), second, &repo.Commit{DID: string(second), Rev: "rev-second"}))
+
+	// nextSeq=42 means events through seq 41 are durable, so both completions
+	// are eligible and must stage into the same batch.
+	b := st.NewBatch()
+	afterCommit, afterDone, err := cb.StageDurable(t.Context(), b, 42, false)
+	require.NoError(t, err)
+	require.NotNil(t, afterCommit)
+	require.NotNil(t, afterDone)
+	requireLookupState(t, bs, first, atmosbackfill.StateDiscovered)
+	requireLookupState(t, bs, second, atmosbackfill.StateDiscovered)
+
+	commitErr := st.Commit(b, store.SyncWrites)
+	if commitErr != nil {
+		afterDone(commitErr)
+		require.NoError(t, commitErr)
+	}
+	// One synced commit flips both repos complete.
+	requireLookupState(t, bs, first, atmosbackfill.StateComplete)
+	requireLookupState(t, bs, second, atmosbackfill.StateComplete)
+
+	afterCommit()
+	afterDone(nil)
+	require.NoError(t, b.Close())
+	require.Empty(t, cb.queued)
+
+	require.InDelta(t, 1.0, testutil.ToFloat64(metrics.CompletionDurableBatches), 0,
+		"two completions must coalesce into a single durable batch")
+	require.InDelta(t, 2.0, testutil.ToFloat64(metrics.CompletionDurableRepos), 0)
+
+	counts, ok, err := LoadCounts(st)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, Counts{Total: 2, Complete: 2}, counts,
+		"the shared counts row must reflect both completions from the single batch")
+}
+
+// TestCompletionBatcherForcedStageRejectsNonDurableAppendedCompletion pins the
+// crash-over-corruption guard: a force=true (drain/terminal) commit must never
+// stage an appended completion whose final event is not yet durable (lastSeq >=
+// nextSeq). If it did, saveBatchCursor could advance the listRepos cursor past a
+// non-durable completion. The forced path must surface a hard error instead.
+func TestCompletionBatcherForcedStageRejectsNonDurableAppendedCompletion(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	st, err := store.Open(dir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	metrics := NewMetrics(prometheus.NewRegistry())
+	bs := NewStore(st, metrics)
+	did := atmos.DID("did:plc:completebatch-forced-nondurable")
+	require.NoError(t, bs.OnDiscover(t.Context(), testListReposEntry(did)))
+
+	cb := NewCompletionBatcher(bs, metrics)
+	// lastSeq=42 with nextSeq=42 means the final event is NOT yet durable.
+	cb.RecordWatermark(did, 42, true)
+	require.NoError(t, cb.QueueComplete(t.Context(), did, &repo.Commit{DID: string(did), Rev: "rev-forced"}))
+
+	b := st.NewBatch()
+	afterCommit, afterDone, err := cb.StageDurable(t.Context(), b, 42, true)
+	require.Error(t, err, "forced commit must reject an appended completion whose events are not durable")
+	require.ErrorContains(t, err, "events not durable")
+	require.Nil(t, afterCommit)
+	require.Nil(t, afterDone)
+	require.NoError(t, b.Close())
+
+	requireLookupState(t, bs, did, atmosbackfill.StateDiscovered)
+	require.Len(t, cb.queued, 1, "the completion stays queued, not silently dropped")
+	require.InDelta(t, 1.0, testutil.ToFloat64(metrics.CompletionStageErrors), 0)
+
+	// A non-forced commit at the same seq must NOT crash — it simply leaves the
+	// completion queued until its block becomes durable. This proves the guard
+	// is force-only and does not disturb the steady per-block path.
+	b2 := st.NewBatch()
+	afterCommit, afterDone, err = cb.StageDurable(t.Context(), b2, 42, false)
+	require.NoError(t, err)
+	require.Nil(t, afterCommit)
+	require.Nil(t, afterDone)
+	require.NoError(t, b2.Close())
+	require.Len(t, cb.queued, 1)
+}
+
 func TestCompletionBatcherQueueCompleteReplacesDuplicateDID(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ingest/backfill/cursor.go
+++ b/internal/ingest/backfill/cursor.go
@@ -10,24 +10,13 @@
 //
 // # Persistence semantics
 //
-// SaveListReposCursor uses pebble.Sync, same as the per-DID write
-// path. atmos calls our save callback after every listRepos page
-// boundary, so the cost is one fsync per ~1000 DIDs (the protocol's
-// page cap). Cheap relative to repo download.
-//
-// # Known durability hole
-//
-// atmos fires OnPageComplete after a page's eligible jobs are
-// queued onto the worker channel — workers may still be downloading.
-// On a process kill mid-page-flush, those workers' DIDs stay at
-// StateDiscovered. The next Run starts at the saved cursor (page
-// N+1) and never re-walks page N, so those DIDs are stuck until a
-// future cursor-less Run rediscovers them.
-//
-// This is acceptable for now: a future "rewalk" subcommand can
-// clear the cursor to force a full re-enumeration. In practice the
-// hole only bites if every subsequent Run also dies in the same
-// way, which would have bigger problems than orphaned DIDs.
+// Run checkpoints this cursor from atmos's OnBatchComplete callback. atmos
+// fires that callback after the batch has been fully reconciled and
+// every eligible repo in the batch has reached a terminal state for
+// this run. Before checkpointing, Run drains writer durability so
+// queued repo completions and their segment data are durably visible.
+// The checkpoint uses pebble.Sync, so a successful callback means the
+// cursor advance is durable too.
 package backfill
 
 import (
@@ -60,12 +49,35 @@ func LoadListReposCursor(db *store.Store) (string, error) {
 	return out, nil
 }
 
-// SaveListReposCursor durably persists the cursor for resume. Used as
-// the body of atmos's OnPageComplete callback; the synchronous fsync
-// guarantees a crash after the page completes can't lose the advance.
+// SaveListReposCursor durably persists the cursor for resume. Run
+// calls it from atmos's OnBatchComplete callback only after the writer
+// durability drain succeeds, so the cursor cannot outrun queued repo
+// completions from the completed batch.
 func SaveListReposCursor(db *store.Store, cursor string) error {
 	if err := db.Set([]byte(listReposCursorKey), []byte(cursor), store.SyncWrites); err != nil {
 		return fmt.Errorf("backfill: save list_repos_cursor: %w", err)
+	}
+	return nil
+}
+
+// SaveListReposCheckpoint atomically persists the relay resume cursor
+// and, when non-empty, the bootstrap-last cursor. These two keys are
+// one logical checkpoint during Run: the relay cursor must not advance
+// independently of the bootstrap cursor the merge phase will use.
+func SaveListReposCheckpoint(db *store.Store, relayCursor, bootstrapCursor string) error {
+	batch := db.NewBatch()
+	defer func() { _ = batch.Close() }()
+
+	if err := batch.Set([]byte(listReposCursorKey), []byte(relayCursor), nil); err != nil {
+		return fmt.Errorf("backfill: stage list_repos_cursor: %w", err)
+	}
+	if bootstrapCursor != "" {
+		if err := batch.Set([]byte(bootstrapLastListReposCursorKey), []byte(bootstrapCursor), nil); err != nil {
+			return fmt.Errorf("backfill: stage bootstrap_last_listrepos_cursor: %w", err)
+		}
+	}
+	if err := db.Commit(batch, store.SyncWrites); err != nil {
+		return fmt.Errorf("backfill: save list_repos checkpoint: %w", err)
 	}
 	return nil
 }
@@ -100,10 +112,9 @@ func LoadBootstrapLastListReposCursor(db *store.Store) (string, error) {
 
 // MaybeSaveBootstrapLastListReposCursor writes cursor under
 // bootstrapLastListReposCursorKey via pebble.Sync iff cursor != "".
-// The empty-cursor short-circuit is the entire point: atmos's
-// OnPageComplete fires on every page including the post-drain
-// terminator, and we must not overwrite the last meaningful cursor
-// with the relay's "I'm done" empty value.
+// The empty-cursor short-circuit is the entire point: atmos's final
+// OnBatchComplete fires with the relay's "I'm done" empty value, and
+// we must not overwrite the last meaningful cursor with it.
 func MaybeSaveBootstrapLastListReposCursor(db *store.Store, cursor string) error {
 	if cursor == "" {
 		return nil

--- a/internal/ingest/backfill/cursor.go
+++ b/internal/ingest/backfill/cursor.go
@@ -49,10 +49,11 @@ func LoadListReposCursor(db *store.Store) (string, error) {
 	return out, nil
 }
 
-// SaveListReposCursor durably persists the cursor for resume. Run
-// calls it from atmos's OnBatchComplete callback only after the writer
-// durability drain succeeds, so the cursor cannot outrun queued repo
-// completions from the completed batch.
+// SaveListReposCursor durably persists the cursor for resume via
+// pebble.Sync. This is now a test/seed helper only: Run's production
+// checkpoint path uses SaveListReposCheckpoint, which writes the relay
+// and bootstrap cursors atomically after the writer durability drain.
+// Tests that only need to seed a starting cursor still call this.
 func SaveListReposCursor(db *store.Store, cursor string) error {
 	if err := db.Set([]byte(listReposCursorKey), []byte(cursor), store.SyncWrites); err != nil {
 		return fmt.Errorf("backfill: save list_repos_cursor: %w", err)
@@ -86,7 +87,8 @@ func SaveListReposCheckpoint(db *store.Store, relayCursor, bootstrapCursor strin
 // last *non-empty* listRepos cursor saved during the bootstrap
 // phase. The merge phase reads this to resume listRepos against
 // the relay and discover DIDs born during the bootstrap window
-// (DESIGN.md §4.7 of the merge spec).
+// (merge-phase spec §4.7,
+// docs/superpowers/specs/2026-05-27-merge-phase-design.md).
 //
 // We need a separate key from listReposCursorKey because the
 // existing cursor is allowed (correctly) to drain to "" when

--- a/internal/ingest/backfill/cursor_test.go
+++ b/internal/ingest/backfill/cursor_test.go
@@ -59,7 +59,7 @@ func TestSaveListReposCursor_Overwrites(t *testing.T) {
 }
 
 // TestSaveListReposCursor_EmptyValue covers the post-drain state:
-// atmos fires OnPageComplete("") after the final page. We must
+// atmos fires OnBatchComplete("") after the final batch. We must
 // accept the empty string as a valid value, not treat it as a
 // missing-row error. Load afterwards returns "" — the same as
 // fresh-startup, which is the right semantic (next Run starts from
@@ -115,4 +115,54 @@ func TestBootstrapLastListReposCursor_Delete(t *testing.T) {
 	got, err := LoadBootstrapLastListReposCursor(db)
 	require.NoError(t, err)
 	require.Equal(t, "", got)
+}
+
+func TestSaveListReposCheckpoint_WritesBothKeys(t *testing.T) {
+	t.Parallel()
+	db := newCursorTestStore(t)
+
+	require.NoError(t, SaveListReposCheckpoint(db, "relay-page-2", "bootstrap-page-2"))
+
+	relay, err := LoadListReposCursor(db)
+	require.NoError(t, err)
+	require.Equal(t, "relay-page-2", relay)
+
+	bootstrap, err := LoadBootstrapLastListReposCursor(db)
+	require.NoError(t, err)
+	require.Equal(t, "bootstrap-page-2", bootstrap)
+}
+
+func TestSaveListReposCheckpoint_IgnoresEmptyBootstrapCursor(t *testing.T) {
+	t.Parallel()
+	db := newCursorTestStore(t)
+
+	require.NoError(t, MaybeSaveBootstrapLastListReposCursor(db, "existing-bootstrap"))
+
+	require.NoError(t, SaveListReposCheckpoint(db, "relay-page-3", ""))
+
+	relay, err := LoadListReposCursor(db)
+	require.NoError(t, err)
+	require.Equal(t, "relay-page-3", relay)
+
+	bootstrap, err := LoadBootstrapLastListReposCursor(db)
+	require.NoError(t, err)
+	require.Equal(t, "existing-bootstrap", bootstrap)
+}
+
+func TestSaveListReposCheckpoint_SavesEmptyRelayCursor(t *testing.T) {
+	t.Parallel()
+	db := newCursorTestStore(t)
+
+	require.NoError(t, SaveListReposCursor(db, "stale-relay"))
+	require.NoError(t, MaybeSaveBootstrapLastListReposCursor(db, "existing-bootstrap"))
+
+	require.NoError(t, SaveListReposCheckpoint(db, "", ""))
+
+	relay, err := LoadListReposCursor(db)
+	require.NoError(t, err)
+	require.Equal(t, "", relay)
+
+	bootstrap, err := LoadBootstrapLastListReposCursor(db)
+	require.NoError(t, err)
+	require.Equal(t, "existing-bootstrap", bootstrap)
 }

--- a/internal/ingest/backfill/handler.go
+++ b/internal/ingest/backfill/handler.go
@@ -34,6 +34,7 @@ type SegmentHandler struct {
 	now           func() time.Time
 	metrics       *Metrics
 	onWriterError func(error)
+	completions   *completionBatcher
 }
 
 const segmentHandlerAppendBatchSize = 1024
@@ -58,6 +59,12 @@ func NewSegmentHandler(writer *ingest.Writer, logger *slog.Logger, m *Metrics) *
 	}
 }
 
+// SetCompletionBatcher queues repo completion watermarks for durable batch
+// metadata. It is intended for construction-time wiring before HandleRepo runs.
+func (h *SegmentHandler) SetCompletionBatcher(b *completionBatcher) {
+	h.completions = b
+}
+
 // HandleRepo emits one segment event per record in r.Tree. The
 // IndexedAt timestamp is the same for every event in this repo: it
 // is the wall-clock instant at which jetstream observed this repo.
@@ -70,6 +77,7 @@ func (h *SegmentHandler) HandleRepo(ctx context.Context, did atmos.DID, r *repo.
 
 		indexedAt := h.now().UnixMicro()
 		appended := false
+		lastSeq := uint64(0)
 		batch := make([]segment.Event, 0, segmentHandlerAppendBatchSize)
 
 		flushBatch := func() error {
@@ -81,6 +89,7 @@ func (h *SegmentHandler) HandleRepo(ctx context.Context, did atmos.DID, r *repo.
 				h.abortOnWriterError(err)
 				return err
 			}
+			lastSeq = batch[len(batch)-1].Seq
 			appended = true
 			batch = batch[:0]
 			return nil
@@ -135,12 +144,8 @@ func (h *SegmentHandler) HandleRepo(ctx context.Context, did atmos.DID, r *repo.
 		if err := flushBatch(); err != nil {
 			return err
 		}
-		if appended {
-			if err := h.writer.Flush(ctx); err != nil {
-				err = fmt.Errorf("backfill: did=%s flush before complete: %w", did, err)
-				h.abortOnWriterError(err)
-				return err
-			}
+		if h.completions != nil {
+			h.completions.RecordWatermark(did, lastSeq, appended)
 		}
 		return nil
 	})

--- a/internal/ingest/backfill/handler_test.go
+++ b/internal/ingest/backfill/handler_test.go
@@ -2,6 +2,7 @@ package backfill
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"path/filepath"
@@ -56,6 +57,26 @@ func buildSingleRecordRepo(t *testing.T, did atmos.DID, collection, rkey string,
 		Tree:  mst.NewTree(mstore),
 	}
 	require.NoError(t, r.Create(collection, rkey, record))
+	commit, err := r.Commit(key)
+	require.NoError(t, err)
+	return r, commit
+}
+
+func buildMultiRecordRepo(t *testing.T, did atmos.DID, collection string, n int) (*atmosrepo.Repo, *atmosrepo.Commit) {
+	t.Helper()
+	key, err := crypto.GenerateP256()
+	require.NoError(t, err)
+	mstore := mst.NewMemBlockStore()
+	r := &atmosrepo.Repo{
+		DID:   did,
+		Clock: atmos.NewTIDClock(0),
+		Store: mstore,
+		Tree:  mst.NewTree(mstore),
+	}
+	for i := range n {
+		rkey := fmt.Sprintf("rkey%03d", i)
+		require.NoError(t, r.Create(collection, rkey, map[string]any{"text": rkey}))
+	}
 	commit, err := r.Commit(key)
 	require.NoError(t, err)
 	return r, commit
@@ -136,6 +157,73 @@ func TestSegmentHandler_HandleRepoQueuesCompletionWithoutFlush(t *testing.T) {
 	require.NoError(t, w.DrainDurability(t.Context()))
 	requireLookupState(t, bs, did, atmosbackfill.StateComplete)
 	require.Empty(t, cb.queued)
+}
+
+// TestSegmentHandler_MultiBlockRepoCompletesOnlyWithFinalBlock covers the spec
+// testing checklist item "a repo spanning multiple blocks completes only with
+// the final block" — the core durability gate this change introduces. A repo
+// whose events span several blocks must stay StateDiscovered while earlier
+// blocks become durable (advancing seq/next), and flip StateComplete only once
+// the block containing its FINAL event is fsynced. We use a small
+// MaxEventsPerBlock and the sync flush path so block boundaries are
+// deterministic and intermediate durable commits are observable.
+func TestSegmentHandler_MultiBlockRepoCompletesOnlyWithFinalBlock(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	st, err := store.Open(dir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+	bs := NewStore(st, nil)
+	cb := NewCompletionBatcher(bs, nil)
+
+	const perBlock = 2
+	const records = 5 // seqs 0..4 across 3 blocks: [0,1] [2,3] [4]
+	w, err := ingest.Open(ingest.Config{
+		SegmentsDir:       filepath.Join(dir, "segments"),
+		Store:             st,
+		MaxEventsPerBlock: perBlock,
+		MaxSegmentBytes:   1 << 30,
+		OnDurableBatch:    cb.StageDurable,
+		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	did := atmos.DID("did:plc:multi-block-repo")
+	require.NoError(t, bs.OnDiscover(t.Context(), testListReposEntry(did)))
+	bs.SetCompletionBatcher(cb)
+
+	r, commit := buildMultiRecordRepo(t, did, "app.bsky.feed.post", records)
+	h := NewSegmentHandler(w, slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	h.SetCompletionBatcher(cb)
+
+	require.NoError(t, h.HandleRepo(t.Context(), did, r, commit))
+
+	// HandleRepo appended all 5 events; the two full blocks [0,1] and [2,3]
+	// auto-flushed during AppendBatch and committed durably (seq/next advanced
+	// to 4), but the final event seq 4 sits in an un-fsynced pending block. The
+	// watermark records the repo's final event seq before OnComplete consumes
+	// it (QueueComplete deletes the watermark entry).
+	require.Equal(t, completionWatermark{lastSeq: uint64(records - 1), appended: true}, cb.watermarks[did],
+		"watermark must record the repo's final event seq")
+	require.Equal(t, uint64(records), w.NextSeq())
+
+	require.NoError(t, bs.OnComplete(t.Context(), did, commit))
+	// The completion must NOT be durable yet: its watermark lastSeq=4 is not
+	// below the durable seq/next=4 (final event's block not fsynced).
+	requireLookupState(t, bs, did, atmosbackfill.StateDiscovered)
+	require.Len(t, cb.queued, 1, "completion stays queued until the final block is durable")
+
+	// Draining flushes the trailing block (seq 4), fsyncs it, then commits the
+	// completion in the same durable batch. Only now may it be complete.
+	require.NoError(t, w.DrainDurability(t.Context()))
+	requireLookupState(t, bs, did, atmosbackfill.StateComplete)
+	require.Empty(t, cb.queued)
+
+	rs, err := bs.readRepoStatus(did)
+	require.NoError(t, err)
+	require.Equal(t, commit.Rev, rs.Backfill.Rev)
 }
 
 func TestSegmentHandler_HandleEmptyRepoRecordsEmptyWatermark(t *testing.T) {

--- a/internal/ingest/backfill/handler_test.go
+++ b/internal/ingest/backfill/handler_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bluesky-social/jetstream-v2/internal/store"
 	"github.com/bluesky-social/jetstream-v2/segment"
 	"github.com/jcalabro/atmos"
+	atmosbackfill "github.com/jcalabro/atmos/backfill"
 	"github.com/jcalabro/atmos/cbor"
 	"github.com/jcalabro/atmos/crypto"
 	"github.com/jcalabro/atmos/mst"
@@ -91,34 +92,131 @@ func TestSegmentHandler_EmitsOneEventPerRecord(t *testing.T) {
 		"one record yields exactly one event")
 }
 
-func TestSegmentHandler_HandleRepoFlushesBeforeReturning(t *testing.T) {
+func TestSegmentHandler_HandleRepoQueuesCompletionWithoutFlush(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
 	st, err := store.Open(dir, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = st.Close() })
+	bs := NewStore(st, nil)
 
 	segmentsDir := filepath.Join(dir, "segments")
+	cb := NewCompletionBatcher(bs, nil)
 	w, err := ingest.Open(ingest.Config{
 		SegmentsDir:       segmentsDir,
 		Store:             st,
 		MaxEventsPerBlock: 4096,
+		OnDurableBatch:    cb.StageDurable,
 		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = w.Close() })
 
-	did := atmos.DID("did:plc:flush-before-complete")
+	did := atmos.DID("did:plc:no-flush-before-complete")
+	require.NoError(t, bs.OnDiscover(t.Context(), testListReposEntry(did)))
+	bs.SetCompletionBatcher(cb)
+
 	r, commit := buildSingleRecordRepo(t,
 		did, "app.bsky.feed.post", "rkey1",
-		map[string]any{"text": "flush before complete"})
+		map[string]any{"text": "completion is tied to durable block metadata"})
 	h := NewSegmentHandler(w, slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	h.SetCompletionBatcher(cb)
 
 	require.NoError(t, h.HandleRepo(t.Context(), did, r, commit))
 
 	events := collectActiveEvents(t, filepath.Join(segmentsDir, ingest.SegmentFilename(0)))
-	require.Len(t, events, 1, "HandleRepo must flush appended rows before returning to the engine")
+	require.Empty(t, events, "HandleRepo must not force a per-repo segment flush")
+	require.Equal(t, completionWatermark{lastSeq: 0, appended: true}, cb.watermarks[did])
+
+	require.NoError(t, bs.OnComplete(t.Context(), did, commit))
+	requireLookupState(t, bs, did, atmosbackfill.StateDiscovered)
+	require.Len(t, cb.queued, 1)
+
+	require.NoError(t, w.DrainDurability(t.Context()))
+	requireLookupState(t, bs, did, atmosbackfill.StateComplete)
+	require.Empty(t, cb.queued)
+}
+
+func TestSegmentHandler_HandleEmptyRepoRecordsEmptyWatermark(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	st, err := store.Open(dir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+	bs := NewStore(st, nil)
+	cb := NewCompletionBatcher(bs, nil)
+
+	w, err := ingest.Open(ingest.Config{
+		SegmentsDir:       filepath.Join(dir, "segments"),
+		Store:             st,
+		MaxEventsPerBlock: 4096,
+		OnDurableBatch:    cb.StageDurable,
+		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	did := atmos.DID("did:plc:empty-repo")
+	require.NoError(t, bs.OnDiscover(t.Context(), testListReposEntry(did)))
+	bs.SetCompletionBatcher(cb)
+
+	blockStore := mst.NewMemBlockStore()
+	r := &atmosrepo.Repo{
+		DID:   did,
+		Store: blockStore,
+		Tree:  mst.NewTree(blockStore),
+	}
+	commit := &atmosrepo.Commit{DID: string(did), Rev: "rev-empty"}
+	h := NewSegmentHandler(w, slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	h.SetCompletionBatcher(cb)
+
+	require.NoError(t, h.HandleRepo(t.Context(), did, r, commit))
+	require.Equal(t, completionWatermark{lastSeq: 0, appended: false}, cb.watermarks[did])
+
+	require.NoError(t, bs.OnComplete(t.Context(), did, commit))
+	requireLookupState(t, bs, did, atmosbackfill.StateDiscovered)
+	require.NoError(t, w.DrainDurability(t.Context()))
+	requireLookupState(t, bs, did, atmosbackfill.StateComplete)
+}
+
+func TestSegmentHandler_QueuedCompletionBecomesDurableOnWriterClose(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	st, err := store.Open(dir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+	bs := NewStore(st, nil)
+	cb := NewCompletionBatcher(bs, nil)
+
+	w, err := ingest.Open(ingest.Config{
+		SegmentsDir:       filepath.Join(dir, "segments"),
+		Store:             st,
+		MaxEventsPerBlock: 4096,
+		OnDurableBatch:    cb.StageDurable,
+		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	require.NoError(t, err)
+
+	did := atmos.DID("did:plc:complete-on-close")
+	require.NoError(t, bs.OnDiscover(t.Context(), testListReposEntry(did)))
+	bs.SetCompletionBatcher(cb)
+
+	r, commit := buildSingleRecordRepo(t,
+		did, "app.bsky.feed.post", "rkey1",
+		map[string]any{"text": "completion should be durable on close"})
+	h := NewSegmentHandler(w, slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	h.SetCompletionBatcher(cb)
+
+	require.NoError(t, h.HandleRepo(t.Context(), did, r, commit))
+	require.NoError(t, bs.OnComplete(t.Context(), did, commit))
+	requireLookupState(t, bs, did, atmosbackfill.StateDiscovered)
+
+	require.NoError(t, w.Close())
+	requireLookupState(t, bs, did, atmosbackfill.StateComplete)
+	require.Empty(t, cb.queued)
 }
 
 func TestSegmentHandler_DropsRecordThatExceedsSegmentColumnWidth(t *testing.T) {

--- a/internal/ingest/backfill/metrics.go
+++ b/internal/ingest/backfill/metrics.go
@@ -14,14 +14,19 @@ const metricsSubsystem = "backfill"
 // A nil *Metrics is a valid zero-value: every method is a no-op,
 // which lets tests skip metric registration entirely.
 type Metrics struct {
-	Discovered         prometheus.Counter
-	Completed          prometheus.Counter
-	Failed             prometheus.Counter
-	ActiveFlips        prometheus.Counter
-	OnFailErrors       prometheus.Counter
-	HandleRepoDuration prometheus.Histogram
-	ProgressCompleted  prometheus.Gauge
-	DroppedRecords     prometheus.Counter
+	Discovered               prometheus.Counter
+	Completed                prometheus.Counter
+	Failed                   prometheus.Counter
+	ActiveFlips              prometheus.Counter
+	OnFailErrors             prometheus.Counter
+	HandleRepoDuration       prometheus.Histogram
+	ProgressCompleted        prometheus.Gauge
+	DroppedRecords           prometheus.Counter
+	CompletionQueued         prometheus.Counter
+	CompletionQueueDepth     prometheus.Gauge
+	CompletionDurableBatches prometheus.Counter
+	CompletionDurableRepos   prometheus.Counter
+	CompletionStageErrors    prometheus.Counter
 }
 
 // NewMetrics registers the backfill counters against reg. Pass the
@@ -75,10 +80,37 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 			Name: "dropped_records_total",
 			Help: "Number of upstream repo records skipped because their fields cannot be represented in the segment format.",
 		}),
+		CompletionQueued: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: metricsNamespace, Subsystem: metricsSubsystem,
+			Name: "completion_queued_total",
+			Help: "Number of repo completions queued for async durable metadata commit.",
+		}),
+		CompletionQueueDepth: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: metricsNamespace, Subsystem: metricsSubsystem,
+			Name: "completion_queue_depth",
+			Help: "Current number of repo completions waiting for a writer durable metadata batch.",
+		}),
+		CompletionDurableBatches: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: metricsNamespace, Subsystem: metricsSubsystem,
+			Name: "completion_durable_batches_total",
+			Help: "Number of writer durable metadata batches that committed at least one queued repo completion.",
+		}),
+		CompletionDurableRepos: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: metricsNamespace, Subsystem: metricsSubsystem,
+			Name: "completion_durable_repos_total",
+			Help: "Number of queued repo completions committed by writer durable metadata batches.",
+		}),
+		CompletionStageErrors: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: metricsNamespace, Subsystem: metricsSubsystem,
+			Name: "completion_stage_errors_total",
+			Help: "Number of errors staging queued repo completions into a writer durable metadata batch.",
+		}),
 	}
 	reg.MustRegister(
 		m.Discovered, m.Completed, m.Failed, m.ActiveFlips, m.OnFailErrors,
 		m.HandleRepoDuration, m.ProgressCompleted, m.DroppedRecords,
+		m.CompletionQueued, m.CompletionQueueDepth, m.CompletionDurableBatches,
+		m.CompletionDurableRepos, m.CompletionStageErrors,
 	)
 	return m
 }
@@ -136,5 +168,30 @@ func (m *Metrics) setProgressCompleted(v int64) {
 func (m *Metrics) incDroppedRecords() {
 	if m != nil {
 		m.DroppedRecords.Inc()
+	}
+}
+
+func (m *Metrics) incCompletionQueued() {
+	if m != nil {
+		m.CompletionQueued.Inc()
+	}
+}
+
+func (m *Metrics) setCompletionQueueDepth(v int) {
+	if m != nil {
+		m.CompletionQueueDepth.Set(float64(v))
+	}
+}
+
+func (m *Metrics) observeCompletionDurableBatch(repos int) {
+	if m != nil && repos > 0 {
+		m.CompletionDurableBatches.Inc()
+		m.CompletionDurableRepos.Add(float64(repos))
+	}
+}
+
+func (m *Metrics) incCompletionStageErrors() {
+	if m != nil {
+		m.CompletionStageErrors.Inc()
 	}
 }

--- a/internal/ingest/backfill/metrics.go
+++ b/internal/ingest/backfill/metrics.go
@@ -27,6 +27,8 @@ type Metrics struct {
 	CompletionDurableBatches prometheus.Counter
 	CompletionDurableRepos   prometheus.Counter
 	CompletionStageErrors    prometheus.Counter
+	CompletionQueueWait      prometheus.Histogram
+	ForcedCheckpointFlushes  prometheus.Counter
 }
 
 // NewMetrics registers the backfill counters against reg. Pass the
@@ -105,12 +107,24 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 			Name: "completion_stage_errors_total",
 			Help: "Number of errors staging queued repo completions into a writer durable metadata batch.",
 		}),
+		CompletionQueueWait: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: metricsNamespace, Subsystem: metricsSubsystem,
+			Name:    "completion_queue_wait_seconds",
+			Help:    "Time a repo completion waited in the in-memory queue between being queued and becoming durable. A rising tail surfaces a durability backlog that completion_queue_depth alone cannot distinguish from steady draining.",
+			Buckets: obs.LatencyBucketsSlow,
+		}),
+		ForcedCheckpointFlushes: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: metricsNamespace, Subsystem: metricsSubsystem,
+			Name: "forced_checkpoint_flushes_total",
+			Help: "Number of forced writer durability drains at a batch/checkpoint barrier (DrainDurability), as opposed to completions that drained naturally on a block boundary.",
+		}),
 	}
 	reg.MustRegister(
 		m.Discovered, m.Completed, m.Failed, m.ActiveFlips, m.OnFailErrors,
 		m.HandleRepoDuration, m.ProgressCompleted, m.DroppedRecords,
 		m.CompletionQueued, m.CompletionQueueDepth, m.CompletionDurableBatches,
 		m.CompletionDurableRepos, m.CompletionStageErrors,
+		m.CompletionQueueWait, m.ForcedCheckpointFlushes,
 	)
 	return m
 }
@@ -193,5 +207,20 @@ func (m *Metrics) observeCompletionDurableBatch(repos int) {
 func (m *Metrics) incCompletionStageErrors() {
 	if m != nil {
 		m.CompletionStageErrors.Inc()
+	}
+}
+
+// observeCompletionQueueWait records how long a completion sat in the queue
+// before becoming durable. since is the duration from QueueComplete's captured
+// timestamp to the durable commit; negative values (clock skew) are dropped.
+func (m *Metrics) observeCompletionQueueWait(since time.Duration) {
+	if m != nil && since >= 0 {
+		m.CompletionQueueWait.Observe(since.Seconds())
+	}
+}
+
+func (m *Metrics) incForcedCheckpointFlushes() {
+	if m != nil {
+		m.ForcedCheckpointFlushes.Inc()
 	}
 }

--- a/internal/ingest/backfill/metrics_test.go
+++ b/internal/ingest/backfill/metrics_test.go
@@ -24,6 +24,10 @@ func TestNewMetrics_RegistersStableMetrics(t *testing.T) {
 	m.observeHandleRepo(time.Now().Add(-time.Millisecond), nil)
 	m.setProgressCompleted(42)
 	m.incDroppedRecords()
+	m.incCompletionQueued()
+	m.setCompletionQueueDepth(3)
+	m.observeCompletionDurableBatch(2)
+	m.incCompletionStageErrors()
 
 	require.InDelta(t, 1.0, testutil.ToFloat64(m.Discovered), 0)
 	require.InDelta(t, 1.0, testutil.ToFloat64(m.Completed), 0)
@@ -33,6 +37,11 @@ func TestNewMetrics_RegistersStableMetrics(t *testing.T) {
 	require.Equal(t, 1, testutil.CollectAndCount(m.HandleRepoDuration))
 	require.InDelta(t, 42.0, testutil.ToFloat64(m.ProgressCompleted), 0)
 	require.InDelta(t, 1.0, testutil.ToFloat64(m.DroppedRecords), 0)
+	require.InDelta(t, 1.0, testutil.ToFloat64(m.CompletionQueued), 0)
+	require.InDelta(t, 3.0, testutil.ToFloat64(m.CompletionQueueDepth), 0)
+	require.InDelta(t, 1.0, testutil.ToFloat64(m.CompletionDurableBatches), 0)
+	require.InDelta(t, 2.0, testutil.ToFloat64(m.CompletionDurableRepos), 0)
+	require.InDelta(t, 1.0, testutil.ToFloat64(m.CompletionStageErrors), 0)
 	requireNoDebugMetricFields(t, m)
 	requireNoDebugMetrics(t, reg)
 }
@@ -50,6 +59,10 @@ func TestNewMetrics_NilSafe(t *testing.T) {
 		m.observeHandleRepo(time.Now(), nil)
 		m.setProgressCompleted(1)
 		m.incDroppedRecords()
+		m.incCompletionQueued()
+		m.setCompletionQueueDepth(1)
+		m.observeCompletionDurableBatch(1)
+		m.incCompletionStageErrors()
 	})
 }
 

--- a/internal/ingest/backfill/metrics_test.go
+++ b/internal/ingest/backfill/metrics_test.go
@@ -28,6 +28,8 @@ func TestNewMetrics_RegistersStableMetrics(t *testing.T) {
 	m.setCompletionQueueDepth(3)
 	m.observeCompletionDurableBatch(2)
 	m.incCompletionStageErrors()
+	m.observeCompletionQueueWait(time.Millisecond)
+	m.incForcedCheckpointFlushes()
 
 	require.InDelta(t, 1.0, testutil.ToFloat64(m.Discovered), 0)
 	require.InDelta(t, 1.0, testutil.ToFloat64(m.Completed), 0)
@@ -42,6 +44,8 @@ func TestNewMetrics_RegistersStableMetrics(t *testing.T) {
 	require.InDelta(t, 1.0, testutil.ToFloat64(m.CompletionDurableBatches), 0)
 	require.InDelta(t, 2.0, testutil.ToFloat64(m.CompletionDurableRepos), 0)
 	require.InDelta(t, 1.0, testutil.ToFloat64(m.CompletionStageErrors), 0)
+	require.Equal(t, 1, testutil.CollectAndCount(m.CompletionQueueWait))
+	require.InDelta(t, 1.0, testutil.ToFloat64(m.ForcedCheckpointFlushes), 0)
 	requireNoDebugMetricFields(t, m)
 	requireNoDebugMetrics(t, reg)
 }
@@ -63,6 +67,8 @@ func TestNewMetrics_NilSafe(t *testing.T) {
 		m.setCompletionQueueDepth(1)
 		m.observeCompletionDurableBatch(1)
 		m.incCompletionStageErrors()
+		m.observeCompletionQueueWait(time.Millisecond)
+		m.incForcedCheckpointFlushes()
 	})
 }
 

--- a/internal/ingest/backfill/run.go
+++ b/internal/ingest/backfill/run.go
@@ -147,6 +147,7 @@ func Run(ctx context.Context, cfg Config) error {
 			return fatalErr
 		}
 		drainDurability := func() error {
+			cfg.Metrics.incForcedCheckpointFlushes()
 			if err := cfg.Writer.DrainDurability(ctx); err != nil {
 				return fmt.Errorf("backfill: drain durable completions: %w", err)
 			}

--- a/internal/ingest/backfill/run.go
+++ b/internal/ingest/backfill/run.go
@@ -146,11 +146,25 @@ func Run(ctx context.Context, cfg Config) error {
 			defer fatalMu.Unlock()
 			return fatalErr
 		}
+		drainDurability := func() error {
+			if err := cfg.Writer.DrainDurability(ctx); err != nil {
+				return fmt.Errorf("backfill: drain durable completions: %w", err)
+			}
+			if fatal := loadFatal(); fatal != nil {
+				logger := cfg.Logger.With(slog.String("component", "backfill/run"))
+				logger.ErrorContext(ctx, "backfill aborted during durable completion drain", "err", fatal)
+				return fmt.Errorf("backfill: %w", fatal)
+			}
+			return nil
+		}
 
 		st := NewStore(cfg.Store, cfg.Metrics)
 		st.afterComplete = cfg.AfterRepoComplete
 		st.afterCompleteError = recordFatal
 		st.crashInjector = cfg.CrashInjector
+		completions := NewCompletionBatcher(st, cfg.Metrics)
+		st.SetCompletionBatcher(completions)
+		cfg.Writer.SetDurableBatchHook(completions.StageDurable)
 		directory := directoryWithRecordingResolver(cfg.Directory, st, recordFatal)
 
 		sc := atmossync.NewClient(atmossync.Options{
@@ -160,6 +174,7 @@ func Run(ctx context.Context, cfg Config) error {
 
 		handler := NewSegmentHandler(cfg.Writer, cfg.Logger, cfg.Metrics)
 		handler.onWriterError = recordFatal
+		handler.SetCompletionBatcher(completions)
 		logger := cfg.Logger.With(slog.String("component", "backfill/run"))
 
 		if len(cfg.BackfillRepos) > 0 {
@@ -203,7 +218,7 @@ func Run(ctx context.Context, cfg Config) error {
 				logger.ErrorContext(ctx, "selected repo backfill aborted after local writer error", "err", fatal)
 				return fmt.Errorf("backfill: %w", fatal)
 			}
-			return nil
+			return drainDurability()
 		}
 
 		startCursor, err := LoadListReposCursor(cfg.Store)
@@ -293,7 +308,7 @@ func Run(ctx context.Context, cfg Config) error {
 			// so the orchestrator advances to merge.
 			if limitTripped.Load() && errors.Is(err, context.Canceled) && ctx.Err() == nil {
 				logger.InfoContext(ctx, "engine drained early via max-backfill-repos")
-				return nil
+				return drainDurability()
 			}
 			logger.ErrorContext(ctx, "engine returned error", "err", err)
 			return fmt.Errorf("backfill: %w", err)
@@ -304,7 +319,7 @@ func Run(ctx context.Context, cfg Config) error {
 		}
 
 		logger.InfoContext(ctx, "engine drained")
-		return nil
+		return drainDurability()
 	})
 }
 

--- a/internal/ingest/backfill/run.go
+++ b/internal/ingest/backfill/run.go
@@ -71,10 +71,10 @@ type Config struct {
 	// counter and do not count.
 	//
 	// Intended for fast local-dev iteration against the production
-	// relay (millions of users); leave 0 in production. The persisted
-	// listRepos cursor will not advance past the page on which the
-	// limit trips, so subsequent runs without the flag re-walk from
-	// the same point.
+	// relay (millions of users); leave 0 in production. Cursor
+	// advancement remains batch/checkpoint-bound and may advance for a
+	// fully completed durable batch, but MaxRepos does not force
+	// terminal empty-cursor advancement.
 	MaxRepos int
 
 	// BackfillWorkers, when > 0, overrides atmos's repo download worker count.
@@ -157,6 +157,43 @@ func Run(ctx context.Context, cfg Config) error {
 			}
 			return nil
 		}
+		var lastNonEmptyListReposCursor string
+		var batchCursorSaved bool
+		rememberPageCursor := func(cursor string) error {
+			if cursor != "" {
+				lastNonEmptyListReposCursor = cursor
+			}
+			return nil
+		}
+		saveBatchCursor := func(cursor string) error {
+			if err := drainDurability(); err != nil {
+				return err
+			}
+			// Persist the last non-empty cursor under a sibling key so the
+			// merge phase can resume listRepos to discover DIDs born during
+			// bootstrap. OnBatchComplete's final cursor can be empty even
+			// when its completed batch covered earlier non-empty pages, so
+			// OnPageComplete only records the latest candidate in memory;
+			// this callback is still the only durable persistence point.
+			bootstrapCursor := cursor
+			if bootstrapCursor == "" {
+				bootstrapCursor = lastNonEmptyListReposCursor
+			}
+			if err := SaveListReposCheckpoint(cfg.Store, cursor, bootstrapCursor); err != nil {
+				return err
+			}
+			batchCursorSaved = true
+			return nil
+		}
+		finishCleanEngineDrain := func() error {
+			if err := drainDurability(); err != nil {
+				return err
+			}
+			if batchCursorSaved {
+				return nil
+			}
+			return SaveListReposCheckpoint(cfg.Store, "", "")
+		}
 
 		st := NewStore(cfg.Store, cfg.Metrics)
 		st.afterComplete = cfg.AfterRepoComplete
@@ -237,22 +274,14 @@ func Run(ctx context.Context, cfg Config) error {
 		var limitTripped atomic.Bool
 
 		engineOpts := atmosbackfill.Options{
-			SyncClient:  sc,
-			Store:       st,
-			Handler:     handler,
-			Directory:   gt.Some(directory),
-			HTTPClient:  gt.Some(cfg.HTTPClient),
-			StartCursor: gt.Some(startCursor),
-			OnPageComplete: gt.Some(func(cursor string) error {
-				if err := SaveListReposCursor(cfg.Store, cursor); err != nil {
-					return err
-				}
-				// Persist the last non-empty cursor under a sibling
-				// key so the merge phase can resume listRepos to
-				// discover DIDs born during bootstrap. The
-				// MaybeSave helper short-circuits on cursor=="".
-				return MaybeSaveBootstrapLastListReposCursor(cfg.Store, cursor)
-			}),
+			SyncClient:      sc,
+			Store:           st,
+			Handler:         handler,
+			Directory:       gt.Some(directory),
+			HTTPClient:      gt.Some(cfg.HTTPClient),
+			StartCursor:     gt.Some(startCursor),
+			OnBatchComplete: gt.Some(saveBatchCursor),
+			OnPageComplete:  gt.Some(rememberPageCursor),
 			OnError: gt.Some(func(did atmos.DID, err error) {
 				if !shouldLogBackfillError(err) {
 					return
@@ -319,7 +348,7 @@ func Run(ctx context.Context, cfg Config) error {
 		}
 
 		logger.InfoContext(ctx, "engine drained")
-		return drainDurability()
+		return finishCleanEngineDrain()
 	})
 }
 

--- a/internal/ingest/backfill/run_test.go
+++ b/internal/ingest/backfill/run_test.go
@@ -1077,7 +1077,7 @@ func TestRun_WritesSegmentFile(t *testing.T) {
 		"two repos × 1 record each = 2 events; max seq must be at least 1")
 }
 
-func TestRun_WriterFlushErrorAbortsWithoutMarkingRepoFailed(t *testing.T) {
+func TestRun_WriterFlushErrorAbortsAfterDurableCompletion(t *testing.T) {
 	t.Parallel()
 
 	did := atmos.DID("did:plc:flush-fails")
@@ -1129,8 +1129,8 @@ func TestRun_WriterFlushErrorAbortsWithoutMarkingRepoFailed(t *testing.T) {
 
 	got, err := NewStore(db, nil).Lookup(t.Context(), did)
 	require.NoError(t, err)
-	require.Equal(t, atmosbackfill.StateDiscovered, got.State,
-		"local writer durability errors must abort the run, not become a per-DID failure")
+	require.Equal(t, atmosbackfill.StateComplete, got.State,
+		"completion is committed in the same durable batch before legacy OnAfterFlush runs")
 }
 
 func TestRun_AfterRepoCompleteErrorAbortsRun(t *testing.T) {

--- a/internal/ingest/backfill/run_test.go
+++ b/internal/ingest/backfill/run_test.go
@@ -1163,6 +1163,80 @@ func TestRun_WriterFlushErrorAbortsAfterDurableCompletion(t *testing.T) {
 		"completion is committed in the same durable batch before legacy OnAfterFlush runs")
 }
 
+func TestRun_RestartAfterQueuedCompletionErrorDoesNotRedownload(t *testing.T) {
+	t.Parallel()
+
+	did := atmos.DID("did:plc:queued-complete-restart")
+	fixtures := map[atmos.DID]repoFixture{did: buildRepoFixture(t, did)}
+	srv := newStubServer(t, fixtures)
+
+	dataDir := t.TempDir()
+	db, err := store.Open(dataDir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	docs := make(map[atmos.DID]*identity.DIDDocument, len(fixtures))
+	for did, f := range fixtures {
+		docs[did] = &identity.DIDDocument{
+			ID: string(did),
+			VerificationMethod: []identity.VerificationMethod{
+				{ID: "#atproto", Type: "Multikey", Controller: string(did), PublicKeyMultibase: f.multibase},
+			},
+			Service: []identity.Service{
+				{ID: "#atproto_pds", Type: "AtprotoPersonalDataServer", ServiceEndpoint: srv.srv.URL},
+			},
+		}
+	}
+	dir := &identity.Directory{Resolver: &stubResolver{docs: docs}}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	errFlush := errors.New("flush failed after completion commit")
+	w, err := ingest.Open(ingest.Config{
+		SegmentsDir:       filepath.Join(dataDir, "segments"),
+		Store:             db,
+		Logger:            logger,
+		MaxEventsPerBlock: 4096,
+		MaxSegmentBytes:   1 << 30,
+		OnAfterFlush: func(context.Context) error {
+			return errFlush
+		},
+	})
+	require.NoError(t, err)
+
+	err = Run(t.Context(), Config{
+		Store:      db,
+		Directory:  dir,
+		HTTPClient: &http.Client{Timeout: 5 * time.Second},
+		Writer:     w,
+		RelayURL:   srv.srv.URL,
+		Logger:     logger,
+	})
+	require.ErrorIs(t, err, errFlush)
+	require.NoError(t, w.Close())
+	firstGetRepo := srv.getRepoHit.Load()
+	require.Equal(t, int64(1), firstGetRepo)
+
+	w, err = ingest.Open(ingest.Config{
+		SegmentsDir:       filepath.Join(dataDir, "segments"),
+		Store:             db,
+		Logger:            logger,
+		MaxEventsPerBlock: 4096,
+		MaxSegmentBytes:   1 << 30,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	require.NoError(t, Run(t.Context(), Config{
+		Store:      db,
+		Directory:  dir,
+		HTTPClient: &http.Client{Timeout: 5 * time.Second},
+		Writer:     w,
+		RelayURL:   srv.srv.URL,
+		Logger:     logger,
+	}))
+	require.Equal(t, firstGetRepo, srv.getRepoHit.Load(), "durable queued completion must prevent restart redownload")
+}
+
 func TestRun_AfterRepoCompleteErrorAbortsRun(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ingest/backfill/run_test.go
+++ b/internal/ingest/backfill/run_test.go
@@ -241,6 +241,10 @@ type stubServer struct {
 	// in pages of this size. Cursor is the first DID of the next page,
 	// or "" when drained.
 	listReposPageSize int
+
+	// emptyListReposCursor, when non-empty, makes listRepos return an empty
+	// terminal page for that cursor. This models resuming after the final DID.
+	emptyListReposCursor string
 }
 
 func newStubServer(t *testing.T, fixtures map[atmos.DID]repoFixture) *stubServer {
@@ -267,12 +271,17 @@ func (s *stubServer) handle(w http.ResponseWriter, r *http.Request) {
 	case "/xrpc/com.atproto.sync.listRepos":
 		s.listReposHit.Add(1)
 		s.recordEvent("listRepos")
+		cursor := r.URL.Query().Get("cursor")
 		s.firstListReposCursorMu.Lock()
 		if !s.firstListReposCursorOK {
-			s.firstListReposCursor = r.URL.Query().Get("cursor")
+			s.firstListReposCursor = cursor
 			s.firstListReposCursorOK = true
 		}
 		s.firstListReposCursorMu.Unlock()
+		if s.emptyListReposCursor != "" && cursor == s.emptyListReposCursor {
+			_ = json.NewEncoder(w).Encode(listPage{})
+			return
+		}
 		// Stable order so tests that count fail-vs-not are deterministic.
 		dids := make([]atmos.DID, 0, len(s.fixtures))
 		for did := range s.fixtures {
@@ -283,7 +292,6 @@ func (s *stubServer) handle(w http.ResponseWriter, r *http.Request) {
 		page := listPage{}
 		if s.listReposPageSize > 0 {
 			// Paginated mode: cursor is the first DID of this page.
-			cursor := r.URL.Query().Get("cursor")
 			startIdx := 0
 			if cursor != "" {
 				// Find where this cursor starts in the sorted DID list.
@@ -884,7 +892,7 @@ func TestRun_Resume_NoOpAfterCompletion(t *testing.T) {
 // TestRun_PersistsCursorAfterDrain confirms the post-drain cursor
 // (empty string) is durably saved to pebble. Following the existing
 // HappyPath: after Run returns, the cursor key exists in pebble with
-// value "" — atmos fires OnPageComplete("") after the terminator
+// value "" — atmos fires OnBatchComplete("") after the terminator
 // page. Without this assertion, the cursor optimization could
 // silently no-op.
 func TestRun_PersistsCursorAfterDrain(t *testing.T) {
@@ -1014,6 +1022,28 @@ func TestRun_PassesSavedCursorToRelay(t *testing.T) {
 		"first listRepos request must use the pre-seeded cursor as startCursor")
 }
 
+func TestRun_ClearsSavedCursorWhenResumeDrainsNoRepos(t *testing.T) {
+	t.Parallel()
+
+	did := atmos.DID("did:plc:aaa")
+	fixtures := map[atmos.DID]repoFixture{did: buildRepoFixture(t, did)}
+	srv := newStubServer(t, fixtures)
+	srv.emptyListReposCursor = "after-last-did"
+
+	db, err := store.Open(t.TempDir(), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	require.NoError(t, SaveListReposCursor(db, "after-last-did"))
+
+	require.NoError(t, runWithStub(t, t.Context(), srv, db))
+
+	got, err := LoadListReposCursor(db)
+	require.NoError(t, err)
+	require.Equal(t, "", got, "full clean drain must clear stale non-empty resume cursor")
+	require.Equal(t, int64(0), srv.getRepoHit.Load(), "empty resumed listRepos must not download repos")
+}
+
 // TestRun_WritesSegmentFile confirms that backfilling a non-empty
 // fixture leaves a real seg_*.jss on disk with at least one event.
 func TestRun_WritesSegmentFile(t *testing.T) {
@@ -1136,9 +1166,12 @@ func TestRun_WriterFlushErrorAbortsAfterDurableCompletion(t *testing.T) {
 func TestRun_AfterRepoCompleteErrorAbortsRun(t *testing.T) {
 	t.Parallel()
 
-	did := atmos.DID("did:plc:after-complete-fails")
-	fixtures := map[atmos.DID]repoFixture{did: buildRepoFixture(t, did)}
-	srv := newStubServer(t, fixtures)
+	dids := []atmos.DID{"did:plc:after-complete-fails", "did:plc:after-complete-next"}
+	fixtures := make(map[atmos.DID]repoFixture, len(dids))
+	for _, did := range dids {
+		fixtures[did] = buildRepoFixture(t, did)
+	}
+	srv := newPaginatingStubServer(t, fixtures, 1)
 
 	dataDir := t.TempDir()
 	db, err := store.Open(dataDir, nil)
@@ -1182,6 +1215,25 @@ func TestRun_AfterRepoCompleteErrorAbortsRun(t *testing.T) {
 		},
 	})
 	require.ErrorIs(t, err, errHook)
+
+	got, err := NewStore(db, nil).Lookup(t.Context(), dids[0])
+	require.NoError(t, err)
+	require.Equal(t, atmosbackfill.StateComplete, got.State,
+		"completion row is durable before the hook failure is surfaced")
+
+	_, closer, err := db.Get([]byte(listReposCursorKey))
+	if closer != nil {
+		require.NoError(t, closer.Close())
+	}
+	require.ErrorIs(t, err, store.ErrNotFound,
+		"listRepos cursor must not advance past a failed durable completion hook")
+
+	_, closer, err = db.Get([]byte(bootstrapLastListReposCursorKey))
+	if closer != nil {
+		require.NoError(t, closer.Close())
+	}
+	require.ErrorIs(t, err, store.ErrNotFound,
+		"bootstrap-last cursor must not advance past a failed durable completion hook")
 }
 
 // TestRun_PersistsBootstrapLastListReposCursor confirms the bootstrap-

--- a/internal/ingest/backfill/store.go
+++ b/internal/ingest/backfill/store.go
@@ -37,6 +37,7 @@ type Store struct {
 	afterCompleteError func(error)
 	crashInjector      crashpoint.Injector
 	countsMu           sync.Mutex
+	completions        *completionBatcher
 }
 
 // Compile-time guarantee that Store satisfies the atmos contract.
@@ -46,6 +47,13 @@ var _ atmosbackfill.Store = (*Store)(nil)
 // metrics may be nil; callbacks are no-ops in that case.
 func NewStore(db *store.Store, metrics *Metrics) *Store {
 	return &Store{db: db, metrics: metrics}
+}
+
+// SetCompletionBatcher defers OnComplete writes into writer durable metadata
+// batches. It is intended for construction-time wiring before the backfill
+// engine starts.
+func (s *Store) SetCompletionBatcher(b *completionBatcher) {
+	s.completions = b
 }
 
 // Lookup reads repo/<did> and projects the on-disk RepoStatus into
@@ -329,7 +337,28 @@ func (s *Store) stageCompleteBatch(ctx context.Context, batch *pebble.Batch, com
 			return fail(err)
 		}
 	}
-	return unlock, nil
+	return func(commitErr error) {
+		unlock(commitErr)
+		if commitErr != nil {
+			return
+		}
+		for _, c := range completions {
+			if err := s.simulateCrash(ctx, crashpoint.AfterRepoComplete); err != nil {
+				if s.afterCompleteError != nil {
+					s.afterCompleteError(fmt.Errorf("backfill: after repo complete crashpoint %s: %w", c.did, err))
+				}
+				continue
+			}
+			if s.afterComplete != nil {
+				if err := s.afterComplete(ctx, c.did); err != nil {
+					err = fmt.Errorf("backfill: after complete hook %s: %w", c.did, err)
+					if s.afterCompleteError != nil {
+						s.afterCompleteError(err)
+					}
+				}
+			}
+		}
+	}, nil
 }
 
 func applyCountTransition(c *Counts, hadRow bool, old, next Status) {
@@ -610,6 +639,10 @@ func (s *Store) OnUpdate(_ context.Context, entry atmossync.ListReposEntry) erro
 // survives. The read, aggregate transition, and durable write must
 // stay serialized with deferred completion staging via countsMu.
 func (s *Store) OnComplete(ctx context.Context, did atmos.DID, commit *repo.Commit) error {
+	if s.completions != nil {
+		return s.completions.QueueComplete(ctx, did, commit)
+	}
+
 	now := timeNow()
 	if err := s.updateRepoStatusAndCounts(did, func(rs *RepoStatus, _ bool, _ Status) (func(*HostStatus), error) {
 		rs.Backfill.Status = StatusComplete

--- a/internal/ingest/backfill/store.go
+++ b/internal/ingest/backfill/store.go
@@ -6,10 +6,10 @@
 // OnFail) write with pebble.Sync to satisfy atmos's durability
 // contract: the engine treats a successful return as durable.
 //
-// atmos guarantees no two callbacks are in flight for the same DID
-// simultaneously, so OnUpdate/OnComplete/OnFail use a non-transactional
-// read-modify-write to preserve fields a future PR may have added to
-// RepoStatus (e.g. RecordCount).
+// Whole-row read-modify-write paths preserve fields a future PR may
+// add to RepoStatus (e.g. RecordCount). They serialize through countsMu
+// with aggregate writes and deferred completion staging so a stale
+// callback cannot overwrite a just-committed completion row.
 package backfill
 
 import (
@@ -21,6 +21,7 @@ import (
 
 	"github.com/bluesky-social/jetstream-v2/internal/crashpoint"
 	"github.com/bluesky-social/jetstream-v2/internal/store"
+	"github.com/cockroachdb/pebble"
 	"github.com/jcalabro/atmos"
 	atmosbackfill "github.com/jcalabro/atmos/backfill"
 	"github.com/jcalabro/atmos/repo"
@@ -150,6 +151,187 @@ func (s *Store) putRepoStatusAndCounts(
 	return nil
 }
 
+func (s *Store) updateRepoStatusAndCounts(
+	did atmos.DID,
+	mutate func(*RepoStatus, bool, Status) (func(*HostStatus), error),
+) error {
+	s.countsMu.Lock()
+	defer s.countsMu.Unlock()
+
+	rs, err := s.readRepoStatus(did)
+	if err != nil {
+		return err
+	}
+	hadRow := rs != nil
+	old := Status("")
+	if rs == nil {
+		rs = &RepoStatus{}
+	} else {
+		old = rs.Backfill.Status
+	}
+	updateHost, err := mutate(rs, hadRow, old)
+	if err != nil {
+		return err
+	}
+
+	counts, ok, err := LoadCounts(s.db)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		counts, err = CountStatuses(s.db)
+		if err != nil {
+			return err
+		}
+	}
+	applyCountTransition(&counts, hadRow, old, rs.Backfill.Status)
+	countsEnc, err := encodeCounts(counts)
+	if err != nil {
+		return err
+	}
+	enc, err := encodeRepoStatus(rs)
+	if err != nil {
+		return err
+	}
+
+	batch := s.db.NewBatch()
+	defer func() { _ = batch.Close() }()
+	if err := batch.Set(repoKey(did), enc, nil); err != nil {
+		return fmt.Errorf("backfill: stage repo/%s: %w", did, err)
+	}
+	if err := batch.Set([]byte(countsKey), countsEnc, nil); err != nil {
+		return fmt.Errorf("backfill: stage counts: %w", err)
+	}
+	if rs.Host != "" {
+		hs, _, err := loadHostStatus(s.db, rs.Host)
+		if err != nil {
+			return err
+		}
+		applyHostStatusTransition(hs, hadRow, rs.Active, old, rs.Backfill.Status)
+		if updateHost != nil {
+			updateHost(hs)
+		}
+		if err := stageHostStatus(batch, hs); err != nil {
+			return err
+		}
+	}
+	if err := s.db.Commit(batch, store.SyncWrites); err != nil {
+		return fmt.Errorf("backfill: write repo/%s and counts: %w", did, err)
+	}
+	return nil
+}
+
+func (s *Store) stageCompleteBatch(ctx context.Context, batch *pebble.Batch, completions []queuedCompletion) (func(error), error) {
+	s.countsMu.Lock()
+	locked := true
+	unlock := func(error) {
+		if locked {
+			locked = false
+			s.countsMu.Unlock()
+		}
+	}
+	fail := func(err error) (func(error), error) {
+		unlock(err)
+		return nil, err
+	}
+
+	if err := ctx.Err(); err != nil {
+		return fail(err)
+	}
+	if len(completions) == 0 {
+		unlock(nil)
+		return nil, nil
+	}
+
+	counts, ok, err := LoadCounts(s.db)
+	if err != nil {
+		return fail(err)
+	}
+	if !ok {
+		counts, err = CountStatuses(s.db)
+		if err != nil {
+			return fail(err)
+		}
+	}
+
+	type stagedRepoStatus struct {
+		status *RepoStatus
+		hadRow bool
+	}
+	repoCache := make(map[atmos.DID]stagedRepoStatus)
+	hostCache := make(map[string]*HostStatus)
+	for _, c := range completions {
+		if err := ctx.Err(); err != nil {
+			return fail(err)
+		}
+		if c.commit == nil {
+			return fail(fmt.Errorf("backfill: stage complete %s: nil commit", c.did))
+		}
+
+		cached, ok := repoCache[c.did]
+		rs := cached.status
+		hadRow := cached.hadRow
+		if !ok {
+			var err error
+			rs, err = s.readRepoStatus(c.did)
+			if err != nil {
+				return fail(err)
+			}
+			hadRow = rs != nil
+			if rs == nil {
+				rs = &RepoStatus{}
+			}
+		}
+		old := rs.Backfill.Status
+		if !hadRow {
+			old = Status("")
+		}
+		rs.Backfill.Status = StatusComplete
+		rs.Backfill.Rev = c.commit.Rev
+		rs.Backfill.CompletedAt = c.completed
+		rs.Backfill.LastError = ""
+		rs.Rev = c.commit.Rev
+		rs.UpdatedAt = c.completed
+		rs.LastAttemptedAt = c.completed
+		applyCountTransition(&counts, hadRow, old, StatusComplete)
+
+		enc, err := encodeRepoStatus(rs)
+		if err != nil {
+			return fail(err)
+		}
+		if err := batch.Set(repoKey(c.did), enc, nil); err != nil {
+			return fail(fmt.Errorf("backfill: stage repo/%s: %w", c.did, err))
+		}
+		repoCache[c.did] = stagedRepoStatus{status: rs, hadRow: true}
+		if rs.Host != "" {
+			hs := hostCache[rs.Host]
+			if hs == nil {
+				var err error
+				hs, _, err = loadHostStatus(s.db, rs.Host)
+				if err != nil {
+					return fail(err)
+				}
+				hostCache[rs.Host] = hs
+			}
+			applyHostStatusTransition(hs, hadRow, rs.Active, old, StatusComplete)
+			hs.LastAttemptedAt = c.completed
+		}
+	}
+	countsEnc, err := encodeCounts(counts)
+	if err != nil {
+		return fail(err)
+	}
+	if err := batch.Set([]byte(countsKey), countsEnc, nil); err != nil {
+		return fail(fmt.Errorf("backfill: stage counts: %w", err))
+	}
+	for _, hs := range hostCache {
+		if err := stageHostStatus(batch, hs); err != nil {
+			return fail(err)
+		}
+	}
+	return unlock, nil
+}
+
 func applyCountTransition(c *Counts, hadRow bool, old, next Status) {
 	if !hadRow {
 		c.Total++
@@ -222,14 +404,24 @@ func (s *Store) readRepoStatus(did atmos.DID) (*RepoStatus, error) {
 	return decodeRepoStatus(val)
 }
 
-func (s *Store) putRepoStatusAndHostActive(did atmos.DID, rs *RepoStatus, oldActive bool) error {
+func (s *Store) updateRepoActive(did atmos.DID, active bool) error {
+	s.countsMu.Lock()
+	defer s.countsMu.Unlock()
+
+	rs, err := s.readRepoStatus(did)
+	if err != nil {
+		return err
+	}
+	if rs == nil {
+		return fmt.Errorf("backfill: on_update %s: missing row (atmos invariant violation)", did)
+	}
+	oldActive := rs.Active
+	rs.Active = active
+
 	enc, err := encodeRepoStatus(rs)
 	if err != nil {
 		return err
 	}
-
-	s.countsMu.Lock()
-	defer s.countsMu.Unlock()
 
 	batch := s.db.NewBatch()
 	defer func() { _ = batch.Close() }()
@@ -400,16 +592,7 @@ func (s *Store) OnDiscover(_ context.Context, entry atmossync.ListReposEntry) er
 // listRepos.Active value differs from what the Store last saw, and
 // it never changes the Status as a side effect.
 func (s *Store) OnUpdate(_ context.Context, entry atmossync.ListReposEntry) error {
-	rs, err := s.readRepoStatus(entry.DID)
-	if err != nil {
-		return err
-	}
-	if rs == nil {
-		return fmt.Errorf("backfill: on_update %s: missing row (atmos invariant violation)", entry.DID)
-	}
-	oldActive := rs.Active
-	rs.Active = entry.Active
-	if err := s.putRepoStatusAndHostActive(entry.DID, rs, oldActive); err != nil {
+	if err := s.updateRepoActive(entry.DID, entry.Active); err != nil {
 		return err
 	}
 	s.metrics.incActiveFlips()
@@ -424,35 +607,21 @@ func (s *Store) OnUpdate(_ context.Context, entry atmossync.ListReposEntry) erro
 //
 // We RMW rather than write fresh so a future field on RepoStatus
 // (RecordCount, TotalBytes) added between OnDiscover and OnComplete
-// survives. atmos's no-concurrent-callback guarantee per-DID makes
-// the RMW race-free.
+// survives. The read, aggregate transition, and durable write must
+// stay serialized with deferred completion staging via countsMu.
 func (s *Store) OnComplete(ctx context.Context, did atmos.DID, commit *repo.Commit) error {
-	rs, err := s.readRepoStatus(did)
-	if err != nil {
-		return err
-	}
-	hadRow := rs != nil
-	old := Status("")
-	if rs == nil {
-		// Defensive: the engine only fires OnComplete after a Lookup
-		// returned Discovered/Failed, so the row exists. If somehow
-		// it doesn't, recreate it rather than failing the run — the
-		// download already happened and we don't want to lose the
-		// progress signal.
-		rs = &RepoStatus{}
-	} else {
-		old = rs.Backfill.Status
-	}
 	now := timeNow()
-	rs.Backfill.Status = StatusComplete
-	rs.Backfill.Rev = commit.Rev
-	rs.Backfill.CompletedAt = now
-	rs.Backfill.LastError = ""
-	rs.Rev = commit.Rev
-	rs.UpdatedAt = now
-	rs.LastAttemptedAt = now
-	if err := s.putRepoStatusAndCounts(did, rs, hadRow, old, func(hs *HostStatus) {
-		hs.LastAttemptedAt = now
+	if err := s.updateRepoStatusAndCounts(did, func(rs *RepoStatus, _ bool, _ Status) (func(*HostStatus), error) {
+		rs.Backfill.Status = StatusComplete
+		rs.Backfill.Rev = commit.Rev
+		rs.Backfill.CompletedAt = now
+		rs.Backfill.LastError = ""
+		rs.Rev = commit.Rev
+		rs.UpdatedAt = now
+		rs.LastAttemptedAt = now
+		return func(hs *HostStatus) {
+			hs.LastAttemptedAt = now
+		}, nil
 	}); err != nil {
 		return err
 	}
@@ -498,27 +667,17 @@ func (s *Store) OnFail(ctx context.Context, did atmos.DID, failErr error, attemp
 		return err
 	}
 
-	rs, err := s.readRepoStatus(did)
-	if err != nil {
-		s.metrics.incOnFailErrors()
-		return err
-	}
-	hadRow := rs != nil
-	old := Status("")
-	if rs == nil {
-		rs = &RepoStatus{}
-	} else {
-		old = rs.Backfill.Status
-	}
 	now := timeNow()
 	if isRepoNotFoundError(failErr) {
-		rs.Backfill.Status = StatusComplete
-		rs.Backfill.LastError = ""
-		rs.Backfill.Attempts = 0
-		rs.Backfill.CompletedAt = now
-		rs.LastAttemptedAt = now
-		return s.putRepoStatusAndCounts(did, rs, hadRow, old, func(hs *HostStatus) {
-			hs.LastAttemptedAt = now
+		return s.updateRepoStatusAndCounts(did, func(rs *RepoStatus, _ bool, _ Status) (func(*HostStatus), error) {
+			rs.Backfill.Status = StatusComplete
+			rs.Backfill.LastError = ""
+			rs.Backfill.Attempts = 0
+			rs.Backfill.CompletedAt = now
+			rs.LastAttemptedAt = now
+			return func(hs *HostStatus) {
+				hs.LastAttemptedAt = now
+			}, nil
 		})
 	}
 
@@ -528,18 +687,20 @@ func (s *Store) OnFail(ctx context.Context, did atmos.DID, failErr error, attemp
 	}
 	errMsg = truncateErrorString(errMsg)
 	errClass := classifyBackfillError(failErr)
-	rs.Backfill.Status = StatusFailed
-	rs.Backfill.LastError = errMsg
-	rs.Backfill.Attempts = attempts
-	rs.LastAttemptedAt = now
-	if err := s.putRepoStatusAndCounts(did, rs, hadRow, old, func(hs *HostStatus) {
-		hs.LastAttemptedAt = now
-		hs.addErrorSample(HostErrorSample{
-			DID:         did,
-			AttemptedAt: now,
-			Class:       errClass,
-			Error:       errMsg,
-		})
+	if err := s.updateRepoStatusAndCounts(did, func(rs *RepoStatus, _ bool, _ Status) (func(*HostStatus), error) {
+		rs.Backfill.Status = StatusFailed
+		rs.Backfill.LastError = errMsg
+		rs.Backfill.Attempts = attempts
+		rs.LastAttemptedAt = now
+		return func(hs *HostStatus) {
+			hs.LastAttemptedAt = now
+			hs.addErrorSample(HostErrorSample{
+				DID:         did,
+				AttemptedAt: now,
+				Class:       errClass,
+				Error:       errMsg,
+			})
+		}, nil
 	}); err != nil {
 		s.metrics.incOnFailErrors()
 		return err

--- a/internal/ingest/backfill/store_test.go
+++ b/internal/ingest/backfill/store_test.go
@@ -510,6 +510,50 @@ func TestStore_HostAggregates_ActiveFlip(t *testing.T) {
 	require.Equal(t, uint64(0), hs.Active)
 }
 
+func TestStore_StaleActiveFlipCannotRegressCompletedStatus(t *testing.T) {
+	t.Parallel()
+
+	st, err := store.Open(t.TempDir(), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	bs := NewStore(st, nil)
+	ctx := context.Background()
+	did := atmos.DID("did:plc:staleactiveflip")
+	require.NoError(t, bs.OnDiscover(ctx, atmossync.ListReposEntry{DID: did, Active: true}))
+
+	cb := NewCompletionBatcher(bs, nil)
+	cb.RecordWatermark(did, 41, true)
+	require.NoError(t, cb.QueueComplete(ctx, did, &repo.Commit{DID: string(did), Rev: "rev-complete"}))
+
+	b := st.NewBatch()
+	afterCommit, afterDone, err := cb.StageDurable(ctx, b, 42, false)
+	require.NoError(t, err)
+	require.NotNil(t, afterCommit)
+	require.NotNil(t, afterDone)
+	commitErr := st.Commit(b, store.SyncWrites)
+	if commitErr != nil {
+		afterDone(commitErr)
+		require.NoError(t, commitErr)
+	}
+	afterCommit()
+	afterDone(nil)
+	require.NoError(t, b.Close())
+
+	require.NoError(t, bs.updateRepoActive(did, false))
+
+	rs, err := bs.readRepoStatus(did)
+	require.NoError(t, err)
+	require.Equal(t, StatusComplete, rs.Backfill.Status)
+	require.Equal(t, "rev-complete", rs.Backfill.Rev)
+	require.False(t, rs.Active)
+
+	counts, ok, err := LoadCounts(st)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, Counts{Total: 1, Complete: 1}, counts)
+}
+
 func TestStore_HandleIndex_DeclaredHandleChange(t *testing.T) {
 	t.Parallel()
 	s := newTestStore(t)

--- a/internal/ingest/backfill/store_test.go
+++ b/internal/ingest/backfill/store_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/jcalabro/atmos/repo"
 	atmossync "github.com/jcalabro/atmos/sync"
 	"github.com/jcalabro/atmos/xrpc"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -196,6 +198,8 @@ func TestStore_OnUpdate_MissingRow(t *testing.T) {
 func TestStore_OnComplete_WritesComplete(t *testing.T) {
 	t.Parallel()
 	s := newTestStore(t)
+	metrics := NewMetrics(prometheus.NewRegistry())
+	s.metrics = metrics
 	did := atmos.DID("did:plc:done")
 
 	require.NoError(t, s.OnDiscover(context.Background(), atmossync.ListReposEntry{
@@ -215,6 +219,76 @@ func TestStore_OnComplete_WritesComplete(t *testing.T) {
 	require.Equal(t, "rev-final", rs.Rev)
 	require.False(t, rs.Backfill.CompletedAt.IsZero())
 	require.False(t, rs.UpdatedAt.IsZero())
+	require.InDelta(t, 1.0, testutil.ToFloat64(metrics.Completed), 0)
+}
+
+func TestStore_OnCompleteQueuesWhenBatcherConfigured(t *testing.T) {
+	t.Parallel()
+
+	st, err := store.Open(t.TempDir(), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	metrics := NewMetrics(prometheus.NewRegistry())
+	s := NewStore(st, metrics)
+	cb := NewCompletionBatcher(s, metrics)
+	s.SetCompletionBatcher(cb)
+
+	ctx := t.Context()
+	did := atmos.DID("did:plc:queued-complete")
+	require.NoError(t, s.OnDiscover(ctx, atmossync.ListReposEntry{DID: did, Active: true}))
+
+	var hookRan bool
+	s.afterComplete = func(ctx context.Context, got atmos.DID) error {
+		require.Equal(t, did, got)
+		requireLookupState(t, s, got, atmosbackfill.StateComplete)
+		hookRan = true
+		return nil
+	}
+
+	cb.RecordWatermark(did, 41, true)
+	require.NoError(t, s.OnComplete(ctx, did, &repo.Commit{DID: string(did), Rev: "rev-queued"}))
+	requireLookupState(t, s, did, atmosbackfill.StateDiscovered)
+	require.False(t, hookRan, "afterComplete must wait for durable completion commit")
+	require.InDelta(t, 0.0, testutil.ToFloat64(metrics.Completed), 0)
+	require.Len(t, cb.queued, 1)
+
+	b := st.NewBatch()
+	afterCommit, afterDone, err := cb.StageDurable(ctx, b, 42, false)
+	require.NoError(t, err)
+	require.NotNil(t, afterCommit)
+	require.NotNil(t, afterDone)
+
+	commitErr := st.Commit(b, store.SyncWrites)
+	if commitErr != nil {
+		afterDone(commitErr)
+		require.NoError(t, commitErr)
+	}
+	afterCommit()
+	afterDone(nil)
+	require.NoError(t, b.Close())
+
+	requireLookupState(t, s, did, atmosbackfill.StateComplete)
+	require.True(t, hookRan)
+	require.Empty(t, cb.queued)
+	require.InDelta(t, 1.0, testutil.ToFloat64(metrics.Completed), 0)
+}
+
+func TestStore_OnCompleteWithBatcherRequiresWatermark(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+	cb := NewCompletionBatcher(s, nil)
+	s.SetCompletionBatcher(cb)
+
+	ctx := t.Context()
+	did := atmos.DID("did:plc:queued-missing-watermark")
+	require.NoError(t, s.OnDiscover(ctx, atmossync.ListReposEntry{DID: did, Active: true}))
+
+	err := s.OnComplete(ctx, did, &repo.Commit{DID: string(did), Rev: "rev-missing"})
+	require.ErrorContains(t, err, "missing watermark")
+	requireLookupState(t, s, did, atmosbackfill.StateDiscovered)
+	require.Empty(t, cb.queued)
 }
 
 func TestStore_OnCompleteRunsHookAfterDurableRow(t *testing.T) {

--- a/internal/ingest/config.go
+++ b/internal/ingest/config.go
@@ -13,7 +13,7 @@ import (
 // DurableBatchHook stages block-specific metadata into the same synced Pebble
 // batch that persists the writer's next sequence after a segment block is
 // durable.
-type DurableBatchHook func(ctx context.Context, b *pebble.Batch, nextSeq uint64, force bool) (afterCommit func(), err error)
+type DurableBatchHook func(ctx context.Context, b *pebble.Batch, nextSeq uint64, force bool) (afterCommit func(), afterDone func(error), err error)
 
 // defaultMaxSegmentBytes is the rotation threshold. DESIGN.md §3.1.1
 // names ~256MB as the target sealed-segment size. Operator-tunable
@@ -69,12 +69,15 @@ type Config struct {
 	// OnDurableBatch, if non-nil, stages extra metadata into the same synced
 	// Pebble batch that persists SeqKey after a segment block has been fsynced.
 	// The hook may return an afterCommit callback, which runs only after the
-	// batch commit succeeds. Unlike OnAfterFlush, this hook is supported with
-	// AsyncFlushWorkers because it is tied to a specific durable block.
+	// batch commit succeeds, and an afterDone callback, which runs after the
+	// batch commit attempt on both success and failure. Unlike OnAfterFlush,
+	// this hook is supported with AsyncFlushWorkers because it is tied to a
+	// specific durable block.
 	//
-	// The hook and afterCommit callback run under the writer mutex. Hooks must
-	// not call back into the Writer (that would deadlock) or perform unbounded
-	// I/O (that would stall every Append in the active worker pool).
+	// The hook, afterCommit callback, and afterDone callback run under the
+	// writer mutex. Hooks must not call back into the Writer (that would
+	// deadlock) or perform unbounded I/O (that would stall every Append in the
+	// active worker pool).
 	OnDurableBatch DurableBatchHook
 
 	// OnAppend, if non-nil, runs synchronously inside Append after

--- a/internal/ingest/config.go
+++ b/internal/ingest/config.go
@@ -7,7 +7,13 @@ import (
 
 	"github.com/bluesky-social/jetstream-v2/internal/store"
 	"github.com/bluesky-social/jetstream-v2/segment"
+	"github.com/cockroachdb/pebble"
 )
+
+// DurableBatchHook stages block-specific metadata into the same synced Pebble
+// batch that persists the writer's next sequence after a segment block is
+// durable.
+type DurableBatchHook func(ctx context.Context, b *pebble.Batch, nextSeq uint64, force bool) (afterCommit func(), err error)
 
 // defaultMaxSegmentBytes is the rotation threshold. DESIGN.md §3.1.1
 // names ~256MB as the target sealed-segment size. Operator-tunable
@@ -59,6 +65,17 @@ type Config struct {
 	// on the writer mutex) or perform unbounded I/O (that would stall
 	// every Append in the active worker pool).
 	OnAfterFlush func(ctx context.Context) error
+
+	// OnDurableBatch, if non-nil, stages extra metadata into the same synced
+	// Pebble batch that persists SeqKey after a segment block has been fsynced.
+	// The hook may return an afterCommit callback, which runs only after the
+	// batch commit succeeds. Unlike OnAfterFlush, this hook is supported with
+	// AsyncFlushWorkers because it is tied to a specific durable block.
+	//
+	// The hook and afterCommit callback run under the writer mutex. Hooks must
+	// not call back into the Writer (that would deadlock) or perform unbounded
+	// I/O (that would stall every Append in the active worker pool).
+	OnDurableBatch DurableBatchHook
 
 	// OnAppend, if non-nil, runs synchronously inside Append after
 	// the event's Seq is assigned and BEFORE the block can flush or

--- a/internal/ingest/config.go
+++ b/internal/ingest/config.go
@@ -78,6 +78,14 @@ type Config struct {
 	// writer mutex. Hooks must not call back into the Writer (that would
 	// deadlock) or perform unbounded I/O (that would stall every Append in the
 	// active worker pool).
+	//
+	// force is true only on the drain/terminal commit paths (DrainDurability,
+	// Close, SealActiveAndClose) and means "commit the seq/next checkpoint even
+	// though no new block was just flushed." It does NOT license the hook to
+	// stage metadata whose backing events are not yet durable: a hook that ties
+	// metadata to event durability (e.g. backfill repo completion) must still
+	// gate every staged row on nextSeq, never on force, or it would mark data
+	// durable ahead of its segment fsync (violating DESIGN.md §3.1.1 ordering).
 	OnDurableBatch DurableBatchHook
 
 	// OnAppend, if non-nil, runs synchronously inside Append after

--- a/internal/ingest/writer.go
+++ b/internal/ingest/writer.go
@@ -711,6 +711,17 @@ func stageNextSeq(b *pebble.Batch, key string, v uint64) error {
 }
 
 func (w *Writer) commitDurableBatchLocked(ctx context.Context, nextSeq uint64, force bool) error {
+	// The block this commit describes is already fsynced by the time we get
+	// here (flushBlockLocked / commitAsyncFlush / the drain paths all flush
+	// first). The durable metadata commit must therefore run to completion
+	// regardless of caller cancellation: aborting now would leave seq/next and
+	// any OnDurableBatch metadata (e.g. queued repo completions) behind durable
+	// segment data, and would surface a benign run-cancel (backfill MaxRepos,
+	// graceful shutdown) as a spurious fatal "on_durable_batch: context
+	// canceled". WithoutCancel keeps trace/span lineage while detaching
+	// cancellation, matching the async path's context.Background() intent.
+	ctx = context.WithoutCancel(ctx)
+
 	b := w.cfg.Store.NewBatch()
 	defer func() { _ = b.Close() }()
 

--- a/internal/ingest/writer.go
+++ b/internal/ingest/writer.go
@@ -29,12 +29,17 @@ const seqNextKey = "seq/next"
 type Writer struct {
 	cfg Config
 
-	mu          sync.Mutex
-	active      *segment.Writer
-	activeBytes int64
-	activeIdx   uint64
-	nextSeq     uint64
-	closed      bool
+	// drainMu is an admission barrier for appends and explicit flushes. Acquire
+	// it before mu, and hold it through async job submission so DrainDurability
+	// can safely wait for all already-admitted jobs without racing future Add.
+	drainMu        sync.Mutex
+	mu             sync.Mutex
+	active         *segment.Writer
+	activeBytes    int64
+	activeIdx      uint64
+	nextSeq        uint64
+	durableNextSeq uint64
+	closed         bool
 
 	async            *asyncFlushPipeline
 	asyncPrepared    int
@@ -136,6 +141,7 @@ func Open(cfg Config) (*Writer, error) {
 		}
 	}
 	w.nextSeq = reconciled
+	w.durableNextSeq = reconciled
 
 	w.cfg.Metrics.setActiveSegBytes(w.activeBytes)
 	w.cfg.Metrics.setNextSeq(w.nextSeq)
@@ -244,15 +250,22 @@ func (w *Writer) SealActiveAndClose() error {
 // a phantom allocation. Goroutine-safe.
 func (w *Writer) Append(ctx context.Context, ev *segment.Event) error {
 	if w.async != nil {
+		w.drainMu.Lock()
 		w.mu.Lock()
 		job, err := w.appendLocked(ctx, ev)
 		w.mu.Unlock()
+		if err == nil {
+			w.submitAsyncFlushes([]*asyncFlushJob{job})
+		}
+		w.drainMu.Unlock()
 		if err != nil {
 			return err
 		}
-		return w.waitAsyncFlushes([]*asyncFlushJob{job})
+		return w.waitSubmittedAsyncFlushes([]*asyncFlushJob{job})
 	}
 
+	w.drainMu.Lock()
+	defer w.drainMu.Unlock()
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
@@ -270,6 +283,7 @@ func (w *Writer) AppendBatch(ctx context.Context, events []segment.Event) error 
 		return nil
 	}
 
+	w.drainMu.Lock()
 	w.mu.Lock()
 	var jobs []*asyncFlushJob
 	var appendErr error
@@ -285,8 +299,10 @@ func (w *Writer) AppendBatch(ctx context.Context, events []segment.Event) error 
 		}
 	}
 	w.mu.Unlock()
+	w.submitAsyncFlushes(jobs)
+	w.drainMu.Unlock()
 
-	flushErr := w.waitAsyncFlushes(jobs)
+	flushErr := w.waitSubmittedAsyncFlushes(jobs)
 	if appendErr != nil {
 		return appendErr
 	}
@@ -341,23 +357,36 @@ func (w *Writer) appendLocked(ctx context.Context, ev *segment.Event) (*asyncFlu
 // A no-op when nothing is buffered.
 func (w *Writer) Flush(ctx context.Context) error {
 	if w.async != nil {
-		w.mu.Lock()
-		if w.closed {
-			w.mu.Unlock()
-			return ErrClosed
+		w.drainMu.Lock()
+		job, err := w.prepareAsyncFlushForFlush()
+		if err == nil {
+			w.submitAsyncFlushes([]*asyncFlushJob{job})
 		}
-		if w.active == nil {
-			w.mu.Unlock()
-			return nil
-		}
-		job, err := w.prepareAsyncFlushLocked()
-		w.mu.Unlock()
+		w.drainMu.Unlock()
 		if err != nil {
 			return err
 		}
-		return w.waitAsyncFlushes([]*asyncFlushJob{job})
+		return w.waitSubmittedAsyncFlushes([]*asyncFlushJob{job})
 	}
 
+	w.drainMu.Lock()
+	defer w.drainMu.Unlock()
+	return w.flushSync(ctx)
+}
+
+func (w *Writer) prepareAsyncFlushForFlush() (*asyncFlushJob, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return nil, ErrClosed
+	}
+	if w.active == nil {
+		return nil, nil
+	}
+	return w.prepareAsyncFlushLocked()
+}
+
+func (w *Writer) flushSync(ctx context.Context) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if w.closed {
@@ -367,6 +396,54 @@ func (w *Writer) Flush(ctx context.Context) error {
 		return nil
 	}
 	return w.flushAndRotateLocked(ctx)
+}
+
+func (w *Writer) drainAsync(ctx context.Context) error {
+	job, err := w.prepareAsyncFlushForFlush()
+	if err != nil {
+		return err
+	}
+	w.submitAsyncFlushes([]*asyncFlushJob{job})
+	if err := w.waitSubmittedAsyncFlushes([]*asyncFlushJob{job}); err != nil {
+		return err
+	}
+	w.asyncJobs.Wait()
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return ErrClosed
+	}
+	return w.commitDurableBatchLocked(ctx, w.durableNextSeq, true)
+}
+
+func (w *Writer) drainSync(ctx context.Context) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return ErrClosed
+	}
+	if w.active == nil {
+		return nil
+	}
+	if w.active.Pending() > 0 {
+		if err := w.flushAndRotateLocked(ctx); err != nil {
+			return err
+		}
+	}
+	return w.commitDurableBatchLocked(ctx, w.durableNextSeq, true)
+}
+
+// DrainDurability forces pending event-backed metadata to its block durability
+// point and commits metadata-only durable hooks even when no events are pending.
+func (w *Writer) DrainDurability(ctx context.Context) error {
+	w.drainMu.Lock()
+	defer w.drainMu.Unlock()
+
+	if w.async != nil {
+		return w.drainAsync(ctx)
+	}
+	return w.drainSync(ctx)
 }
 
 // flushAndRotateLocked is the post-Append durability commit. The
@@ -637,6 +714,7 @@ func (w *Writer) commitDurableBatchLocked(ctx context.Context, nextSeq uint64, f
 	if err := w.cfg.Store.Commit(b, store.SyncWrites); err != nil {
 		return fmt.Errorf("ingest: commit durable batch: %w", err)
 	}
+	w.durableNextSeq = nextSeq
 	if afterCommit != nil {
 		afterCommit()
 	}

--- a/internal/ingest/writer.go
+++ b/internal/ingest/writer.go
@@ -186,7 +186,7 @@ func (w *Writer) Close() error {
 	if err := w.active.Close(); err != nil {
 		return fmt.Errorf("ingest: close active segment: %w", err)
 	}
-	if err := saveNextSeq(w.cfg.Store, w.cfg.SeqKey, w.nextSeq); err != nil {
+	if err := w.commitTerminalDurableBatchLocked(); err != nil {
 		return err
 	}
 	return nil
@@ -233,7 +233,7 @@ func (w *Writer) SealActiveAndClose() error {
 		}
 		return fmt.Errorf("ingest: seal active segment: %w", err)
 	}
-	if err := saveNextSeq(w.cfg.Store, w.cfg.SeqKey, w.nextSeq); err != nil {
+	if err := w.commitTerminalDurableBatchLocked(); err != nil {
 		return err
 	}
 	sealedIdx := w.activeIdx
@@ -444,6 +444,20 @@ func (w *Writer) DrainDurability(ctx context.Context) error {
 		return w.drainAsync(ctx)
 	}
 	return w.drainSync(ctx)
+}
+
+// SetDurableBatchHook installs or replaces the metadata hook invoked when the
+// writer commits durable block metadata. Backfill Run owns this hook for the
+// backfill writer and intentionally replaces any prior hook. Callers should
+// wire this before starting producers.
+func (w *Writer) SetDurableBatchHook(h DurableBatchHook) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.cfg.OnDurableBatch = h
+}
+
+func (w *Writer) commitTerminalDurableBatchLocked() error {
+	return w.commitDurableBatchLocked(context.Background(), w.nextSeq, true)
 }
 
 // flushAndRotateLocked is the post-Append durability commit. The

--- a/internal/ingest/writer.go
+++ b/internal/ingest/writer.go
@@ -704,15 +704,25 @@ func (w *Writer) commitDurableBatchLocked(ctx context.Context, nextSeq uint64, f
 		return err
 	}
 	var afterCommit func()
+	var afterDone func(error)
+	var commitErr error
 	if w.cfg.OnDurableBatch != nil {
-		cb, err := w.cfg.OnDurableBatch(ctx, b, nextSeq, force)
+		cb, done, err := w.cfg.OnDurableBatch(ctx, b, nextSeq, force)
 		if err != nil {
 			return fmt.Errorf("ingest: on_durable_batch: %w", err)
 		}
 		afterCommit = cb
+		afterDone = done
 	}
-	if err := w.cfg.Store.Commit(b, store.SyncWrites); err != nil {
-		return fmt.Errorf("ingest: commit durable batch: %w", err)
+	defer func() {
+		if afterDone != nil {
+			afterDone(commitErr)
+		}
+	}()
+
+	commitErr = w.cfg.Store.Commit(b, store.SyncWrites)
+	if commitErr != nil {
+		return fmt.Errorf("ingest: commit durable batch: %w", commitErr)
 	}
 	w.durableNextSeq = nextSeq
 	if afterCommit != nil {

--- a/internal/ingest/writer.go
+++ b/internal/ingest/writer.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bluesky-social/jetstream-v2/internal/obs"
 	"github.com/bluesky-social/jetstream-v2/internal/store"
 	"github.com/bluesky-social/jetstream-v2/segment"
+	"github.com/cockroachdb/pebble"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -415,7 +416,7 @@ func (w *Writer) flushBlockLocked(ctx context.Context) error {
 	}
 	w.cfg.Metrics.incBlocksFlushed()
 
-	if err := saveNextSeq(w.cfg.Store, w.cfg.SeqKey, w.nextSeq); err != nil {
+	if err := w.commitDurableBatchLocked(ctx, w.nextSeq, false); err != nil {
 		return err
 	}
 
@@ -605,6 +606,39 @@ func saveNextSeq(st *store.Store, key string, v uint64) error {
 	binary.LittleEndian.PutUint64(buf[:], v)
 	if err := st.Set([]byte(key), buf[:], store.SyncWrites); err != nil {
 		return fmt.Errorf("ingest: save %s: %w", key, err)
+	}
+	return nil
+}
+
+func stageNextSeq(b *pebble.Batch, key string, v uint64) error {
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], v)
+	if err := b.Set([]byte(key), buf[:], nil); err != nil {
+		return fmt.Errorf("ingest: stage %s: %w", key, err)
+	}
+	return nil
+}
+
+func (w *Writer) commitDurableBatchLocked(ctx context.Context, nextSeq uint64, force bool) error {
+	b := w.cfg.Store.NewBatch()
+	defer func() { _ = b.Close() }()
+
+	if err := stageNextSeq(b, w.cfg.SeqKey, nextSeq); err != nil {
+		return err
+	}
+	var afterCommit func()
+	if w.cfg.OnDurableBatch != nil {
+		cb, err := w.cfg.OnDurableBatch(ctx, b, nextSeq, force)
+		if err != nil {
+			return fmt.Errorf("ingest: on_durable_batch: %w", err)
+		}
+		afterCommit = cb
+	}
+	if err := w.cfg.Store.Commit(b, store.SyncWrites); err != nil {
+		return fmt.Errorf("ingest: commit durable batch: %w", err)
+	}
+	if afterCommit != nil {
+		afterCommit()
 	}
 	return nil
 }

--- a/internal/ingest/writer_test.go
+++ b/internal/ingest/writer_test.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/bluesky-social/jetstream-v2/internal/store"
 	"github.com/bluesky-social/jetstream-v2/segment"
@@ -567,7 +568,9 @@ func TestFlush_StagesDurableBatchHookWithSeq(t *testing.T) {
 		MaxEventsPerBlock: 2,
 		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
 		OnDurableBatch: func(ctx context.Context, b *pebble.Batch, nextSeq uint64, force bool) (func(), func(error), error) {
-			require.False(t, force)
+			if force {
+				return nil, nil, nil
+			}
 			hookSeq = nextSeq
 			return nil, nil, b.Set([]byte("hook/ran"), []byte("yes"), nil)
 		},
@@ -971,6 +974,183 @@ func TestDrainDurability_AsyncFlushesPendingEventsBeforeForcedHook(t *testing.T)
 	}))
 	require.Len(t, gotEvents, 1)
 	require.Equal(t, uint64(0), gotEvents[0].Seq)
+}
+
+func TestDurableBatchClose_RunsAfterPendingEvents(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	st, err := store.Open(dir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	type durableCall struct {
+		nextSeq uint64
+		force   bool
+	}
+	calls := make(chan durableCall, 1)
+	w, err := Open(Config{
+		SegmentsDir:       filepath.Join(dir, "segments"),
+		Store:             st,
+		MaxEventsPerBlock: 64,
+		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		OnDurableBatch: func(_ context.Context, b *pebble.Batch, nextSeq uint64, force bool) (func(), func(error), error) {
+			calls <- durableCall{nextSeq: nextSeq, force: force}
+			return nil, nil, b.Set([]byte("metadata/close"), []byte("ok"), nil)
+		},
+	})
+	require.NoError(t, err)
+
+	ev := segment.Event{IndexedAt: 1, Kind: segment.KindCreate, DID: "did:plc:close"}
+	require.NoError(t, w.Append(t.Context(), &ev))
+	require.NoError(t, w.Close())
+
+	require.Equal(t, durableCall{nextSeq: 1, force: true}, requireDurableCall(t, calls))
+	got, closer, err := st.Get([]byte("metadata/close"))
+	require.NoError(t, err)
+	require.Equal(t, "ok", string(got))
+	require.NoError(t, closer.Close())
+	persisted, err := loadNextSeq(st, seqNextKey)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), persisted)
+}
+
+func TestSealActiveAndClose_RunsDurableBatchHookAfterPendingEvents(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	st, err := store.Open(dir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	type durableCall struct {
+		nextSeq uint64
+		force   bool
+	}
+	calls := make(chan durableCall, 1)
+	w, err := Open(Config{
+		SegmentsDir:       filepath.Join(dir, "segments"),
+		Store:             st,
+		MaxEventsPerBlock: 64,
+		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		OnDurableBatch: func(_ context.Context, b *pebble.Batch, nextSeq uint64, force bool) (func(), func(error), error) {
+			calls <- durableCall{nextSeq: nextSeq, force: force}
+			return nil, nil, b.Set([]byte("metadata/seal-close"), []byte("ok"), nil)
+		},
+	})
+	require.NoError(t, err)
+
+	ev := segment.Event{IndexedAt: 1, Kind: segment.KindCreate, DID: "did:plc:seal-close"}
+	require.NoError(t, w.Append(t.Context(), &ev))
+	require.NoError(t, w.SealActiveAndClose())
+
+	require.Equal(t, durableCall{nextSeq: 1, force: true}, requireDurableCall(t, calls))
+	got, closer, err := st.Get([]byte("metadata/seal-close"))
+	require.NoError(t, err)
+	require.Equal(t, "ok", string(got))
+	require.NoError(t, closer.Close())
+	ins, err := segment.Inspect(filepath.Join(dir, "segments", SegmentFilename(0)))
+	require.NoError(t, err)
+	require.True(t, ins.Sealed)
+	require.Equal(t, uint64(1), ins.TotalEvents)
+}
+
+func TestWriter_DurableBatchAsyncCloseRunsAfterPendingEvents(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	st, err := store.Open(dir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	type durableCall struct {
+		nextSeq uint64
+		force   bool
+	}
+	calls := make(chan durableCall, 2)
+	w, err := Open(Config{
+		SegmentsDir:       filepath.Join(dir, "segments"),
+		Store:             st,
+		MaxEventsPerBlock: 64,
+		AsyncFlushWorkers: 2,
+		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		OnDurableBatch: func(_ context.Context, b *pebble.Batch, nextSeq uint64, force bool) (func(), func(error), error) {
+			calls <- durableCall{nextSeq: nextSeq, force: force}
+			key := fmt.Sprintf("metadata/async-close/%t", force)
+			return nil, nil, b.Set([]byte(key), []byte("ok"), nil)
+		},
+	})
+	require.NoError(t, err)
+
+	ev := segment.Event{IndexedAt: 1, Kind: segment.KindCreate, DID: "did:plc:async-close"}
+	require.NoError(t, w.Append(t.Context(), &ev))
+	require.NoError(t, w.Close())
+
+	gotCalls := []durableCall{requireDurableCall(t, calls), requireDurableCall(t, calls)}
+	require.ElementsMatch(t, []durableCall{
+		{nextSeq: 1, force: false},
+		{nextSeq: 1, force: true},
+	}, gotCalls)
+	for _, key := range []string{"metadata/async-close/false", "metadata/async-close/true"} {
+		got, closer, err := st.Get([]byte(key))
+		require.NoError(t, err)
+		require.Equal(t, "ok", string(got))
+		require.NoError(t, closer.Close())
+	}
+}
+
+func TestWriter_AsyncSealActiveAndCloseRunsDurableBatchHookAfterPendingEvents(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	st, err := store.Open(dir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	type durableCall struct {
+		nextSeq uint64
+		force   bool
+	}
+	calls := make(chan durableCall, 2)
+	w, err := Open(Config{
+		SegmentsDir:       filepath.Join(dir, "segments"),
+		Store:             st,
+		MaxEventsPerBlock: 64,
+		AsyncFlushWorkers: 2,
+		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		OnDurableBatch: func(_ context.Context, b *pebble.Batch, nextSeq uint64, force bool) (func(), func(error), error) {
+			calls <- durableCall{nextSeq: nextSeq, force: force}
+			key := fmt.Sprintf("metadata/async-seal-close/%t", force)
+			return nil, nil, b.Set([]byte(key), []byte("ok"), nil)
+		},
+	})
+	require.NoError(t, err)
+
+	ev := segment.Event{IndexedAt: 1, Kind: segment.KindCreate, DID: "did:plc:async-seal-close"}
+	require.NoError(t, w.Append(t.Context(), &ev))
+	require.NoError(t, w.SealActiveAndClose())
+
+	gotCalls := []durableCall{requireDurableCall(t, calls), requireDurableCall(t, calls)}
+	require.ElementsMatch(t, []durableCall{
+		{nextSeq: 1, force: false},
+		{nextSeq: 1, force: true},
+	}, gotCalls)
+	ins, err := segment.Inspect(filepath.Join(dir, "segments", SegmentFilename(0)))
+	require.NoError(t, err)
+	require.True(t, ins.Sealed)
+}
+
+func requireDurableCall[T any](t *testing.T, calls <-chan T) T {
+	t.Helper()
+
+	select {
+	case got := <-calls:
+		return got
+	case <-time.After(time.Second):
+		require.Fail(t, "durable hook did not run")
+		var zero T
+		return zero
+	}
 }
 
 // TestForceRotate_FlushedButUnsealedRotates: events already flushed to

--- a/internal/ingest/writer_test.go
+++ b/internal/ingest/writer_test.go
@@ -552,6 +552,44 @@ func TestFlush_InvokesOnAfterFlushHook(t *testing.T) {
 	require.Equal(t, int32(2), calls.Load())
 }
 
+func TestFlush_StagesDurableBatchHookWithSeq(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	st, err := store.Open(dir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	var hookSeq uint64
+	w, err := Open(Config{
+		SegmentsDir:       filepath.Join(dir, "segments"),
+		Store:             st,
+		MaxEventsPerBlock: 2,
+		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		OnDurableBatch: func(ctx context.Context, b *pebble.Batch, nextSeq uint64, force bool) (func(), error) {
+			require.False(t, force)
+			hookSeq = nextSeq
+			return nil, b.Set([]byte("hook/ran"), []byte("yes"), nil)
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	require.NoError(t, w.AppendBatch(t.Context(), []segment.Event{
+		{Kind: segment.KindCreate, DID: "did:plc:a", Collection: "c", Rkey: "r1", Rev: "1"},
+		{Kind: segment.KindCreate, DID: "did:plc:a", Collection: "c", Rkey: "r2", Rev: "1"},
+	}))
+
+	require.Equal(t, uint64(2), hookSeq)
+	got, closer, err := st.Get([]byte("hook/ran"))
+	require.NoError(t, err)
+	require.Equal(t, "yes", string(got))
+	require.NoError(t, closer.Close())
+	persisted, err := loadNextSeq(st, w.cfg.SeqKey)
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), persisted)
+}
+
 // TestFlush_OnAfterFlushErrorPropagates verifies that an error from
 // the hook surfaces back through Append so the errgroup can tear
 // the process down. AGENTS.md: crashing > silent corruption.
@@ -1168,6 +1206,65 @@ func TestAppendBatch_AsyncFlushPersistsBlocksAndSeqBeforeReturn(t *testing.T) {
 	require.Equal(t, uint64(1), blocks[0][1].Seq)
 	require.Equal(t, uint64(2), blocks[1][0].Seq)
 	require.Equal(t, uint64(3), blocks[1][1].Seq)
+}
+
+func TestAppendBatch_AsyncFlushRunsDurableBatchHook(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	st, err := store.Open(dir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	afterCommit := make(chan error, 1)
+	w, err := Open(Config{
+		SegmentsDir:       filepath.Join(dir, "segments"),
+		Store:             st,
+		MaxEventsPerBlock: 2,
+		AsyncFlushWorkers: 2,
+		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		OnDurableBatch: func(_ context.Context, b *pebble.Batch, nextSeq uint64, force bool) (func(), error) {
+			if force {
+				return nil, fmt.Errorf("force = true")
+			}
+			if nextSeq != 2 {
+				return nil, fmt.Errorf("nextSeq = %d, want 2", nextSeq)
+			}
+			if err := b.Set([]byte("async/hook"), []byte("ok"), nil); err != nil {
+				return nil, fmt.Errorf("stage async/hook: %w", err)
+			}
+			return func() {
+				got, closer, err := st.Get([]byte("async/hook"))
+				if err != nil {
+					afterCommit <- err
+					return
+				}
+				if string(got) != "ok" {
+					afterCommit <- fmt.Errorf("async/hook = %q, want ok", got)
+					_ = closer.Close()
+					return
+				}
+				if err := closer.Close(); err != nil {
+					afterCommit <- err
+					return
+				}
+				afterCommit <- nil
+			}, nil
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	require.NoError(t, w.AppendBatch(t.Context(), []segment.Event{
+		{Kind: segment.KindCreate, DID: "did:plc:a", Collection: "c", Rkey: "r1", Rev: "1"},
+		{Kind: segment.KindCreate, DID: "did:plc:a", Collection: "c", Rkey: "r2", Rev: "1"},
+	}))
+	select {
+	case err := <-afterCommit:
+		require.NoError(t, err)
+	default:
+		require.Fail(t, "afterCommit did not run")
+	}
 }
 
 func TestAppendBatch_AsyncFlushDefersRotationWhilePendingRowsExist(t *testing.T) {

--- a/internal/ingest/writer_test.go
+++ b/internal/ingest/writer_test.go
@@ -830,6 +830,142 @@ func TestForceRotate_EmptyActiveIsNoOp(t *testing.T) {
 		"empty active segment must be left untouched")
 }
 
+func TestDrainDurability_CommitsHookWithoutPendingEvents(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	st, err := store.Open(dir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	var gotForce bool
+	var gotNextSeq uint64
+	w, err := Open(Config{
+		SegmentsDir: filepath.Join(dir, "segments"),
+		Store:       st,
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		OnDurableBatch: func(_ context.Context, b *pebble.Batch, nextSeq uint64, force bool) (func(), error) {
+			gotForce = force
+			gotNextSeq = nextSeq
+			return nil, b.Set([]byte("metadata/only"), []byte("ok"), nil)
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	require.NoError(t, w.DrainDurability(t.Context()))
+	require.True(t, gotForce)
+	require.Equal(t, uint64(0), gotNextSeq)
+
+	got, closer, err := st.Get([]byte("metadata/only"))
+	require.NoError(t, err)
+	require.Equal(t, "ok", string(got))
+	require.NoError(t, closer.Close())
+}
+
+func TestDrainDurability_AsyncCommitsHookWithoutPendingEvents(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	st, err := store.Open(dir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	type durableCall struct {
+		nextSeq uint64
+		force   bool
+	}
+	calls := make(chan durableCall, 4)
+	w, err := Open(Config{
+		SegmentsDir:       filepath.Join(dir, "segments"),
+		Store:             st,
+		AsyncFlushWorkers: 2,
+		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		OnDurableBatch: func(_ context.Context, b *pebble.Batch, nextSeq uint64, force bool) (func(), error) {
+			calls <- durableCall{nextSeq: nextSeq, force: force}
+			return nil, b.Set([]byte("metadata/async-only"), []byte("ok"), nil)
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	require.NoError(t, w.DrainDurability(t.Context()))
+
+	select {
+	case got := <-calls:
+		require.True(t, got.force)
+		require.Equal(t, uint64(0), got.nextSeq)
+	default:
+		require.Fail(t, "durable hook did not run")
+	}
+	require.Empty(t, calls)
+
+	got, closer, err := st.Get([]byte("metadata/async-only"))
+	require.NoError(t, err)
+	require.Equal(t, "ok", string(got))
+	require.NoError(t, closer.Close())
+}
+
+func TestDrainDurability_AsyncFlushesPendingEventsBeforeForcedHook(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	st, err := store.Open(dir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	type durableCall struct {
+		nextSeq uint64
+		force   bool
+	}
+	calls := make(chan durableCall, 4)
+	w, err := Open(Config{
+		SegmentsDir:       filepath.Join(dir, "segments"),
+		Store:             st,
+		MaxEventsPerBlock: 64,
+		AsyncFlushWorkers: 2,
+		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		OnDurableBatch: func(_ context.Context, b *pebble.Batch, nextSeq uint64, force bool) (func(), error) {
+			calls <- durableCall{nextSeq: nextSeq, force: force}
+			key := fmt.Sprintf("metadata/async-pending/%t", force)
+			return nil, b.Set([]byte(key), []byte("ok"), nil)
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	ev := segment.Event{IndexedAt: 1, Kind: segment.KindCreate, DID: "did:plc:a"}
+	require.NoError(t, w.Append(t.Context(), &ev))
+
+	require.NoError(t, w.DrainDurability(t.Context()))
+
+	gotCalls := []durableCall{<-calls, <-calls}
+	require.ElementsMatch(t, []durableCall{
+		{nextSeq: 1, force: false},
+		{nextSeq: 1, force: true},
+	}, gotCalls)
+	require.Empty(t, calls)
+
+	for _, key := range []string{"metadata/async-pending/false", "metadata/async-pending/true"} {
+		got, closer, err := st.Get([]byte(key))
+		require.NoError(t, err)
+		require.Equal(t, "ok", string(got))
+		require.NoError(t, closer.Close())
+	}
+	persisted, err := loadNextSeq(st, seqNextKey)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), persisted)
+
+	path := filepath.Join(w.cfg.SegmentsDir, SegmentFilename(0))
+	var gotEvents []segment.Event
+	require.NoError(t, segment.WalkActive(path, func(events []segment.Event) error {
+		gotEvents = append(gotEvents, events...)
+		return nil
+	}))
+	require.Len(t, gotEvents, 1)
+	require.Equal(t, uint64(0), gotEvents[0].Seq)
+}
+
 // TestForceRotate_FlushedButUnsealedRotates: events already flushed to
 // disk (no pending block) must still rotate — emptiness is about the
 // segment having zero events, not zero buffered events.

--- a/internal/ingest/writer_test.go
+++ b/internal/ingest/writer_test.go
@@ -566,10 +566,10 @@ func TestFlush_StagesDurableBatchHookWithSeq(t *testing.T) {
 		Store:             st,
 		MaxEventsPerBlock: 2,
 		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
-		OnDurableBatch: func(ctx context.Context, b *pebble.Batch, nextSeq uint64, force bool) (func(), error) {
+		OnDurableBatch: func(ctx context.Context, b *pebble.Batch, nextSeq uint64, force bool) (func(), func(error), error) {
 			require.False(t, force)
 			hookSeq = nextSeq
-			return nil, b.Set([]byte("hook/ran"), []byte("yes"), nil)
+			return nil, nil, b.Set([]byte("hook/ran"), []byte("yes"), nil)
 		},
 	})
 	require.NoError(t, err)
@@ -840,14 +840,15 @@ func TestDrainDurability_CommitsHookWithoutPendingEvents(t *testing.T) {
 
 	var gotForce bool
 	var gotNextSeq uint64
+	afterDone := make(chan error, 1)
 	w, err := Open(Config{
 		SegmentsDir: filepath.Join(dir, "segments"),
 		Store:       st,
 		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
-		OnDurableBatch: func(_ context.Context, b *pebble.Batch, nextSeq uint64, force bool) (func(), error) {
+		OnDurableBatch: func(_ context.Context, b *pebble.Batch, nextSeq uint64, force bool) (func(), func(error), error) {
 			gotForce = force
 			gotNextSeq = nextSeq
-			return nil, b.Set([]byte("metadata/only"), []byte("ok"), nil)
+			return nil, func(err error) { afterDone <- err }, b.Set([]byte("metadata/only"), []byte("ok"), nil)
 		},
 	})
 	require.NoError(t, err)
@@ -856,6 +857,12 @@ func TestDrainDurability_CommitsHookWithoutPendingEvents(t *testing.T) {
 	require.NoError(t, w.DrainDurability(t.Context()))
 	require.True(t, gotForce)
 	require.Equal(t, uint64(0), gotNextSeq)
+	select {
+	case err := <-afterDone:
+		require.NoError(t, err)
+	default:
+		require.Fail(t, "afterDone did not run")
+	}
 
 	got, closer, err := st.Get([]byte("metadata/only"))
 	require.NoError(t, err)
@@ -881,9 +888,9 @@ func TestDrainDurability_AsyncCommitsHookWithoutPendingEvents(t *testing.T) {
 		Store:             st,
 		AsyncFlushWorkers: 2,
 		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
-		OnDurableBatch: func(_ context.Context, b *pebble.Batch, nextSeq uint64, force bool) (func(), error) {
+		OnDurableBatch: func(_ context.Context, b *pebble.Batch, nextSeq uint64, force bool) (func(), func(error), error) {
 			calls <- durableCall{nextSeq: nextSeq, force: force}
-			return nil, b.Set([]byte("metadata/async-only"), []byte("ok"), nil)
+			return nil, nil, b.Set([]byte("metadata/async-only"), []byte("ok"), nil)
 		},
 	})
 	require.NoError(t, err)
@@ -925,10 +932,10 @@ func TestDrainDurability_AsyncFlushesPendingEventsBeforeForcedHook(t *testing.T)
 		MaxEventsPerBlock: 64,
 		AsyncFlushWorkers: 2,
 		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
-		OnDurableBatch: func(_ context.Context, b *pebble.Batch, nextSeq uint64, force bool) (func(), error) {
+		OnDurableBatch: func(_ context.Context, b *pebble.Batch, nextSeq uint64, force bool) (func(), func(error), error) {
 			calls <- durableCall{nextSeq: nextSeq, force: force}
 			key := fmt.Sprintf("metadata/async-pending/%t", force)
-			return nil, b.Set([]byte(key), []byte("ok"), nil)
+			return nil, nil, b.Set([]byte(key), []byte("ok"), nil)
 		},
 	})
 	require.NoError(t, err)
@@ -1359,15 +1366,15 @@ func TestAppendBatch_AsyncFlushRunsDurableBatchHook(t *testing.T) {
 		MaxEventsPerBlock: 2,
 		AsyncFlushWorkers: 2,
 		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
-		OnDurableBatch: func(_ context.Context, b *pebble.Batch, nextSeq uint64, force bool) (func(), error) {
+		OnDurableBatch: func(_ context.Context, b *pebble.Batch, nextSeq uint64, force bool) (func(), func(error), error) {
 			if force {
-				return nil, fmt.Errorf("force = true")
+				return nil, nil, fmt.Errorf("force = true")
 			}
 			if nextSeq != 2 {
-				return nil, fmt.Errorf("nextSeq = %d, want 2", nextSeq)
+				return nil, nil, fmt.Errorf("nextSeq = %d, want 2", nextSeq)
 			}
 			if err := b.Set([]byte("async/hook"), []byte("ok"), nil); err != nil {
-				return nil, fmt.Errorf("stage async/hook: %w", err)
+				return nil, nil, fmt.Errorf("stage async/hook: %w", err)
 			}
 			return func() {
 				got, closer, err := st.Get([]byte("async/hook"))
@@ -1385,7 +1392,7 @@ func TestAppendBatch_AsyncFlushRunsDurableBatchHook(t *testing.T) {
 					return
 				}
 				afterCommit <- nil
-			}, nil
+			}, nil, nil
 		},
 	})
 	require.NoError(t, err)

--- a/internal/ingest/writer_test.go
+++ b/internal/ingest/writer_test.go
@@ -553,6 +553,64 @@ func TestFlush_InvokesOnAfterFlushHook(t *testing.T) {
 	require.Equal(t, int32(2), calls.Load())
 }
 
+// TestAppendBatch_DurableCommitNotAbortedByCanceledContext pins the contract
+// that a post-fsync durability commit must run to completion even when the
+// caller's context is cancelled. The sync flush path threads the engine's
+// (cancellable) run context all the way into the per-block durable commit; when
+// the backfill MaxRepos limit trips and cancels that context, a concurrent
+// worker that happens to fill a block must NOT have its already-fsynced block's
+// metadata commit turned into a spurious "on_durable_batch: context canceled"
+// error (which the handler escalates to a fatal run abort). This matches the
+// async flush path, which commits durable batches under context.Background().
+func TestAppendBatch_DurableCommitNotAbortedByCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	st, err := store.Open(dir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	var hookCtxErr error
+	var hookCalls int
+	w, err := Open(Config{
+		SegmentsDir:       filepath.Join(dir, "segments"),
+		Store:             st,
+		MaxEventsPerBlock: 1, // every append fills a block -> durable commit
+		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		OnDurableBatch: func(ctx context.Context, b *pebble.Batch, _ uint64, _ bool) (func(), func(error), error) {
+			hookCalls++
+			// Mirror the completion batcher's leading guard: a cancelled
+			// context here would abort the post-fsync durable commit.
+			if err := ctx.Err(); err != nil {
+				hookCtxErr = err
+				return nil, nil, err
+			}
+			return nil, nil, b.Set([]byte("durable/ok"), []byte("yes"), nil)
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // the run was cancelled (e.g. MaxRepos tripped) before this flush
+
+	err = w.AppendBatch(ctx, []segment.Event{
+		{Kind: segment.KindCreate, DID: "did:plc:a", Collection: "c", Rkey: "r", Rev: "1"},
+	})
+	require.NoError(t, err, "a post-fsync durable commit must not be aborted by a cancelled context")
+	require.NoError(t, hookCtxErr, "OnDurableBatch must not observe a cancelled context")
+	require.Equal(t, 1, hookCalls)
+
+	got, closer, err := st.Get([]byte("durable/ok"))
+	require.NoError(t, err)
+	require.Equal(t, "yes", string(got))
+	require.NoError(t, closer.Close())
+
+	persisted, err := loadNextSeq(st, w.cfg.SeqKey)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), persisted)
+}
+
 func TestFlush_StagesDurableBatchHookWithSeq(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Context

Staging backfill on cpu2-pop3 was under-saturating the network while workers queued behind per-repo segment flushes and completion metadata writes. The desired bottleneck is the real PDS `getRepo` rate limit, not local writer flush cadence.

This branch moves repo completion durability onto the same block durability boundary as segment data: backfill can count a repo as queued/completed in memory once its final events are accepted, while durable `StatusComplete` is only committed after the segment block containing that repo's final event is flushed and the metadata batch commits.

## Changes

- Removes the per-repo `writer.Flush()` from the backfill repo handling path.
- Adds ingest writer durable batch hooks so callers can stage Pebble metadata into the synced writer durability batch.
- Adds a writer durability drain barrier used by backfill checkpointing and terminal close/seal paths.
- Adds a backfill completion batcher that coalesces queued DID completions and commits them at writer durability barriers.
- Preserves the correctness contract that durable repo completion implies the repo's appended events are durable.
- Moves `listRepos` cursor persistence to a durability-safe checkpoint after queued completions have drained.
- Saves relay cursor and bootstrap-last cursor atomically so restart recovery cannot skip repos whose completions were only queued in memory.
- Adds Prometheus metrics for queued completions, queue depth, durable completion batches, durable repo counts, and staging errors.
- Adds restart and batching coverage for queued completions, cursor safety, and writer terminal durability hooks.

## Operational notes

- Backfill progress may now advance after completion is queued but before the completion row is durable. That is intentional in-process asynchrony.
- Pebble `StatusComplete` remains the durable signal. A crash before the next writer durability barrier can require reprocessing queued-but-not-durable repos.
- Completion batching intentionally does not change the per-block bloom residency behavior discussed in #61; that is still a separate query-planner/data-residency design issue.

## Validation

Local verification run on this branch:

```sh
just test ./internal/ingest
just test ./internal/ingest/backfill
just test ./internal/ingest/orchestrator
just test ./internal/oracle
just test ./...
just test-long ./internal/oracle -run TestOracle_Restart -v
git diff --check
```

Closes #60
Closes #62
Refs #61