### PR TITLE
xrpcapi/manifest: wildcard collection filters in planBackfill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,5 @@ go.work.sum
 # .vscode/
 
 # Files not for distribution
+/.superpowers
 /data*

--- a/api/jetstream/jetstreamplanbackfill.go
+++ b/api/jetstream/jetstreamplanbackfill.go
@@ -998,7 +998,7 @@ type JetstreamPlanBackfill_Input struct {
 	LexiconTypeID string           `json:"$type,omitempty"`
 	AfterSeq      gt.Option[int64] `json:"afterSeq,omitzero"`     // Lower exclusive sequence bound. Rows with seq <= afterSeq are outside the requested window.
 	BeforeSeq     gt.Option[int64] `json:"beforeSeq,omitzero"`    // Upper inclusive sequence bound. Rows with seq > beforeSeq are outside the requested window.
-	Collections   []string         `json:"collections,omitempty"` // Exact collection NSIDs to match. Missing or empty means all collections.
+	Collections   []string         `json:"collections,omitempty"` // Collection filters to match. Each entry is either an exact NSID (e.g. app.bsky.feed.post) or a na...
 	Dids          []string         `json:"dids,omitempty"`        // Exact DIDs to match. Missing or empty means all DIDs.
 
 	// extra preserves unknown fields for same-format round-trips.

--- a/docs/superpowers/specs/2026-06-18-planbackfill-wildcard-collections-design.md
+++ b/docs/superpowers/specs/2026-06-18-planbackfill-wildcard-collections-design.md
@@ -66,9 +66,19 @@ staleness (all matching is under the manifest `RLock` against current state),
 and the cap counts patterns, not expansions.
 
 **Equivalence claim (the core correctness property):** for any archive and any
-prefix `P`, planning with `{prefixes: [P]}` selects exactly the same segments
-and blocks as planning with `{collections: <every NSID in the archive under P>}`.
-This is what the equivalence property test (below) proves.
+prefix `P` that matches **at least one** archived NSID, planning with
+`{prefixes: [P]}` selects exactly the same segments and blocks as planning with
+`{collections: <every NSID in the archive under P>}`. This is what the
+equivalence property test (below) proves.
+
+**Match-nothing boundary (important):** when `P` matches *no* archived NSID, the
+two are deliberately *not* interchangeable, and that asymmetry is the point. A
+non-empty `CollectionPrefixes` means "constrain to these prefixes," so a prefix
+matching nothing yields an empty plan. But the enumerated-exact form expands to
+`Collections == []`, which means *match-all*. So "empty list == match all"
+applies only to a genuinely-absent filter, never to a wildcard that happened to
+match nothing. The equivalence test asserts the equality only for non-empty
+expansions and asserts match-nothing directly for empty ones.
 
 ### Wire shape: no new field
 

--- a/docs/superpowers/specs/2026-06-18-planbackfill-wildcard-collections-design.md
+++ b/docs/superpowers/specs/2026-06-18-planbackfill-wildcard-collections-design.md
@@ -1,0 +1,250 @@
+# planBackfill: wildcard collection filters
+
+**Date:** 2026-06-18
+**Status:** Approved design, pre-implementation
+**Subsystem:** `xrpcapi`, `manifest` (lexicon doc touch)
+
+## Context
+
+`network.bsky.jetstream.planBackfill` (`internal/xrpcapi/planbackfill.go`) plans
+sealed-archive downloads. Its `collections` input currently accepts only exact
+NSIDs. The `/subscribe` websocket endpoint already lets clients pass collection
+*wildcards* of the shape `app.bsky.feed.*` (see `internal/subscribe/filter.go`),
+and we want the same ergonomics on the query planner: a client backfilling "all
+feed records" should write `app.bsky.feed.*` instead of enumerating every NSID
+under that namespace by hand.
+
+We do **not** support arbitrary glob patterns — only a trailing `.*` on a
+namespace prefix, matching the one shape `/subscribe` allows.
+
+### How the relevant pieces work today
+
+- **Wire decode** — `JetstreamPlanBackfill_Input.UnmarshalJSON`
+  (`api/jetstream/jetstreamplanbackfill.go`) reads `collections` as plain
+  strings. Despite the lexicon declaring `items: {format: nsid}`, the generated
+  binding performs **no** NSID-format check on input. A value like
+  `app.bsky.feed.*` therefore flows untouched to the handler. This is the
+  single interception point — no decoder change is needed.
+- **Validation** — `validatePlanCollections` (`planbackfill.go:177`) dedupes and
+  `atmos.ParseNSID`-validates each entry, capped at `cfg.MaxCollections`
+  distinct entries.
+- **Matching** — `Manifest.PlanBackfill` (`internal/manifest/plan.go:65`) builds
+  a `map[string]struct{}` of wanted NSIDs once, then per segment calls
+  `collectionIDsForSegment` (`plan.go:242`), which walks that segment's resident
+  `Collections []string` table and keeps the indices whose NSID is in the want
+  set. Block-level filtering uses those indices against `BlockCollections`.
+- **Manifest residence** — every sealed segment's `Collections`,
+  `CollectionEventCounts`, `BlockCollections`, `Blocks`, and blooms are loaded
+  into memory at startup / on seal (`SegmentMetadata`, `manifest.go:37-50`). The
+  whole plan path runs under `m.mu.RLock()` and touches only these in-memory
+  fields. **No segment file is opened during planning.**
+
+### "Omniscient" collection knowledge
+
+The union of every sealed segment's `Collections` table *is* the set of all
+collections the archive has ever seen. We use this knowledge *implicitly*: a
+segment can only contain collections that are in that union, so prefix-matching
+each segment's own table is provably identical to expanding a wildcard against
+the global union and then exact-matching. We never need to materialize or cache
+the union.
+
+## Decision
+
+### Approach: prefix-match inside the planner (not request-time expansion)
+
+Carry wildcard prefixes alongside exact NSIDs through to the planner and match
+them against each segment's resident collection table.
+
+**Rejected alternative — request-time expansion:** resolve a cached "all known
+collections" set, expand each wildcard to concrete NSIDs, feed those to the
+existing exact-match planner. Rejected because it requires a new global-collection
+cache with invalidation on every seal/compaction, opens a staleness window
+(a wildcard could miss a collection that was sealed after the cache snapshot),
+and complicates the `MaxCollections` cap (one wildcard could expand past it).
+The chosen approach has none of these problems: no cache, no invalidation, no
+staleness (all matching is under the manifest `RLock` against current state),
+and the cap counts patterns, not expansions.
+
+**Equivalence claim (the core correctness property):** for any archive and any
+prefix `P`, planning with `{prefixes: [P]}` selects exactly the same segments
+and blocks as planning with `{collections: <every NSID in the archive under P>}`.
+This is what the equivalence property test (below) proves.
+
+### Wire shape: no new field
+
+Wildcards ride in the existing `collections` array, e.g.
+`["app.bsky.feed.post", "app.bsky.graph.*"]`. Exact NSIDs and wildcards may be
+mixed freely. This mirrors `/subscribe`'s `wantedCollections`.
+
+### Validation rules (stricter than `/subscribe`)
+
+`/subscribe` deliberately mirrors v1's lax behavior (no validation of the prefix
+head). `planBackfill` is a new endpoint with no v1 wire contract, so we validate
+strictly, reusing `atmos` as the single source of truth for NSID grammar rather
+than re-deriving label rules.
+
+A `collections` entry is processed as:
+
+1. If it ends in `.*`: it is a **wildcard**. Let `head = strings.TrimSuffix(raw, ".*")`.
+   Accept iff `atmos.ParseNSID(head + ".wildcard")` succeeds, where `wildcard`
+   is a synthetic, known-valid name label. (We append a name label because
+   `atmos.ParseNSID` requires the final segment to start with a letter and be
+   alphanumeric — `head` alone, e.g. `app.bsky`, is only an authority and would
+   wrongly fail as a 2-segment NSID. The probe string is never stored.)
+   The stored prefix is `head + "."` (e.g. `app.bsky.feed.`).
+2. Otherwise: parse as an exact NSID via `atmos.ParseNSID`. Invalid → reject.
+
+Because `atmos.ParseNSID` (v0.1.10) requires the name segment to start with a
+letter and contain only alphanumerics, `_` is invalid; the probe name `wildcard`
+is plain ASCII letters and always valid.
+
+Boundary table (all rows become explicit unit tests):
+
+| input | classified as | head | probe | outcome |
+|---|---|---|---|---|
+| `app.bsky.feed.post` | exact | — | — | accept (exact) |
+| `app.bsky.feed.*` | wildcard | `app.bsky.feed` | `app.bsky.feed.wildcard` | accept, prefix `app.bsky.feed.` |
+| `app.bsky.*` | wildcard | `app.bsky` | `app.bsky.wildcard` | accept, prefix `app.bsky.` |
+| `com.example.*` | wildcard | `com.example` | `com.example.wildcard` | accept, prefix `com.example.` |
+| `app.*` | wildcard | `app` | `app.wildcard` (2 segs) | reject |
+| `*` | wildcard? no `.` before `*` | — | — | not `.*`-suffixed → exact branch → reject |
+| `.*` | wildcard | `` (empty) | `.wildcard` (empty label) | reject |
+| `app.bsky..*` | wildcard | `app.bsky.` | `app.bsky..wildcard` (empty label) | reject |
+| `app.bsky.feed.*.*` | wildcard | `app.bsky.feed.*` | bad label `*` | reject |
+| `app.bsky.fo*` | exact (no `.` before `*`) | — | — | reject (invalid NSID) |
+| `app.bsky.feed.*x` | exact (ends `*x`, not `.*`) | — | — | reject (invalid NSID) |
+| `1pp.bsky.*` | wildcard | `1pp.bsky` | `1pp.bsky.wildcard` | reject (TLD not letter-initial) |
+| `APP.BSKY.*` | wildcard | `APP.BSKY` | `APP.BSKY.wildcard` | accept (atmos permits uppercase labels) |
+
+(The `APP.BSKY.*` row documents atmos's actual behavior; we assert whatever
+`atmos.ParseNSID` decides rather than inventing a stricter rule. If atmos
+rejects it, the test asserts rejection — the test mirrors the parser, it does
+not override it.)
+
+### Cap semantics
+
+`MaxCollections` counts **distinct patterns** (exact NSIDs + distinct prefixes),
+not expanded collections. `app.bsky.*` counts as 1 regardless of how many
+collections it covers. This matches `/subscribe` and keeps the cap meaningful
+and predictable. Exact NSIDs and prefixes are deduped independently (an entry
+repeated verbatim counts once). `MaxCollections == 0` with any pattern present
+yields the existing "collection filters are disabled" `InvalidRequest`.
+
+### Lexicon
+
+Relax `collections.items` in `lexicons/network/bsky/jetstream/planBackfill.json`
+from `{type: string, format: nsid}` to `{type: string}` and update the field
+description to document the two accepted shapes (exact NSID, or
+`<namespace>.*` wildcard). The generated binding already reads plain strings, so
+this is behaviorally a doc change — but we regenerate the binding so the lexicon
+and code do not contradict each other (a `format: nsid` annotation alongside
+code that accepts non-NSID wildcards is latent tech debt).
+
+## Components & changes
+
+### `internal/manifest/plan.go`
+
+- `PlanBackfillRequest` gains `CollectionPrefixes []string` (each entry ends in
+  `.`). Existing `Collections []string` (exact) is unchanged.
+- `collectionMatchAll` becomes
+  `len(req.Collections) == 0 && len(req.CollectionPrefixes) == 0`.
+- `collectionIDsForSegment(seg, want, prefixes)` keeps a segment collection
+  index if its NSID is in the exact `want` set **or** has any prefix in
+  `prefixes` as a `strings.HasPrefix` match.
+- One-sided contract (no false negatives, possible false positives) is preserved
+  — prefixes only ever widen the matched set, never narrow it.
+
+### `internal/xrpcapi/planbackfill.go`
+
+- `validatePlanCollections` returns `(exact []string, prefixes []string, err error)`.
+  It splits entries per the rules above, dedupes each kind, and enforces
+  `MaxCollections` against `len(exactDistinct) + len(prefixDistinct)`.
+- A small pure helper `classifyCollectionPattern(raw string) (exact string, prefix string, err error)`
+  (or two predicates) isolates the wildcard-vs-exact decision so it can be unit
+  tested directly without HTTP plumbing. This helper is the "wildcard parser"
+  that gets exhaustive unit coverage.
+- `planRequestFromInput` threads the prefixes into
+  `manifest.PlanBackfillRequest.CollectionPrefixes`.
+
+### `lexicons/.../planBackfill.json` + regenerated `api/jetstream/...`
+
+Doc/format relaxation as above; regenerate the binding via the repo's codegen.
+
+## Performance
+
+Per segment, matching cost is `O(collections × prefixes)`. Collections per
+segment are <1000 in practice; prefixes are bounded by `MaxCollections`
+(default 25). Worst case is a few tens of thousands of `strings.HasPrefix` calls
+per segment, each cheap, and the exact-match map lookup still runs first. No new
+allocation on the match hot path beyond the existing per-segment index set.
+**The path is in-memory only — no segment file is read during planning** (verified
+against `plan.go` and `SegmentMetadata`).
+
+## Error handling
+
+Surface is unchanged: invalid wildcard or invalid NSID → `InvalidRequest` (400);
+over-cap → `InvalidRequest`; `MaxCollections == 0` with any pattern → "collection
+filters are disabled" `InvalidRequest`. No new error codes; the existing
+`PlanTooLarge` semantics are untouched.
+
+## Testing
+
+Per AGENTS.md: unit tests sparingly but they earn their place for small pure
+paths like the parser; integration for happy paths; fuzz/property for untrusted
+input and invariants. Every test must keep its package suite under ~1s.
+
+### 1. Wildcard-parser unit tests (exhaustive — primary assurance) — `xrpcapi`
+
+Table-driven tests over the pure classify/validate helper covering **every row**
+of the boundary table above, plus:
+
+- exact-only, wildcard-only, and mixed inputs;
+- dedup: repeated exact NSID counts once; repeated identical wildcard counts
+  once; exact + its own wildcard (`app.bsky.feed.post` + `app.bsky.feed.*`) kept
+  as distinct patterns;
+- ordering independence (prefix before/after exact yields same parsed sets);
+- cap: `len(exact)+len(prefixes)` exactly at limit accepts, one over rejects;
+  a wildcard counts as exactly 1 toward the cap;
+- `MaxCollections == 0` with a wildcard → disabled error;
+- stored prefix always ends in exactly one `.` and never retains the `*`;
+- empty input → no patterns, match-all preserved.
+
+Assertions check the *parsed output* (exact set, prefix set), not just
+accept/reject, so a regression that mis-buckets an entry is caught.
+
+### 2. Manifest equivalence property test (core correctness) — `manifest`
+
+Seeded/randomized: build an archive of several segments over a known NSID
+universe with overlapping namespaces (e.g. `app.bsky.feed.*`, `app.bsky.graph.*`,
+`com.example.*`). For each namespace prefix `P` present (and some absent), assert
+`PlanBackfill({CollectionPrefixes: [P]})` produces byte-identical segments,
+block ranges, modes, and stats to `PlanBackfill({Collections: <all archived
+NSIDs under P>})`. Run as a small swarm over multiple seeds. This directly
+proves the prefix-match ≡ expansion claim.
+
+### 3. xrpcapi integration tests (happy paths + edges) — `xrpcapi`
+
+End-to-end HTTP POST against a real manifest built from written segments:
+
+- wildcard-only request matches the expected blocks;
+- mixed exact + wildcard;
+- wildcard matching nothing in a non-empty archive still returns the correct
+  `plannedThroughSeq` (coverage horizon) with zero segments;
+- wildcard combined with a `dids` filter (intersection still correct);
+- wildcard with a seq window (`afterSeq`/`beforeSeq`);
+- invalid wildcard shapes return 400 `InvalidRequest` (a couple of representative
+  reject rows, end-to-end, to prove the wire path surfaces the handler error).
+
+### 4. Fuzz test — `xrpcapi`
+
+Mirror `internal/subscribe/filter_fuzz_test.go`: feed random pattern lists to the
+parser; assert it never panics and that for every accepted entry the invariant
+holds — exact entries parse as NSIDs, and every stored prefix ends in `.` with a
+head that, re-probed, parses as a namespace. Bounded input size.
+
+## Out of scope (kaizen — file as separate issues if warranted)
+
+- Backporting strict validation to `/subscribe` (it is intentionally v1-lax; do
+  not touch).
+- Wildcards for the `dids` filter (DIDs have no namespace hierarchy; not requested).
+- Any global-collection enumeration API (the chosen approach does not need one).

