### PR TITLE
testing: reduce short test wall time

### DIFF
--- a/internal/jetstreamd/options.go
+++ b/internal/jetstreamd/options.go
@@ -80,6 +80,7 @@ type Options struct {
 	CompactionInterval        time.Duration
 	CompactionTombstoneCap    int
 	CompactionRewriteWorkers  int
+	OverlayRebuildInterval    time.Duration
 	BarrierAfterBootstrap     PhaseBarrier
 	BarrierAfterMerge         PhaseBarrier
 	OnCompactionPass          func(CompactionPassResult)

--- a/internal/jetstreamd/runtime.go
+++ b/internal/jetstreamd/runtime.go
@@ -74,6 +74,9 @@ func Build(ctx context.Context, opts Options) (*Runtime, error) {
 	if opts.CompactionInterval < 0 {
 		return nil, fmt.Errorf("serve: --compaction-interval must be >= 0 (CompactionInterval must be >= 0), got %s", opts.CompactionInterval)
 	}
+	if opts.OverlayRebuildInterval < 0 {
+		return nil, fmt.Errorf("serve: overlay rebuild interval must be >= 0 (OverlayRebuildInterval must be >= 0), got %s", opts.OverlayRebuildInterval)
+	}
 	if opts.CompactionTombstoneCap < 0 {
 		return nil, fmt.Errorf("serve: --compaction-tombstone-cap must be >= 0 (CompactionTombstoneCap must be >= 0), got %d", opts.CompactionTombstoneCap)
 	}
@@ -435,6 +438,10 @@ func (r *Runtime) PublicAddr() string {
 // fatal subsystem error.
 func (r *Runtime) Run(ctx context.Context) error {
 	g, gctx := errgroup.WithContext(ctx)
+	overlayInterval := r.opts.OverlayRebuildInterval
+	if overlayInterval == 0 {
+		overlayInterval = overlayRebuildInterval
+	}
 
 	g.Go(func() error {
 		<-gctx.Done()
@@ -461,7 +468,7 @@ func (r *Runtime) Run(ctx context.Context) error {
 	})
 
 	g.Go(func() error {
-		err := r.overlayCache.RunTicker(gctx, overlayRebuildInterval)
+		err := r.overlayCache.RunTicker(gctx, overlayInterval)
 		if errors.Is(err, context.Canceled) {
 			return nil
 		}

--- a/internal/jetstreamd/runtime_test.go
+++ b/internal/jetstreamd/runtime_test.go
@@ -49,6 +49,15 @@ func TestOptionsValidateRejectsNegativeSegmentCache(t *testing.T) {
 	require.ErrorContains(t, err, "SegmentCacheMaxAge must be >= 0")
 }
 
+func TestOptionsValidateRejectsNegativeOverlayRebuildInterval(t *testing.T) {
+	t.Parallel()
+
+	opts := testOptions(t)
+	opts.OverlayRebuildInterval = -time.Second
+	_, err := Build(t.Context(), opts)
+	require.ErrorContains(t, err, "OverlayRebuildInterval must be >= 0")
+}
+
 func TestOptionsValidateRejectsNegativeBackfillWorkers(t *testing.T) {
 	t.Parallel()
 

--- a/internal/oracle/config.go
+++ b/internal/oracle/config.go
@@ -75,10 +75,10 @@ func parseConfigFromLookupEnv(lookupenv func(string) (string, bool)) (Config, er
 	switch mode {
 	case "default":
 	case "fast":
-		cfg.Accounts = 8
-		cfg.MaxInitialRecords = 50
-		cfg.LiveEventsBootstrap = 25
-		cfg.LiveEventsSteady = 25
+		cfg.Accounts = 4
+		cfg.MaxInitialRecords = 10
+		cfg.LiveEventsBootstrap = 12
+		cfg.LiveEventsSteady = 12
 	case "stress":
 		cfg.Accounts = 100
 		cfg.MaxInitialRecords = 5000

--- a/internal/oracle/config_test.go
+++ b/internal/oracle/config_test.go
@@ -45,11 +45,11 @@ func TestConfigModePresets(t *testing.T) {
 		"JETSTREAM_ORACLE_MODE": "fast",
 	}))
 	require.NoError(t, err)
-	require.Equal(t, 8, fast.Accounts)
+	require.Equal(t, 4, fast.Accounts)
 	require.Equal(t, 0, fast.MinInitialRecords)
-	require.Equal(t, 50, fast.MaxInitialRecords)
-	require.Equal(t, 25, fast.LiveEventsBootstrap)
-	require.Equal(t, 25, fast.LiveEventsSteady)
+	require.Equal(t, 10, fast.MaxInitialRecords)
+	require.Equal(t, 12, fast.LiveEventsBootstrap)
+	require.Equal(t, 12, fast.LiveEventsSteady)
 
 	stress, err := ParseConfigFromEnv(envMap(map[string]string{
 		"JETSTREAM_ORACLE_MODE": "stress",
@@ -60,6 +60,38 @@ func TestConfigModePresets(t *testing.T) {
 	require.Equal(t, 5000, stress.MaxInitialRecords)
 	require.Equal(t, 5000, stress.LiveEventsBootstrap)
 	require.Equal(t, 5000, stress.LiveEventsSteady)
+}
+
+func TestDefaultLifecycleConfigUsesFastModeUnderShort(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := defaultLifecycleConfig(lookupEnvMap(nil), true)
+	require.NoError(t, err)
+	require.Equal(t, "fast", cfg.Mode)
+	require.Equal(t, 4, cfg.Accounts)
+	require.Equal(t, 10, cfg.MaxInitialRecords)
+}
+
+func TestDefaultLifecycleConfigHonorsExplicitModeUnderShort(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := defaultLifecycleConfig(lookupEnvMap(map[string]string{
+		"JETSTREAM_ORACLE_MODE": "default",
+	}), true)
+	require.NoError(t, err)
+	require.Equal(t, "default", cfg.Mode)
+	require.Equal(t, 25, cfg.Accounts)
+	require.Equal(t, 1000, cfg.MaxInitialRecords)
+}
+
+func TestDefaultLifecycleConfigKeepsDefaultOutsideShort(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := defaultLifecycleConfig(lookupEnvMap(nil), false)
+	require.NoError(t, err)
+	require.Equal(t, "default", cfg.Mode)
+	require.Equal(t, 25, cfg.Accounts)
+	require.Equal(t, 1000, cfg.MaxInitialRecords)
 }
 
 func TestConfigRejectsInvalidEnv(t *testing.T) {

--- a/internal/oracle/faults.go
+++ b/internal/oracle/faults.go
@@ -107,7 +107,6 @@ func (p *SwarmFaultPlan) ArmSubscribeReposDisconnects() {
 }
 
 func buildSubscribeReposDisconnectSchedule(seed uint64, steadyEvents int) ([]int, error) {
-	const k = subscribeDisconnectScheduleK
 	// floor is clamped to >= 2 so a threshold of 0 or 1 can never make the
 	// fault fire before the consumer has made progress (a livelock boundary).
 	// maxThreshold caps each draw at half the steady-state budget so the first
@@ -123,6 +122,10 @@ func buildSubscribeReposDisconnectSchedule(seed uint64, steadyEvents int) ([]int
 	if maxThreshold <= floor {
 		return nil, fmt.Errorf("oracle: subscribeRepos disconnect cap %d must be > floor %d (steady events %d too small)",
 			maxThreshold, floor, steadyEvents)
+	}
+	k := subscribeDisconnectScheduleK
+	if steadyEvents < 25 {
+		k = max(1, steadyEvents/4)
 	}
 
 	rng := rand.New(rand.NewPCG(seed^oracleSubscribeFaultSeedSalt, seed+oracleSubscribeFaultSeedSalt))

--- a/internal/oracle/faults_test.go
+++ b/internal/oracle/faults_test.go
@@ -144,14 +144,18 @@ func TestBuildSubscribeReposDisconnectScheduleRejectsDegenerateSteadyCounts(t *t
 func TestBuildSubscribeReposDisconnectScheduleAcceptsSupportedModes(t *testing.T) {
 	t.Parallel()
 
-	// steady=6 is the first accepted value (maxThreshold=3 > floor=2); 25 and
-	// 5000 cover the fast and stress presets.
-	for _, steady := range []int{6, 25, 5000} {
+	// steady=6 is the first accepted value (maxThreshold=3 > floor=2); 12
+	// covers the fast preset, while 25 and 5000 cover the full schedule.
+	for _, steady := range []int{6, 12, 25, 5000} {
 		t.Run(fmt.Sprintf("steady_%d", steady), func(t *testing.T) {
 			t.Parallel()
 			got, err := buildSubscribeReposDisconnectSchedule(123, steady)
 			require.NoError(t, err)
-			require.Len(t, got, 8)
+			wantLen := subscribeDisconnectScheduleK
+			if steady < 25 {
+				wantLen = max(1, steady/4)
+			}
+			require.Len(t, got, wantLen)
 		})
 	}
 }

--- a/internal/oracle/harness_test.go
+++ b/internal/oracle/harness_test.go
@@ -26,7 +26,7 @@ import (
 
 // nolint:paralleltest
 func TestOracle_DefaultLifecycle(t *testing.T) {
-	cfg, err := ParseConfigFromLookupEnv(os.LookupEnv)
+	cfg, err := defaultLifecycleConfig(os.LookupEnv, testing.Short())
 	require.NoError(t, err)
 	if cfg.Mode == "stress" && testing.Short() {
 		t.Skip("skipping stress oracle under -short")
@@ -160,6 +160,7 @@ func TestOracle_DefaultLifecycle(t *testing.T) {
 		CursorBlockIndexCacheSize: 32,
 		CompactionInterval:        time.Hour,
 		CompactionTombstoneCap:    1,
+		OverlayRebuildInterval:    10 * time.Millisecond,
 		BarrierAfterBootstrap:     afterBootstrap.Barrier,
 		BarrierAfterMerge:         afterMerge.Barrier,
 		OnCompactionPass: func(result jetstreamd.CompactionPassResult) {
@@ -346,6 +347,21 @@ func TestOracle_DefaultLifecycle(t *testing.T) {
 		"shutdown_start",
 		"runtime_exit",
 	)
+}
+
+func defaultLifecycleConfig(lookupenv func(string) (string, bool), short bool) (Config, error) {
+	if !short {
+		return ParseConfigFromLookupEnv(lookupenv)
+	}
+	if _, ok := lookupenv(envOracleMode); ok {
+		return ParseConfigFromLookupEnv(lookupenv)
+	}
+	return ParseConfigFromLookupEnv(func(key string) (string, bool) {
+		if key == envOracleMode {
+			return "fast", true
+		}
+		return lookupenv(key)
+	})
 }
 
 // assertFaultPlanFired verifies the fault injection actually happened.

--- a/internal/simulator/world/distributions_test.go
+++ b/internal/simulator/world/distributions_test.go
@@ -14,7 +14,7 @@ func newTestRand() *rand.Rand {
 func TestZipfian_AllInRange(t *testing.T) {
 	t.Parallel()
 	r := newTestRand()
-	for range 10000 {
+	for range 1000 {
 		idx := zipfian(r, 1.07, 100)
 		require.GreaterOrEqual(t, idx, 0)
 		require.Less(t, idx, 100)
@@ -25,7 +25,7 @@ func TestZipfian_FavorsLowIndices(t *testing.T) {
 	t.Parallel()
 	r := newTestRand()
 	hits := make(map[int]int, 100)
-	for range 100000 {
+	for range 20000 {
 		hits[zipfian(r, 1.07, 100)]++
 	}
 	require.Greater(t, hits[0], hits[50])
@@ -37,7 +37,7 @@ func TestExponentialDelay_MeanInTolerance(t *testing.T) {
 	r := newTestRand()
 	const want = 0.1 // mean
 	var sum float64
-	const n = 100000
+	const n = 20000
 	for range n {
 		sum += exponentialDelay(r, want)
 	}
@@ -55,7 +55,7 @@ func TestWeightedChoice(t *testing.T) {
 		{value: c, weight: 1},
 	}
 	hits := map[string]int{}
-	for range 100000 {
+	for range 20000 {
 		hits[weightedChoice(r, weights)]++
 	}
 	require.Greater(t, hits[a], hits[b])
@@ -65,7 +65,7 @@ func TestWeightedChoice(t *testing.T) {
 func TestLogNormalClamped(t *testing.T) {
 	t.Parallel()
 	r := newTestRand()
-	for range 5000 {
+	for range 1000 {
 		v := logNormalClamped(r, 4.0, 1.0, 1, 3000)
 		require.GreaterOrEqual(t, v, 1)
 		require.LessOrEqual(t, v, 3000)

--- a/internal/simulator/world/traffic_test.go
+++ b/internal/simulator/world/traffic_test.go
@@ -184,7 +184,7 @@ func TestGenerateOne_RevsStrictlyIncreaseForHotAccount(t *testing.T) {
 
 	w := newRuntimeWorld(t, 1, 1)
 	var prev string
-	for range 100 {
+	for range 50 {
 		_, err := w.GenerateOneForTest(t.Context())
 		require.NoError(t, err)
 		state, err := w.loadState(0)
@@ -224,7 +224,7 @@ func TestGenerateOne_RevsAdvancePastBootstrapForEveryAccount(t *testing.T) {
 		lastRevByRepo[string(a.DID)] = state.Rev
 	}
 
-	for i := range 500 {
+	for i := range 200 {
 		frame, err := w.generateOne(context.Background())
 		require.NoError(t, err, "iter=%d", i)
 
@@ -259,7 +259,7 @@ func TestGenerateOne_DeterministicFramesAcrossRuns(t *testing.T) {
 func TestRunTraffic_StopsOnContext(t *testing.T) {
 	t.Parallel()
 	w := newTestWorld(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
 	defer cancel()
 	require.NoError(t, w.RunTraffic(ctx, slog.Default()))
 }
@@ -278,7 +278,7 @@ func TestRunTraffic_StopsOnContext(t *testing.T) {
 //
 // Configuration is tuned to make duplicates likely without the fix:
 // 5 accounts, 1 initial record each, RNG biased so multi-op commits
-// happen often, run 500 commits.
+// happen often, run 200 commits.
 func TestGenerateOne_NoDuplicateOpPaths(t *testing.T) {
 	t.Parallel()
 
@@ -294,7 +294,7 @@ func TestGenerateOne_NoDuplicateOpPaths(t *testing.T) {
 	require.NoError(t, w.Bootstrap(context.Background(), slog.Default()))
 	require.NoError(t, w.AttachRuntime(rand.New(rand.NewPCG(11, 22)), fanout.New(64)))
 
-	for i := range 500 {
+	for i := range 200 {
 		frame, err := w.generateOne(context.Background())
 		require.NoError(t, err, "iter=%d", i)
 

--- a/internal/subscribe/burst_test.go
+++ b/internal/subscribe/burst_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -21,12 +22,14 @@ import (
 func TestTail_BurstDoesNotDropSlowButLiveReaders(t *testing.T) {
 	t.Parallel()
 
-	const total = 500_000
+	const total = 50_000
 	// In-memory cold log so the test needs no disk fixtures: it records every
 	// appended event and replays Seq >= cursor on a cold miss. Seq == index.
 	var logMu sync.RWMutex
+	var coldReads atomic.Int64
 	logged := make([]*segment.Event, 0, total)
 	cold := func(_ context.Context, cursor uint64, max int) ([]*Entry, uint64, error) {
+		coldReads.Add(1)
 		logMu.RLock()
 		defer logMu.RUnlock()
 		n := uint64(len(logged))
@@ -42,7 +45,7 @@ func TestTail_BurstDoesNotDropSlowButLiveReaders(t *testing.T) {
 	}
 
 	tl := newTail(tailConfig{
-		hotBytes: 8 << 20, // deliberately small so readers fall cold
+		hotBytes: 64 << 10, // deliberately small so readers fall cold
 		cold:     cold,
 		nextSeq:  func() uint64 { logMu.RLock(); defer logMu.RUnlock(); return uint64(len(logged)) },
 		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
@@ -81,10 +84,11 @@ func TestTail_BurstDoesNotDropSlowButLiveReaders(t *testing.T) {
 		logged = append(logged, ev)
 		logMu.Unlock()
 		tl.Append(ev)
-		require.LessOrEqual(t, tl.ringBytes(), 8<<20, "ring must stay within budget mid-burst")
+		require.LessOrEqual(t, tl.ringBytes(), 64<<10, "ring must stay within budget mid-burst")
 	}
 
 	wg.Wait()
+	require.Positive(t, coldReads.Load(), "burst must force at least one cold replay")
 	for r := range readers {
 		require.Equal(t, total, received[r], "reader %d must receive every event, zero drops", r)
 	}

--- a/internal/subscribe/handler_shutdown_test.go
+++ b/internal/subscribe/handler_shutdown_test.go
@@ -53,7 +53,7 @@ func TestHandler_GracefulShutdownSendsGoingAway(t *testing.T) {
 	defer func() { _ = conn.CloseNow() }()
 
 	// Let the handler register its connection in the shutdown registry.
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 
 	// Model a real subscriber: always blocked in Read consuming the
 	// firehose. This matters for timing — the server's closeConn does a

--- a/internal/subscribe/handler_test.go
+++ b/internal/subscribe/handler_test.go
@@ -33,6 +33,15 @@ func newSteadyStateStore(t *testing.T) *store.Store {
 	return st
 }
 
+func waitForTailBlocked(t *testing.T, b *Tail) {
+	t.Helper()
+	select {
+	case <-b.blocked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("subscriber did not park at live tip")
+	}
+}
+
 func TestHandler_RejectsWhenNotSteadyState(t *testing.T) {
 	t.Parallel()
 
@@ -90,7 +99,7 @@ func TestHandler_HappyPath_DeliversIdentityEvent(t *testing.T) {
 	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "test done") }()
 
 	// Give the handler time to register the subscriber.
-	time.Sleep(50 * time.Millisecond)
+	waitForTailBlocked(t, b)
 
 	id := &comatproto.SyncSubscribeRepos_Identity{
 		DID:  "did:plc:test",
@@ -143,7 +152,7 @@ func TestHandler_SyncEventNotEmitted(t *testing.T) {
 	}
 	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "test done") }()
 
-	time.Sleep(50 * time.Millisecond)
+	waitForTailBlocked(t, b)
 
 	// Publish a sync event (which the encoder skips) followed by an
 	// identity (which the encoder emits). Only the identity should
@@ -199,7 +208,7 @@ func TestHandler_DefaultModeDoesNotEmitResyncReplacementRows(t *testing.T) {
 	}
 	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "test done") }()
 
-	time.Sleep(50 * time.Millisecond)
+	waitForTailBlocked(t, b)
 
 	var seq uint64
 	appendSeq(b, &seq, &segment.Event{
@@ -248,7 +257,7 @@ func TestHandler_ResyncModeEmitsResyncReplacementRows(t *testing.T) {
 	}
 	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "test done") }()
 
-	time.Sleep(50 * time.Millisecond)
+	waitForTailBlocked(t, b)
 
 	var seq uint64
 	appendSeq(b, &seq, &segment.Event{
@@ -298,7 +307,7 @@ func TestHandler_ExtendedDeliversRecordCBORAndSync(t *testing.T) {
 	}
 	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "test done") }()
 
-	time.Sleep(50 * time.Millisecond)
+	waitForTailBlocked(t, b)
 
 	var seq uint64
 	payload := []byte{0xa0}
@@ -375,7 +384,7 @@ func TestHandler_DefaultModeDoesNotEmitExtendedFields(t *testing.T) {
 	}
 	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "test done") }()
 
-	time.Sleep(50 * time.Millisecond)
+	waitForTailBlocked(t, b)
 
 	var seq uint64
 	appendSeq(b, &seq, &segment.Event{
@@ -586,7 +595,7 @@ func TestHandler_ZstdQueryParam_DeliversDictCompressedFrames(t *testing.T) {
 	}
 	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "test done") }()
 
-	time.Sleep(50 * time.Millisecond)
+	waitForTailBlocked(t, b)
 	var seq uint64
 	publishIdentity(t, b, &seq, "did:plc:zstdquery", 1)
 
@@ -627,7 +636,7 @@ func TestHandler_ZstdSocketEncodingHeader_DeliversDictCompressedFrames(t *testin
 	}
 	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "test done") }()
 
-	time.Sleep(50 * time.Millisecond)
+	waitForTailBlocked(t, b)
 	var seq uint64
 	publishIdentity(t, b, &seq, "did:plc:zstdheader", 1)
 
@@ -738,7 +747,7 @@ func TestHandler_NegotiatesCompression_WhenClientOffers(t *testing.T) {
 
 	// Compression is transparent on the wire: a compressed frame must
 	// still decode to the same JSON the uncompressed path produces.
-	time.Sleep(50 * time.Millisecond)
+	waitForTailBlocked(t, b)
 	var seq uint64
 	publishIdentity(t, b, &seq, "did:plc:compressed", 1)
 	frame := readOneFrame(t, ctx, conn)
@@ -783,7 +792,7 @@ func TestHandler_NoCompression_WhenClientDoesNotOffer(t *testing.T) {
 	require.Empty(t, resp.Header.Get("Sec-WebSocket-Extensions"),
 		"no compression extension should be negotiated when the client does not offer one")
 
-	time.Sleep(50 * time.Millisecond)
+	waitForTailBlocked(t, b)
 	var seq uint64
 	publishIdentity(t, b, &seq, "did:plc:plain", 1)
 	frame := readOneFrame(t, ctx, conn)
@@ -816,7 +825,7 @@ func TestHandler_Filter_WantedCollections_DeliversMatching(t *testing.T) {
 	}
 	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "test done") }()
 
-	time.Sleep(50 * time.Millisecond)
+	waitForTailBlocked(t, b)
 
 	// Build a record-bearing commit. Encoder needs DAG-CBOR Payload + a CID;
 	// the simplest valid CBOR is an empty map: 0xa0 = empty map.
@@ -863,7 +872,7 @@ func TestHandler_Filter_WantedCollections_TopLevelPrefix(t *testing.T) {
 		defer func() { _ = resp.Body.Close() }()
 	}
 	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "test done") }()
-	time.Sleep(50 * time.Millisecond)
+	waitForTailBlocked(t, b)
 
 	var seq uint64
 	publishCommit(t, b, &seq, "did:plc:abc", "com.example.foo", 1)       // outside prefix
@@ -907,7 +916,7 @@ func TestHandler_Filter_WantedCollections_PrefixMatch(t *testing.T) {
 		defer func() { _ = resp.Body.Close() }()
 	}
 	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "test done") }()
-	time.Sleep(50 * time.Millisecond)
+	waitForTailBlocked(t, b)
 
 	var seq uint64
 	publishCommit(t, b, &seq, "did:plc:abc", "app.bsky.feed.post", 1)
@@ -946,7 +955,7 @@ func TestHandler_Filter_WantedDIDs_DeliversMatching(t *testing.T) {
 		defer func() { _ = resp.Body.Close() }()
 	}
 	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "test done") }()
-	time.Sleep(50 * time.Millisecond)
+	waitForTailBlocked(t, b)
 
 	var seq uint64
 	publishCommit(t, b, &seq, "did:plc:other", "app.bsky.feed.post", 1)
@@ -983,7 +992,7 @@ func TestHandler_Filter_IdentityBypassesCollectionFilter(t *testing.T) {
 		defer func() { _ = resp.Body.Close() }()
 	}
 	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "test done") }()
-	time.Sleep(50 * time.Millisecond)
+	waitForTailBlocked(t, b)
 
 	var seq uint64
 	publishIdentity(t, b, &seq, "did:plc:any", 1)
@@ -1019,7 +1028,7 @@ func TestHandler_Filter_IdentityRespectsDIDFilter(t *testing.T) {
 		defer func() { _ = resp.Body.Close() }()
 	}
 	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "test done") }()
-	time.Sleep(50 * time.Millisecond)
+	waitForTailBlocked(t, b)
 
 	var seq uint64
 	publishIdentity(t, b, &seq, "did:plc:other", 1)
@@ -1056,7 +1065,7 @@ func TestHandler_Filter_MaxMessageSize_DropsOversize(t *testing.T) {
 		defer func() { _ = resp.Body.Close() }()
 	}
 	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "test done") }()
-	time.Sleep(50 * time.Millisecond)
+	waitForTailBlocked(t, b)
 
 	// Identity events are tiny; one should fit. Use them as the
 	// "delivered" half of this test rather than constructing oversize
@@ -1151,7 +1160,7 @@ func TestHandler_OptionsUpdate_ChangesFilter(t *testing.T) {
 		defer func() { _ = resp.Body.Close() }()
 	}
 	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "test done") }()
-	time.Sleep(50 * time.Millisecond)
+	waitForTailBlocked(t, b)
 
 	// Narrow to likes only.
 	update := SubscriberSourcedMessage{
@@ -1163,7 +1172,7 @@ func TestHandler_OptionsUpdate_ChangesFilter(t *testing.T) {
 	require.NoError(t, conn.Write(ctx, websocket.MessageText, jsonMust(t, update)))
 
 	// Give the reader goroutine a moment to apply the update.
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 
 	var seq uint64
 	publishCommit(t, b, &seq, "did:plc:abc", "app.bsky.feed.post", 1)
@@ -1202,7 +1211,7 @@ func TestHandler_OptionsUpdate_InvalidPayloadDisconnects(t *testing.T) {
 		defer func() { _ = resp.Body.Close() }()
 	}
 	defer func() { _ = conn.Close(websocket.StatusInternalError, "test done") }()
-	time.Sleep(50 * time.Millisecond)
+	waitForTailBlocked(t, b)
 
 	// Send malformed JSON envelope.
 	require.NoError(t, conn.Write(ctx, websocket.MessageText, []byte("not json")))
@@ -1239,7 +1248,7 @@ func TestHandler_OptionsUpdate_BadNSIDDisconnects(t *testing.T) {
 		defer func() { _ = resp.Body.Close() }()
 	}
 	defer func() { _ = conn.Close(websocket.StatusInternalError, "test done") }()
-	time.Sleep(50 * time.Millisecond)
+	waitForTailBlocked(t, b)
 
 	update := SubscriberSourcedMessage{
 		Type: SubMessageTypeOptionsUpdate,
@@ -1285,7 +1294,7 @@ func TestHandler_OptionsUpdate_OversizePayload(t *testing.T) {
 	// the application path observes as a Read error and counts via
 	// the optionsUpdateErrorReasonOversize metric label.
 	defer func() { _ = conn.Close(websocket.StatusInternalError, "test done") }()
-	time.Sleep(50 * time.Millisecond)
+	waitForTailBlocked(t, b)
 
 	// Send a payload just over MaxSubscriberMessageBytes.
 	big := make([]byte, MaxSubscriberMessageBytes+1)
@@ -1325,7 +1334,7 @@ func TestHandler_OptionsUpdate_UnknownTypeIgnored(t *testing.T) {
 		defer func() { _ = resp.Body.Close() }()
 	}
 	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "test done") }()
-	time.Sleep(50 * time.Millisecond)
+	waitForTailBlocked(t, b)
 
 	// V1 PARITY: unknown message types are logged and ignored, not fatal.
 	unknown := SubscriberSourcedMessage{
@@ -1335,7 +1344,7 @@ func TestHandler_OptionsUpdate_UnknownTypeIgnored(t *testing.T) {
 	require.NoError(t, conn.Write(ctx, websocket.MessageText, jsonMust(t, unknown)))
 
 	// Subsequent events must still flow.
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 	var seq uint64
 	publishIdentity(t, b, &seq, "did:plc:still-alive", 1)
 	frame := readOneFrame(t, ctx, conn)
@@ -1373,7 +1382,7 @@ func TestHandler_RequireHello_BlocksUntilOptionsUpdate(t *testing.T) {
 
 	// Give the handler time to start the reader goroutine but NOT
 	// time to subscribe (it shouldn't subscribe until hello).
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 
 	// Append a matching event. The subscriber loop hasn't started yet (it
 	// waits for hello), so it will begin reading at the live tip — which is
@@ -1385,7 +1394,7 @@ func TestHandler_RequireHello_BlocksUntilOptionsUpdate(t *testing.T) {
 	// Wait long enough to ensure that IF the event were going to be
 	// delivered, it would have been (but it won't be, because we
 	// haven't sent hello yet).
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 
 	// Send the hello.
 	hello := SubscriberSourcedMessage{
@@ -1395,7 +1404,7 @@ func TestHandler_RequireHello_BlocksUntilOptionsUpdate(t *testing.T) {
 	require.NoError(t, conn.Write(ctx, websocket.MessageText, jsonMust(t, hello)))
 
 	// Give the handler time to subscribe.
-	time.Sleep(50 * time.Millisecond)
+	waitForTailBlocked(t, b)
 
 	// Publish a fresh event AFTER hello. Only this one should arrive.
 	publishIdentity(t, b, &seq, "did:plc:post-hello", 2)
@@ -1447,7 +1456,7 @@ func TestHandler_RequireHello_FilterFromHelloApplies(t *testing.T) {
 	require.NoError(t, conn.Write(ctx, websocket.MessageText, jsonMust(t, hello)))
 
 	// Give the handler time to apply the filter and Subscribe.
-	time.Sleep(50 * time.Millisecond)
+	waitForTailBlocked(t, b)
 
 	// Publish an event that the filter should drop, then one it should
 	// pass. The reader can only see the second one if the filter was
@@ -1576,7 +1585,7 @@ func TestHandler_RequireHello_FalseHasNoEffect(t *testing.T) {
 			defer func() { _ = conn.Close(websocket.StatusNormalClosure, "test done") }()
 
 			// Wait for the handler to register the subscriber.
-			time.Sleep(50 * time.Millisecond)
+			waitForTailBlocked(t, b)
 
 			// No hello sent. Publish and expect immediate delivery.
 			var seq uint64
@@ -1662,7 +1671,7 @@ func TestHandler_RequireHello_NoLeakOnClientDisconnect(t *testing.T) {
 
 	// Let the handler get into its hello wait. The reader goroutine
 	// is running; the writer-side serve() body is blocked on helloCh.
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 
 	// Client closes without sending hello. The handler's reader goroutine
 	// observes the read error, defer cancel()s the connection context,
@@ -1716,8 +1725,8 @@ func TestHandler_RequireHello_MultipleUpdatesDoNotPanic(t *testing.T) {
 	// And a third, for good measure.
 	require.NoError(t, conn.Write(ctx, websocket.MessageText, helloBytes))
 
-	// Give the handler time to process all three and Subscribe.
-	time.Sleep(100 * time.Millisecond)
+	// Wait for the handler to process the hellos and subscribe.
+	waitForTailBlocked(t, b)
 
 	// Confirm normal flow works after the chatty start.
 	var seq uint64

--- a/internal/subscribe/tail.go
+++ b/internal/subscribe/tail.go
@@ -41,6 +41,7 @@ type Tail struct {
 	mu      sync.Mutex
 	ring    *hotRing
 	notify  chan struct{} // closed + replaced on each Append to wake tip waiters
+	blocked chan uint64   // nonblocking test/diagnostic signal when a reader parks at the tip
 	cold    coldReader
 	nextSeq func() uint64
 	logger  *slog.Logger
@@ -98,6 +99,7 @@ func newTail(cfg tailConfig) *Tail {
 	return &Tail{
 		ring:    newHotRing(cfg.hotBytes),
 		notify:  make(chan struct{}),
+		blocked: make(chan uint64, 1024),
 		cold:    cfg.cold,
 		nextSeq: cfg.nextSeq,
 		logger:  cfg.logger,
@@ -201,6 +203,10 @@ func (t *Tail) ReadFrom(ctx context.Context, cursor uint64, max int) ([]*Entry, 
 			return t.cold(ctx, cursor, max)
 		}
 
+		select {
+		case t.blocked <- cursor:
+		default:
+		}
 		select {
 		case <-ctx.Done():
 			return nil, cursor, ctx.Err()

--- a/segment/block_swarm_test.go
+++ b/segment/block_swarm_test.go
@@ -50,7 +50,7 @@ func (f swarmFlags) any() bool {
 func TestSwarm(t *testing.T) {
 	t.Parallel()
 
-	iterations := 50
+	iterations := 20
 	if !testing.Short() {
 		iterations = 1000
 	}

--- a/segment/block_test.go
+++ b/segment/block_test.go
@@ -414,7 +414,11 @@ func randBytes(r *rand.Rand, n int) []byte {
 func TestEncodeBlockRoundtripProperty(t *testing.T) {
 	t.Parallel()
 
-	cfg := &quick.Config{MaxCount: 200}
+	maxCount := 100
+	if !testing.Short() {
+		maxCount = 200
+	}
+	cfg := &quick.Config{MaxCount: maxCount}
 
 	prop := func(seed int64, n uint16) bool {
 		// Map n into [1, 256] for fast tests. The swarm test covers


### PR DESCRIPTION
## Summary

- make short-mode oracle use a smaller fast lifecycle preset unless an explicit oracle mode is set
- let the oracle harness use a shorter overlay rebuild interval while keeping the production default unchanged
- replace avoidable subscribe registration sleeps with a deterministic tail-blocked signal and reduce oversized short-mode simulator/segment/burst workloads

## Verification

- just test ./internal/oracle
- just test ./internal/subscribe
- just test ./internal/simulator/world
- just test ./segment
- just test

Closes #75