--- a/docs/superpowers/specs/2026-06-18-planbackfill-wildcard-collections-plan.md
+++ b/docs/superpowers/specs/2026-06-18-planbackfill-wildcard-collections-plan.md
@@ -1,0 +1,79 @@
+# Implementation plan: planBackfill wildcard collection filters
+
+Tracks issue #73. Design: `2026-06-18-planbackfill-wildcard-collections-design.md`.
+
+Work proceeds test-first. Each task lands its tests (red) then code (green) and
+keeps the touched package's suite < ~1s. Branch: `73-planbackfill-wildcards`.
+
+## Task 1 — manifest: prefix matching in the planner
+
+**Files:** `internal/manifest/plan.go`, `internal/manifest/plan_test.go`
+
+1. Add `CollectionPrefixes []string` to `PlanBackfillRequest` (each entry ends in `.`).
+2. `collectionMatchAll` becomes `len(Collections)==0 && len(CollectionPrefixes)==0`.
+3. `collectionIDsForSegment(seg, want, prefixes)` keeps an index if its NSID is in
+   `want` OR `strings.HasPrefix(nsid, p)` for some `p` in `prefixes`.
+4. Tests first: extend `plan_test.go` with prefix-only, mixed exact+prefix,
+   prefix-matches-nothing, and a small assertion that prefixes never narrow the
+   set (one-sided contract). Keep existing exact-match tests green.
+
+**Done when:** planner matches prefixes; existing plan tests still pass.
+
+## Task 2 — manifest: equivalence property test
+
+**Files:** `internal/manifest/plan_prefix_equiv_test.go` (new)
+
+Seeded/randomized archive over a known NSID universe with overlapping namespaces.
+For each present (and some absent) prefix `P`, assert
+`PlanBackfill({CollectionPrefixes:[P]})` == `PlanBackfill({Collections: <all
+archived NSIDs under P>})` for segments, block ranges, modes, and stats. Swarm
+over several fixed seeds (no `Math.random`; iterate seed values).
+
+**Done when:** equivalence holds across all seeds; runs fast (< ~1s).
+
+## Task 3 — xrpcapi: wildcard parser + validation
+
+**Files:** `internal/xrpcapi/planbackfill.go`, `internal/xrpcapi/planbackfill_test.go`
+
+1. Add pure helper `classifyCollectionPattern(raw) (exact, prefix string, err error)`:
+   - ends in `.*` → wildcard; `head = TrimSuffix(raw, ".*")`; accept iff
+     `atmos.ParseNSID(head + ".wildcard")` succeeds; return `prefix = head + "."`.
+   - else → exact via `atmos.ParseNSID`.
+2. `validatePlanCollections` returns `(exact, prefixes []string, err error)`:
+   dedup each kind; cap on `len(exactDistinct)+len(prefixDistinct)` vs
+   `MaxCollections`; `MaxCollections==0` with any pattern → disabled error.
+3. `planRequestFromInput` threads `prefixes` into `CollectionPrefixes`.
+4. Tests first — exhaustive table over the design's boundary table, asserting
+   parsed exact/prefix sets; dedup; ordering independence; cap-at-limit vs
+   over-by-one; disabled; stored prefix ends in exactly one `.`.
+
+**Done when:** parser unit tests pass; existing planbackfill tests green.
+
+## Task 4 — xrpcapi: integration + fuzz
+
+**Files:** `internal/xrpcapi/planbackfill_test.go`, `internal/xrpcapi/planbackfill_fuzz_test.go` (new)
+
+- Integration POSTs: wildcard-only, mixed, matches-nothing (still returns
+  `plannedThroughSeq`), wildcard+DID, wildcard+seq window, invalid wildcard → 400.
+- Fuzz: random pattern lists → parser; assert no panic and the accepted-entry
+  invariant (exact parses as NSID; every prefix ends in `.` and its head re-probes
+  as a namespace). Mirror `internal/subscribe/filter_fuzz_test.go`.
+
+**Done when:** integration + fuzz pass; suite fast.
+
+## Task 5 — lexicon + regenerate binding
+
+**Files:** `lexicons/network/bsky/jetstream/planBackfill.json`, regenerated `api/jetstream/jetstreamplanbackfill.go`
+
+Relax `collections.items` to `{type: string}`; update description to document the
+two shapes. Regenerate via the repo's codegen recipe; verify only the intended
+diff (binding already reads plain strings).
+
+**Done when:** lexicon + binding consistent; build green.
+
+## Task 6 — verify, commit, PR
+
+- `just test ./internal/manifest ./internal/xrpcapi` (+ race), `just lint`.
+- Run a brief fuzz pass (`just fuzz 30s ./internal/xrpcapi`).
+- Self-review (requesting-code-review skill or /code-review).
+- Commit with `Closes #73`; open PR.

--- a/internal/manifest/plan.go
+++ b/internal/manifest/plan.go
@@ -3,6 +3,7 @@ package manifest
 import (
 	"errors"
 	"math"
+	"strings"
 
 	"github.com/bluesky-social/jetstream-v2/segment"
 )
@@ -22,6 +23,12 @@ const (
 type PlanBackfillRequest struct {
 	DIDs        []string
 	Collections []string
+	// CollectionPrefixes are namespace prefixes from wildcard filters
+	// (e.g. "app.bsky.feed." from "app.bsky.feed.*"). Each entry ends in
+	// ".". A segment collection matches if its NSID is in Collections OR
+	// has any of these as a prefix. Like Collections, an empty set here
+	// imposes no collection constraint; the two are combined as a union.
+	CollectionPrefixes []string
 
 	AfterSeq     uint64
 	HasAfterSeq  bool
@@ -180,7 +187,7 @@ func blockOverlapsSeq(block segment.BlockInfo, req PlanBackfillRequest) bool {
 }
 
 func selectPlanBlocks(seg *SegmentMetadata, req PlanBackfillRequest, wantCollections map[string]struct{}) []int {
-	collectionMatchAll := len(req.Collections) == 0
+	collectionMatchAll := len(req.Collections) == 0 && len(req.CollectionPrefixes) == 0
 	didMatchAll := len(req.DIDs) == 0
 
 	if !didMatchAll && !segmentBloomMayContainAny(seg, req.DIDs) {
@@ -189,7 +196,7 @@ func selectPlanBlocks(seg *SegmentMetadata, req PlanBackfillRequest, wantCollect
 
 	var collectionIDs map[uint32]struct{}
 	if !collectionMatchAll {
-		collectionIDs = collectionIDsForSegment(seg, wantCollections)
+		collectionIDs = collectionIDsForSegment(seg, wantCollections, req.CollectionPrefixes)
 		if len(collectionIDs) == 0 {
 			return nil
 		}
@@ -239,11 +246,33 @@ func blockBloomMayContainAny(seg *SegmentMetadata, blockIdx int, dids []string) 
 	return false
 }
 
-func collectionIDsForSegment(seg *SegmentMetadata, want map[string]struct{}) map[uint32]struct{} {
-	out := make(map[uint32]struct{}, min(len(want), len(seg.Collections)))
+// collectionIDsForSegment returns the segment-local collection indices whose
+// NSID is exact-matched by want OR is covered by one of prefixes. Prefixes only
+// widen the matched set, preserving the planner's one-sided contract (no false
+// negatives). Matching prefixes against this segment's own resident collection
+// table is equivalent to expanding each prefix against the global collection
+// union and exact-matching, because a segment can only contain collections that
+// exist in that union — but it needs no global cache and stays current under
+// the manifest read lock.
+func collectionIDsForSegment(seg *SegmentMetadata, want map[string]struct{}, prefixes []string) map[uint32]struct{} {
+	out := make(map[uint32]struct{}, min(len(want)+len(prefixes), len(seg.Collections)))
 	for id, collection := range seg.Collections {
-		if _, ok := want[collection]; ok && id <= math.MaxUint32 {
+		// BlockCollections references collections by uint32 index, so an index
+		// past MaxUint32 can never appear in a block and matching it would be
+		// dead weight. Skipping it cannot cause a false negative (no block
+		// could reference it), preserving the one-sided contract.
+		if id > math.MaxUint32 {
+			continue
+		}
+		if _, ok := want[collection]; ok {
 			out[uint32(id)] = struct{}{}
+			continue
+		}
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(collection, prefix) {
+				out[uint32(id)] = struct{}{}
+				break
+			}
 		}
 	}
 	return out

--- a/internal/manifest/plan_prefix_equiv_test.go
+++ b/internal/manifest/plan_prefix_equiv_test.go
@@ -1,0 +1,149 @@
+package manifest_test
+
+import (
+	"fmt"
+	"math/rand"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/bluesky-social/jetstream-v2/internal/ingest"
+	"github.com/bluesky-social/jetstream-v2/internal/manifest"
+	"github.com/bluesky-social/jetstream-v2/segment"
+	"github.com/stretchr/testify/require"
+)
+
+// nsidUniverse is a fixed set of collections spanning several overlapping
+// namespaces. Prefix equivalence must hold for every namespace boundary in it.
+var nsidUniverse = []string{
+	"app.bsky.feed.post",
+	"app.bsky.feed.like",
+	"app.bsky.feed.repost",
+	"app.bsky.graph.follow",
+	"app.bsky.graph.block",
+	"app.bsky.actor.profile",
+	"com.example.foo.bar",
+	"com.example.foo.baz",
+	"com.example.qux.thing",
+}
+
+// prefixesUnderTest are namespace prefixes (each ending in ".") to probe. The
+// list deliberately mixes broad and narrow prefixes, prefixes that match
+// everything, and a prefix that matches nothing in the universe.
+var prefixesUnderTest = []string{
+	"app.bsky.feed.",
+	"app.bsky.graph.",
+	"app.bsky.",
+	"com.example.foo.",
+	"com.example.",
+	"com.",
+	"net.nonexistent.", // matches nothing
+}
+
+// archivedNSIDsUnderPrefix returns every universe NSID covered by prefix.
+func archivedNSIDsUnderPrefix(prefix string) []string {
+	var out []string
+	for _, nsid := range nsidUniverse {
+		if strings.HasPrefix(nsid, prefix) {
+			out = append(out, nsid)
+		}
+	}
+	return out
+}
+
+// TestPlanBackfill_PrefixEquivalentToEnumeratedExact is the core correctness
+// property for wildcard support: for any archive and any namespace prefix P,
+// planning with CollectionPrefixes=[P] must produce a byte-identical plan
+// (segments, block ranges, modes, and stats) to planning with the explicit set
+// of every archived NSID under P. This directly proves that in-planner prefix
+// matching is equivalent to expanding the wildcard against the global
+// collection union and exact-matching.
+func TestPlanBackfill_PrefixEquivalentToEnumeratedExact(t *testing.T) {
+	t.Parallel()
+
+	// Multiple fixed seeds give a small deterministic swarm: each builds a
+	// different randomized-but-reproducible archive layout.
+	seeds := []int64{1, 2, 3, 7, 42, 1337}
+	for _, seed := range seeds {
+		t.Run(fmt.Sprintf("seed=%d", seed), func(t *testing.T) {
+			t.Parallel()
+			m := buildRandomArchive(t, seed)
+
+			for _, prefix := range prefixesUnderTest {
+				exact := archivedNSIDsUnderPrefix(prefix)
+
+				prefixReq := planReq()
+				prefixReq.CollectionPrefixes = []string{prefix}
+				prefixPlan, err := m.PlanBackfill(prefixReq)
+				require.NoError(t, err)
+
+				if len(exact) == 0 {
+					// A prefix that matches no archived NSID must match
+					// NOTHING, not everything. The enumerated-exact oracle
+					// cannot model this: Collections=[] means match-all, so
+					// the equivalence only holds for non-empty expansions.
+					// This boundary is precisely where "empty list == all"
+					// would be a correctness bug, so we assert match-nothing
+					// directly (coverage horizon and examined count are still
+					// reported).
+					require.Empty(t, prefixPlan.Segments,
+						"seed=%d prefix=%q: prefix matching nothing must yield no segments", seed, prefix)
+					require.Zero(t, prefixPlan.Stats.SegmentsMatched,
+						"seed=%d prefix=%q: prefix matching nothing must match no segments", seed, prefix)
+					continue
+				}
+
+				exactReq := planReq()
+				exactReq.Collections = exact
+				exactPlan, err := m.PlanBackfill(exactReq)
+				require.NoError(t, err)
+
+				require.Equal(t, exactPlan, prefixPlan,
+					"seed=%d prefix=%q: prefix plan must equal enumerated exact plan (exact set=%v)",
+					seed, prefix, exact)
+			}
+		})
+	}
+}
+
+// buildRandomArchive writes several sealed segments full of events drawn from
+// nsidUniverse with reproducible per-seed randomness, then opens a manifest.
+func buildRandomArchive(t *testing.T, seed int64) *manifest.Manifest {
+	t.Helper()
+	rng := rand.New(rand.NewSource(seed))
+	dir := t.TempDir()
+
+	dids := []string{"did:plc:a", "did:plc:b", "did:plc:c", "did:plc:d"}
+	numSegments := 2 + rng.Intn(3) // 2..4 segments
+	var seq uint64
+	for segIdx := range numSegments {
+		numEvents := 3 + rng.Intn(8) // 3..10 events per segment
+		events := make([]segment.Event, 0, numEvents)
+		for range numEvents {
+			seq++
+			nsid := nsidUniverse[rng.Intn(len(nsidUniverse))]
+			did := dids[rng.Intn(len(dids))]
+			events = append(events, planEvent(seq, did, nsid))
+		}
+		// Vary block packing so some segments coalesce and some don't.
+		maxPerBlock := 1 + rng.Intn(3)
+		mustWriteSealedSegmentWithEvents(t, filepath.Join(dir, ingest.SegmentFilename(uint64(segIdx))), maxPerBlock, events)
+	}
+	return openManifestDir(t, dir)
+}
+
+// TestArchivedNSIDsUnderPrefix guards the test helper itself so a bug in the
+// oracle can't silently make the equivalence assertion vacuous.
+func TestArchivedNSIDsUnderPrefix(t *testing.T) {
+	t.Parallel()
+
+	got := archivedNSIDsUnderPrefix("app.bsky.feed.")
+	want := []string{"app.bsky.feed.post", "app.bsky.feed.like", "app.bsky.feed.repost"}
+	sort.Strings(got)
+	sort.Strings(want)
+	require.Equal(t, want, got)
+
+	require.Empty(t, archivedNSIDsUnderPrefix("net.nonexistent."))
+	require.Len(t, archivedNSIDsUnderPrefix("com."), 3)
+}

--- a/internal/manifest/plan_test.go
+++ b/internal/manifest/plan_test.go
@@ -118,6 +118,72 @@ func TestPlanBackfill_CollectionFilterUsesResidentCollectionIndex(t *testing.T) 
 	require.Equal(t, 2, got.Stats.Entries)
 }
 
+func TestPlanBackfill_CollectionPrefixMatchesNamespace(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writePlanSegment(t, dir, 0, 1,
+		planEvent(1, otherDID, postNSID), // app.bsky.feed.post
+		planEvent(2, otherDID, "app.bsky.graph.follow"),
+		planEvent(3, otherDID, likeNSID), // app.bsky.feed.like
+		planEvent(4, otherDID, "app.bsky.graph.block"),
+	)
+	m := openManifestDir(t, dir)
+	req := planReq()
+	req.CollectionPrefixes = []string{"app.bsky.feed."}
+
+	got, err := m.PlanBackfill(req)
+	require.NoError(t, err)
+	require.Len(t, got.Segments, 1)
+	require.Equal(t, manifest.PlanModeBlocks, got.Segments[0].Mode)
+	// Only the two app.bsky.feed.* blocks (0-indexed 0 and 2) match.
+	require.Equal(t, []manifest.BlockRange{{First: 0, Last: 0}, {First: 2, Last: 2}}, got.Segments[0].Blocks)
+	require.Equal(t, 2, got.Stats.BlocksMatched)
+}
+
+func TestPlanBackfill_CollectionPrefixAndExactUnion(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writePlanSegment(t, dir, 0, 1,
+		planEvent(1, otherDID, postNSID),                // matched by exact
+		planEvent(2, otherDID, "app.bsky.graph.follow"), // matched by prefix
+		planEvent(3, otherDID, "com.example.thing"),     // matched by neither
+		planEvent(4, otherDID, "app.bsky.graph.block"),  // matched by prefix
+	)
+	m := openManifestDir(t, dir)
+	req := planReq()
+	req.Collections = []string{postNSID}
+	req.CollectionPrefixes = []string{"app.bsky.graph."}
+
+	got, err := m.PlanBackfill(req)
+	require.NoError(t, err)
+	require.Len(t, got.Segments, 1)
+	require.Equal(t, []manifest.BlockRange{{First: 0, Last: 1}, {First: 3, Last: 3}}, got.Segments[0].Blocks)
+	require.Equal(t, 3, got.Stats.BlocksMatched)
+}
+
+func TestPlanBackfill_CollectionPrefixMatchesNothing(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writePlanSegment(t, dir, 0, 1,
+		planEvent(1, otherDID, postNSID),
+		planEvent(2, otherDID, likeNSID),
+	)
+	m := openManifestDir(t, dir)
+	req := planReq()
+	req.CollectionPrefixes = []string{"com.example."}
+
+	got, err := m.PlanBackfill(req)
+	require.NoError(t, err)
+	// Coverage horizon still reported even though nothing matched.
+	require.EqualValues(t, 2, got.PlannedThroughSeq)
+	require.Empty(t, got.Segments)
+	require.Equal(t, 1, got.Stats.SegmentsExamined)
+	require.Zero(t, got.Stats.SegmentsMatched)
+}
+
 func TestPlanBackfill_DIDAndCollectionFiltersIntersect(t *testing.T) {
 	t.Parallel()
 

--- a/internal/xrpcapi/planbackfill.go
+++ b/internal/xrpcapi/planbackfill.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"strings"
 
 	"github.com/bluesky-social/jetstream-v2/api/jetstream"
 	"github.com/bluesky-social/jetstream-v2/internal/ingest"
@@ -108,7 +109,7 @@ func planRequestFromInput(input *jetstream.JetstreamPlanBackfill_Input, cfg Plan
 	if err != nil {
 		return manifest.PlanBackfillRequest{}, err
 	}
-	collections, err := validatePlanCollections(input.Collections, cfg.MaxCollections)
+	collections, collectionPrefixes, err := validatePlanCollections(input.Collections, cfg.MaxCollections)
 	if err != nil {
 		return manifest.PlanBackfillRequest{}, err
 	}
@@ -116,6 +117,7 @@ func planRequestFromInput(input *jetstream.JetstreamPlanBackfill_Input, cfg Plan
 	req := manifest.PlanBackfillRequest{
 		DIDs:                  dids,
 		Collections:           collections,
+		CollectionPrefixes:    collectionPrefixes,
 		MaxEntries:            cfg.MaxEntries,
 		WholeSegmentThreshold: cfg.WholeSegmentThreshold,
 	}
@@ -173,31 +175,82 @@ func validatePlanDIDs(raw []string, maxDIDs int) ([]string, error) {
 	return out, nil
 }
 
-// validatePlanCollections mirrors validatePlanDIDs for collection NSIDs.
-func validatePlanCollections(raw []string, maxCollections int) ([]string, error) {
+// wildcardSuffix is the only glob shape planBackfill accepts: a trailing ".*"
+// on a namespace prefix (e.g. "app.bsky.feed.*"). This mirrors the one shape
+// /subscribe allows.
+const wildcardSuffix = ".*"
+
+// classifyCollectionPattern decides whether raw is an exact NSID or a namespace
+// wildcard, returning exactly one of (exact, prefix). A wildcard "<head>.*" is
+// accepted iff head is a valid NSID authority, which we check by appending a
+// synthetic, known-valid name label and reusing atmos.ParseNSID as the single
+// source of truth for NSID grammar. atmos requires the name segment to start
+// with a letter and be alphanumeric, so "wildcard" is always a valid probe
+// label and is never stored. The returned prefix is "<head>." (e.g.
+// "app.bsky.feed."), matched elsewhere with strings.HasPrefix.
+//
+// Validation here is intentionally stricter than /subscribe (which is
+// deliberately v1-lax and skips head validation): planBackfill is a new
+// endpoint with no v1 wire contract.
+func classifyCollectionPattern(raw string) (exact string, prefix string, err error) {
+	if head, ok := strings.CutSuffix(raw, wildcardSuffix); ok {
+		if _, perr := atmos.ParseNSID(head + ".wildcard"); perr != nil {
+			return "", "", xrpcserver.InvalidRequest("invalid collection wildcard: " + raw)
+		}
+		return "", head + ".", nil
+	}
+	nsid, perr := atmos.ParseNSID(raw)
+	if perr != nil {
+		return "", "", xrpcserver.InvalidRequest("invalid collection: " + raw)
+	}
+	return string(nsid), "", nil
+}
+
+// validatePlanCollections splits raw collection filters into distinct exact
+// NSIDs and distinct namespace prefixes (from wildcards). The cap counts
+// distinct PATTERNS (exact + prefix), not expanded collections, so one wildcard
+// counts as one regardless of how many collections it covers — matching
+// /subscribe's cap semantics. Both returned slices are nil when raw is empty,
+// which the planner treats as match-all; a non-empty prefix set that matches no
+// archived collection correctly yields an empty plan (see design doc,
+// "match-nothing boundary").
+func validatePlanCollections(raw []string, maxCollections int) (exact []string, prefixes []string, err error) {
 	if len(raw) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 	if maxCollections == 0 {
-		return nil, xrpcserver.InvalidRequest("collection filters are disabled")
+		return nil, nil, xrpcserver.InvalidRequest("collection filters are disabled")
 	}
+	// Dedup on the raw string BEFORE classifying. classifyCollectionPattern is
+	// deterministic, so identical raw values classify identically; deduping
+	// first bounds parse work (each value runs up to two atmos.ParseNSID scans)
+	// and map growth to maxCollections distinct patterns even when a hostile
+	// caller submits a body full of duplicates. This mirrors validatePlanDIDs
+	// above; the collections array has no maxLength on the wire, so this bound
+	// is the only thing standing between a duplicate-stuffed body and O(N) parse
+	// work. The cap counts distinct PATTERNS (exact + prefix), not expanded
+	// collections, so one wildcard counts as one regardless of coverage —
+	// matching /subscribe's cap semantics.
 	seen := make(map[string]struct{}, min(len(raw), maxCollections))
-	out := make([]string, 0, min(len(raw), maxCollections))
 	for _, value := range raw {
-		if _, ok := seen[value]; ok {
+		if _, dup := seen[value]; dup {
 			continue
 		}
-		if len(out) == maxCollections {
-			return nil, xrpcserver.InvalidRequest("too many collections")
+		if len(exact)+len(prefixes) == maxCollections {
+			return nil, nil, xrpcserver.InvalidRequest("too many collections")
+		}
+		ex, pre, cerr := classifyCollectionPattern(value)
+		if cerr != nil {
+			return nil, nil, cerr
 		}
 		seen[value] = struct{}{}
-		nsid, err := atmos.ParseNSID(value)
-		if err != nil {
-			return nil, xrpcserver.InvalidRequest("invalid collection: " + value)
+		if ex != "" {
+			exact = append(exact, ex)
+		} else {
+			prefixes = append(prefixes, pre)
 		}
-		out = append(out, string(nsid))
 	}
-	return out, nil
+	return exact, prefixes, nil
 }
 
 func planOutput(plan manifest.PlanBackfillResult) (*jetstream.JetstreamPlanBackfill_Output, error) {

--- a/internal/xrpcapi/planbackfill_fuzz_test.go
+++ b/internal/xrpcapi/planbackfill_fuzz_test.go
@@ -1,0 +1,73 @@
+package xrpcapi
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jcalabro/atmos"
+)
+
+// FuzzValidatePlanCollections feeds arbitrary collection-pattern lists to the
+// wildcard parser and asserts panic-freedom plus the structural invariants that
+// every accepted result must satisfy: exact entries parse as NSIDs, every stored
+// prefix ends in exactly one "." and never retains "*", the prefix's head
+// re-probes as a valid namespace, and the distinct-pattern count never exceeds
+// the cap. The corpus is seeded with happy and adversarial inputs.
+func FuzzValidatePlanCollections(f *testing.F) {
+	seeds := []string{
+		"app.bsky.feed.post",
+		"app.bsky.feed.*",
+		"app.bsky.*",
+		"app.*",
+		".*",
+		"*",
+		"app.bsky..*",
+		"app.bsky.feed.*.*",
+		"app.bsky.fo*",
+		"not a collection",
+		"",
+	}
+	for _, s := range seeds {
+		f.Add(s, s, 10)
+	}
+
+	f.Fuzz(func(t *testing.T, a, b string, maxRaw int) {
+		// Bound the cap to a sane window; the function treats 0 as "disabled".
+		maxCollections := maxRaw % 8
+		if maxCollections < 0 {
+			maxCollections = -maxCollections
+		}
+
+		raw := []string{a, b}
+		exact, prefixes, err := validatePlanCollections(raw, maxCollections)
+		if err != nil {
+			// Rejection is always acceptable; nothing further to check.
+			return
+		}
+
+		// Distinct-pattern cap must hold on success.
+		if len(exact)+len(prefixes) > maxCollections {
+			t.Fatalf("accepted %d patterns over cap %d (exact=%v prefixes=%v)",
+				len(exact)+len(prefixes), maxCollections, exact, prefixes)
+		}
+
+		for _, ex := range exact {
+			if _, perr := atmos.ParseNSID(ex); perr != nil {
+				t.Fatalf("accepted exact %q is not a valid NSID: %v", ex, perr)
+			}
+		}
+		for _, pre := range prefixes {
+			if !strings.HasSuffix(pre, ".") {
+				t.Fatalf("stored prefix %q does not end in '.'", pre)
+			}
+			if strings.Contains(pre, "*") {
+				t.Fatalf("stored prefix %q retains '*'", pre)
+			}
+			// head = prefix without the trailing "." must re-probe as a namespace.
+			head := strings.TrimSuffix(pre, ".")
+			if _, perr := atmos.ParseNSID(head + ".wildcard"); perr != nil {
+				t.Fatalf("stored prefix head %q does not re-probe as a namespace: %v", head, perr)
+			}
+		}
+	})
+}

--- a/internal/xrpcapi/planbackfill_test.go
+++ b/internal/xrpcapi/planbackfill_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/bluesky-social/jetstream-v2/internal/ingest"
@@ -105,6 +106,160 @@ func postPlan(t *testing.T, ts *httptest.Server, body any) (int, planResp) {
 	return resp.StatusCode, out
 }
 
+func TestClassifyCollectionPattern(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		raw        string
+		wantExact  string
+		wantPrefix string
+		wantErr    bool
+	}{
+		// Exact NSIDs.
+		{name: "exact post", raw: "app.bsky.feed.post", wantExact: "app.bsky.feed.post"},
+		{name: "exact com", raw: "com.example.foo.bar", wantExact: "com.example.foo.bar"},
+
+		// Accepted wildcards.
+		{name: "wildcard feed", raw: "app.bsky.feed.*", wantPrefix: "app.bsky.feed."},
+		{name: "wildcard two-segment head", raw: "app.bsky.*", wantPrefix: "app.bsky."},
+		{name: "wildcard com.example", raw: "com.example.*", wantPrefix: "com.example."},
+		// atmos permits uppercase domain labels; we assert whatever the parser
+		// decides rather than inventing a stricter rule. If this ever flips in
+		// atmos, this row documents the dependency and will fail loudly.
+		{name: "wildcard uppercase labels", raw: "APP.BSKY.*", wantPrefix: "APP.BSKY."},
+
+		// Rejected wildcards (head fails NSID-authority grammar).
+		{name: "wildcard single-segment head", raw: "app.*", wantErr: true},
+		{name: "wildcard empty head", raw: ".*", wantErr: true},
+		{name: "wildcard trailing-dot head", raw: "app.bsky..*", wantErr: true},
+		{name: "wildcard double star", raw: "app.bsky.feed.*.*", wantErr: true},
+		{name: "wildcard non-letter tld", raw: "1pp.bsky.*", wantErr: true},
+
+		// Not wildcards (no ".*" suffix) -> exact branch -> invalid NSID.
+		{name: "bare star", raw: "*", wantErr: true},
+		{name: "star no dot", raw: "app.bsky.fo*", wantErr: true},
+		{name: "star suffix not dotstar", raw: "app.bsky.feed.*x", wantErr: true},
+		{name: "garbage", raw: "not a collection", wantErr: true},
+		{name: "empty", raw: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			exact, prefix, err := classifyCollectionPattern(tt.raw)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantExact, exact, "exact mismatch")
+			require.Equal(t, tt.wantPrefix, prefix, "prefix mismatch")
+			// Exactly one of exact/prefix is set.
+			require.True(t, (exact == "") != (prefix == ""), "exactly one of exact/prefix must be set")
+			if prefix != "" {
+				require.True(t, strings.HasSuffix(prefix, "."), "stored prefix must end in '.'")
+				require.False(t, strings.Contains(prefix, "*"), "stored prefix must not retain '*'")
+			}
+		})
+	}
+}
+
+func TestValidatePlanCollections(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty input is match-all", func(t *testing.T) {
+		t.Parallel()
+		exact, prefixes, err := validatePlanCollections(nil, 10)
+		require.NoError(t, err)
+		require.Nil(t, exact)
+		require.Nil(t, prefixes)
+	})
+
+	t.Run("splits exact and prefix", func(t *testing.T) {
+		t.Parallel()
+		exact, prefixes, err := validatePlanCollections(
+			[]string{"app.bsky.feed.post", "app.bsky.graph.*", "app.bsky.feed.like"}, 10)
+		require.NoError(t, err)
+		require.ElementsMatch(t, []string{"app.bsky.feed.post", "app.bsky.feed.like"}, exact)
+		require.Equal(t, []string{"app.bsky.graph."}, prefixes)
+	})
+
+	t.Run("exact and its own wildcard are distinct patterns", func(t *testing.T) {
+		t.Parallel()
+		exact, prefixes, err := validatePlanCollections(
+			[]string{"app.bsky.feed.post", "app.bsky.feed.*"}, 10)
+		require.NoError(t, err)
+		require.Equal(t, []string{"app.bsky.feed.post"}, exact)
+		require.Equal(t, []string{"app.bsky.feed."}, prefixes)
+	})
+
+	t.Run("dedup exact", func(t *testing.T) {
+		t.Parallel()
+		exact, _, err := validatePlanCollections(
+			[]string{"app.bsky.feed.post", "app.bsky.feed.post"}, 10)
+		require.NoError(t, err)
+		require.Equal(t, []string{"app.bsky.feed.post"}, exact)
+	})
+
+	t.Run("dedup prefix", func(t *testing.T) {
+		t.Parallel()
+		_, prefixes, err := validatePlanCollections(
+			[]string{"app.bsky.feed.*", "app.bsky.feed.*"}, 10)
+		require.NoError(t, err)
+		require.Equal(t, []string{"app.bsky.feed."}, prefixes)
+	})
+
+	t.Run("order independence", func(t *testing.T) {
+		t.Parallel()
+		e1, p1, err := validatePlanCollections([]string{"app.bsky.graph.*", "app.bsky.feed.post"}, 10)
+		require.NoError(t, err)
+		e2, p2, err := validatePlanCollections([]string{"app.bsky.feed.post", "app.bsky.graph.*"}, 10)
+		require.NoError(t, err)
+		require.ElementsMatch(t, e1, e2)
+		require.ElementsMatch(t, p1, p2)
+	})
+
+	t.Run("cap counts patterns: at limit ok", func(t *testing.T) {
+		t.Parallel()
+		// 1 exact + 1 prefix = 2 distinct patterns, limit 2.
+		exact, prefixes, err := validatePlanCollections(
+			[]string{"app.bsky.feed.post", "app.bsky.graph.*"}, 2)
+		require.NoError(t, err)
+		require.Len(t, exact, 1)
+		require.Len(t, prefixes, 1)
+	})
+
+	t.Run("cap counts patterns: over by one rejects", func(t *testing.T) {
+		t.Parallel()
+		_, _, err := validatePlanCollections(
+			[]string{"app.bsky.feed.post", "app.bsky.graph.*", "app.bsky.actor.*"}, 2)
+		require.Error(t, err)
+	})
+
+	t.Run("wildcard counts as one toward cap", func(t *testing.T) {
+		t.Parallel()
+		// A single wildcard covering many collections is one pattern.
+		_, prefixes, err := validatePlanCollections([]string{"app.bsky.*"}, 1)
+		require.NoError(t, err)
+		require.Len(t, prefixes, 1)
+	})
+
+	t.Run("disabled with any pattern", func(t *testing.T) {
+		t.Parallel()
+		_, _, err := validatePlanCollections([]string{"app.bsky.feed.*"}, 0)
+		require.Error(t, err)
+		_, _, err = validatePlanCollections([]string{"app.bsky.feed.post"}, 0)
+		require.Error(t, err)
+	})
+
+	t.Run("invalid wildcard rejected", func(t *testing.T) {
+		t.Parallel()
+		_, _, err := validatePlanCollections([]string{"app.*"}, 10)
+		require.Error(t, err)
+	})
+}
+
 func TestPlanBackfill_ReturnsBlockPlan(t *testing.T) {
 	t.Parallel()
 
@@ -136,6 +291,124 @@ func TestPlanBackfill_ReturnsBlockPlan(t *testing.T) {
 	require.EqualValues(t, 1, out.Stats.SegmentsMatched)
 	require.EqualValues(t, 1, out.Stats.BlocksMatched)
 	require.EqualValues(t, 1, out.Stats.Entries)
+}
+
+func TestPlanBackfill_WildcardOnly(t *testing.T) {
+	t.Parallel()
+
+	ts := newPlanTestServer(t, defaultPlanTestConfig(),
+		planEvent(1, "did:plc:a", "app.bsky.feed.post"),
+		planEvent(2, "did:plc:b", "app.bsky.graph.follow"),
+		planEvent(3, "did:plc:c", "app.bsky.feed.like"),
+		planEvent(4, "did:plc:d", "com.example.thing"),
+	)
+
+	status, out := postPlan(t, ts, map[string]any{
+		"collections": []string{"app.bsky.feed.*"},
+	})
+	require.Equal(t, http.StatusOK, status)
+	require.Len(t, out.Segments, 1)
+	require.Equal(t, "blocks", out.Segments[0].Mode)
+	// app.bsky.feed.post (block 0) and app.bsky.feed.like (block 2) match.
+	require.Equal(t, []int64{0, 0}, []int64{out.Segments[0].Blocks[0].First, out.Segments[0].Blocks[0].Last})
+	require.Equal(t, []int64{2, 2}, []int64{out.Segments[0].Blocks[1].First, out.Segments[0].Blocks[1].Last})
+	require.EqualValues(t, 2, out.Stats.BlocksMatched)
+}
+
+func TestPlanBackfill_WildcardMixedWithExact(t *testing.T) {
+	t.Parallel()
+
+	ts := newPlanTestServer(t, defaultPlanTestConfig(),
+		planEvent(1, "did:plc:a", "app.bsky.feed.post"),
+		planEvent(2, "did:plc:b", "app.bsky.graph.follow"),
+		planEvent(3, "did:plc:c", "app.bsky.graph.block"),
+		planEvent(4, "did:plc:d", "com.example.thing"),
+	)
+
+	status, out := postPlan(t, ts, map[string]any{
+		"collections": []string{"app.bsky.feed.post", "app.bsky.graph.*"},
+	})
+	require.Equal(t, http.StatusOK, status)
+	require.Len(t, out.Segments, 1)
+	// blocks 0 (post, exact), 1 and 2 (graph.*) match; block 3 (com.example) does not.
+	require.EqualValues(t, 3, out.Stats.BlocksMatched)
+}
+
+func TestPlanBackfill_WildcardMatchesNothing(t *testing.T) {
+	t.Parallel()
+
+	ts := newPlanTestServer(t, defaultPlanTestConfig(),
+		planEvent(1, "did:plc:a", "app.bsky.feed.post"),
+		planEvent(2, "did:plc:b", "app.bsky.feed.like"),
+	)
+
+	status, out := postPlan(t, ts, map[string]any{
+		"collections": []string{"com.example.*"},
+	})
+	require.Equal(t, http.StatusOK, status)
+	// Coverage horizon reported even though no segment matched.
+	require.EqualValues(t, 2, out.PlannedThroughSeq)
+	require.Empty(t, out.Segments)
+	require.EqualValues(t, 1, out.Stats.SegmentsExamined)
+	require.EqualValues(t, 0, out.Stats.SegmentsMatched)
+}
+
+func TestPlanBackfill_WildcardWithDIDFilter(t *testing.T) {
+	t.Parallel()
+
+	ts := newPlanTestServer(t, defaultPlanTestConfig(),
+		planEvent(1, "did:plc:target", "app.bsky.feed.post"),
+		planEvent(2, "did:plc:other", "app.bsky.feed.like"),
+		planEvent(3, "did:plc:target", "app.bsky.graph.follow"),
+		planEvent(4, "did:plc:target", "com.example.thing"),
+	)
+
+	status, out := postPlan(t, ts, map[string]any{
+		"dids":        []string{"did:plc:target"},
+		"collections": []string{"app.bsky.*"},
+	})
+	require.Equal(t, http.StatusOK, status)
+	require.Len(t, out.Segments, 1)
+	// target ∩ app.bsky.*: block 0 (feed.post) and block 2 (graph.follow).
+	// block 1 is other's, block 3 is com.example -> excluded.
+	require.EqualValues(t, 2, out.Stats.BlocksMatched)
+}
+
+func TestPlanBackfill_WildcardWithSeqWindow(t *testing.T) {
+	t.Parallel()
+
+	ts := newPlanTestServer(t, defaultPlanTestConfig(),
+		planEvent(1, "did:plc:a", "app.bsky.feed.post"),
+		planEvent(2, "did:plc:b", "app.bsky.feed.like"),
+		planEvent(3, "did:plc:c", "app.bsky.feed.repost"),
+		planEvent(4, "did:plc:d", "app.bsky.feed.post"),
+	)
+
+	status, out := postPlan(t, ts, map[string]any{
+		"collections": []string{"app.bsky.feed.*"},
+		"afterSeq":    1,
+		"beforeSeq":   3,
+	})
+	require.Equal(t, http.StatusOK, status)
+	require.EqualValues(t, 3, out.PlannedThroughSeq)
+	require.Len(t, out.Segments, 1)
+	// seq window (1,3]: blocks 1 and 2.
+	require.EqualValues(t, 2, out.Stats.BlocksMatched)
+}
+
+func TestPlanBackfill_InvalidWildcardReturns400(t *testing.T) {
+	t.Parallel()
+
+	for _, bad := range []string{"app.*", ".*", "app.bsky..*", "app.bsky.feed.*.*"} {
+		t.Run(bad, func(t *testing.T) {
+			t.Parallel()
+			ts := newPlanTestServer(t, defaultPlanTestConfig())
+			resp := doPostJSON(t, ts.URL+planURLPath, map[string]any{"collections": []string{bad}})
+			defer func() { _ = resp.Body.Close() }()
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			require.Equal(t, "InvalidRequest", readXRPCError(t, resp))
+		})
+	}
 }
 
 func TestPlanBackfill_WholeSegmentWireShape(t *testing.T) {

--- a/lexicons/network/bsky/jetstream/planBackfill.json
+++ b/lexicons/network/bsky/jetstream/planBackfill.json
@@ -17,8 +17,8 @@
             },
             "collections": {
               "type": "array",
-              "description": "Exact collection NSIDs to match. Missing or empty means all collections.",
-              "items": { "type": "string", "format": "nsid" }
+              "description": "Collection filters to match. Each entry is either an exact NSID (e.g. app.bsky.feed.post) or a namespace wildcard ending in '.*' (e.g. app.bsky.feed.*), which matches every collection under that namespace prefix. Missing or empty means all collections. A wildcard that matches no archived collection yields an empty plan (it is not treated as match-all).",
+              "items": { "type": "string" }
             },
             "afterSeq": {
               "type": "integer",


### PR DESCRIPTION
## Summary

Adds namespace **wildcard** collection filters (e.g. `app.bsky.feed.*`) to the `network.bsky.jetstream.planBackfill` query planner, mixed freely with exact NSIDs in the existing `collections` array. This mirrors the one glob shape `/subscribe` already accepts, so a client backfilling "all feed records" can write `app.bsky.feed.*` instead of enumerating every NSID under the namespace.

Only a trailing `.*` on a namespace prefix is supported — no arbitrary globs.

Closes #73.

## Approach: in-planner prefix matching (not request-time expansion)

The planner carries a new `CollectionPrefixes []string` on `PlanBackfillRequest`; `collectionIDsForSegment` keeps a segment's collection index if its NSID is exact-matched **or** has any requested prefix (`strings.HasPrefix`).

This is **provably equivalent** to expanding a wildcard against the global collection union and exact-matching — a segment can only contain collections that exist in that union — but it:

- needs **no global-collection cache** and no invalidation on seal/compaction,
- has **no staleness window** (all matching runs under the manifest `RLock` against current state),
- stays **fully in-memory**: planning reads only resident `SegmentMetadata` (collection tables, block indices, blooms) — **no segment file is opened during planning**,
- keeps the `MaxCollections` cap meaningful: it counts **distinct patterns**, so one wildcard counts as one regardless of how many collections it covers.

The rejected alternative (request-time expansion against a cached union) was discarded for the cache/invalidation/staleness/cap complications above.

## Behavioral details

- **No new wire field.** Wildcards ride in the existing `collections` array. The generated binding already reads `collections` as plain strings, so the lexicon's `items` was relaxed from `{format: nsid}` to `{type: string}` (doc + regenerated binding only — behavior unchanged) to stop it contradicting the code.
- **Stricter validation than `/subscribe`.** `/subscribe` is deliberately v1-lax (no validation of the prefix head). `planBackfill` is a new endpoint with no v1 contract, so a wildcard `<head>.*` is accepted **iff** `atmos.ParseNSID(head + ".wildcard")` succeeds, reusing `atmos` as the single source of truth for NSID grammar (the synthetic name label is never stored). Result: `app.bsky.feed.*` and `app.bsky.*` accept; `app.*`, `.*`, `app.bsky..*`, `app.bsky.feed.*.*` reject.
- **Match-nothing boundary (important).** A wildcard that matches no archived collection yields an **empty plan**, not match-all. Only a genuinely-absent filter (`collections` empty) means match-all. The two are deliberately *not* interchangeable, and the equivalence property test asserts this asymmetry directly.
- **DoS bound preserved.** Validation dedups on the raw string **before** parsing, bounding parse work and map growth to `maxCollections` distinct patterns even under a duplicate-stuffed body. This mirrors the sibling `validatePlanDIDs` (the `collections` array has no `maxLength` on the wire, so this is the only bound).

## Testing

- **Exhaustive wildcard-parser unit tests** — table-driven over every accept/reject boundary, asserting the parsed exact/prefix *output* (not just accept/reject); plus dedup, order-independence, pattern-counting cap (at-limit vs over-by-one), and disabled-filter cases.
- **Manifest equivalence property test** — seeded swarm: for each namespace prefix `P`, planning with `{CollectionPrefixes:[P]}` produces a byte-identical plan (segments, block ranges, modes, stats) to planning with the enumerated set of every archived NSID under `P`. Directly proves prefix-match ≡ expansion; asserts match-nothing for empty expansions.
- **HTTP integration tests** — wildcard-only, mixed exact+wildcard, matches-nothing (still returns `plannedThroughSeq`), wildcard + DID filter, wildcard + seq window, invalid shapes → 400.
- **Parser fuzz test** — random pattern lists; asserts panic-freedom and structural invariants (exact entries parse as NSIDs; every stored prefix ends in `.`, retains no `*`, and its head re-probes as a namespace; distinct-pattern count never exceeds the cap).

## Verification

- `just test ./internal/manifest ./internal/xrpcapi` — 175 tests pass (~50ms)
- `go test -race` — clean on both packages
- `just lint` — 0 issues
- `go build ./...` — clean
- Fuzz — 100k+ execs, no failures

## Notes / out of scope (kaizen, file separately if warranted)

- Backporting strict validation to `/subscribe` (intentionally v1-lax; untouched).
- Wildcards for the `dids` filter (DIDs have no namespace hierarchy; not requested).
- A self-review caught and fixed a first-cut regression where validation parsed before deduping, which would have lost the duplicate-stuffing parse bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)