### PR TITLE
backfill: treat upstream "NotFound: Repo not found" as a missing repo

### DIFF
--- a/internal/ingest/backfill/diagnostics.go
+++ b/internal/ingest/backfill/diagnostics.go
@@ -30,6 +30,13 @@ const (
 var (
 	http429ErrorRE = regexp.MustCompile(`(?i)\bhttp\s+429\b`)
 	http5xxErrorRE = regexp.MustCompile(`(?i)\bhttp\s+5[0-9][0-9]\b`)
+
+	// repoNotFoundMessageRE matches the "repo not found" message used by
+	// upstreams that report a generic "NotFound" error name instead of
+	// the canonical RepoNotFound lexicon error. The message is the only
+	// thing distinguishing it from other generic NotFound responses
+	// (e.g. a missing record or blob), so we gate on it.
+	repoNotFoundMessageRE = regexp.MustCompile(`(?i)\brepo not found\b`)
 )
 
 func normalizeHandleIndexKey(handle string) ([]byte, bool) {
@@ -225,9 +232,24 @@ func classifyBackfillError(err error) ErrorClass {
 	}
 }
 
+// isRepoNotFoundError reports whether err is the terminal "this repo
+// does not exist" signal from com.atproto.sync.getRepo. The canonical
+// lexicon error name is RepoNotFound, but production bsky.network hosts
+// report it as a generic "NotFound" name with a "Repo not found"
+// message instead. Both mean the same thing — there is nothing to
+// download and never will be — so we must not retry or count either as
+// a failed host. The generic "NotFound" name is gated on the message so
+// an unrelated NotFound (a missing record or blob) can't be mistaken
+// for a missing repo.
 func isRepoNotFoundError(err error) bool {
 	var xerr *xrpc.Error
-	return errors.As(err, &xerr) && xerr.Name == "RepoNotFound"
+	if !errors.As(err, &xerr) {
+		return false
+	}
+	if xerr.Name == "RepoNotFound" {
+		return true
+	}
+	return xerr.Name == "NotFound" && repoNotFoundMessageRE.MatchString(xerr.Message)
 }
 
 // isRepoUnavailableError reports whether err is a terminal "the account

--- a/internal/ingest/backfill/diagnostics_test.go
+++ b/internal/ingest/backfill/diagnostics_test.go
@@ -65,6 +65,25 @@ func TestIsRepoNotFoundError(t *testing.T) {
 	require.True(t, isRepoNotFoundError(fmt.Errorf("wrapped: %w", repoNotFound)))
 	require.False(t, shouldLogBackfillError(repoNotFound))
 
+	// Production bsky.network hosts report a missing repo with a generic
+	// "NotFound" name and a "Repo not found" message rather than the
+	// canonical RepoNotFound lexicon error. This must be treated as a
+	// missing repo too, otherwise these get retried and counted as
+	// failed hosts.
+	genericNotFound := &xrpc.Error{
+		StatusCode: 400,
+		Name:       "NotFound",
+		Message:    "Repo not found",
+	}
+	require.True(t, isRepoNotFoundError(genericNotFound))
+	require.True(t, isRepoNotFoundError(fmt.Errorf("wrapped: %w", genericNotFound)))
+	require.False(t, shouldLogBackfillError(genericNotFound))
+
+	// A generic NotFound for something other than a repo (a missing
+	// record or blob) must not be mistaken for a missing repo.
+	require.False(t, isRepoNotFoundError(&xrpc.Error{StatusCode: 400, Name: "NotFound", Message: "Could not find record"}))
+	require.False(t, isRepoNotFoundError(&xrpc.Error{StatusCode: 400, Name: "NotFound"}))
+
 	require.False(t, isRepoNotFoundError(&xrpc.Error{StatusCode: 400, Name: "InvalidRequest"}))
 	require.False(t, isRepoNotFoundError(errors.New("xrpc 400 RepoNotFound: text only")))
 	require.True(t, shouldLogBackfillError(&xrpc.Error{StatusCode: 400, Name: "InvalidRequest"}))


### PR DESCRIPTION
## What

During a live backfill we saw large volumes of `unknown xrpc 400 NotFound: Repo not found` counted as failed hosts and retried. That status is not a real failure — the repo is taken down, the account was deactivated/deleted, or it never existed.

`isRepoNotFoundError` (`internal/ingest/backfill/diagnostics.go`) only matched the canonical lexicon error name `RepoNotFound` (what the open-source PDS returns). Production `*.host.bsky.network` hosts instead return a non-canonical `xrpc.Error{StatusCode: 400, Name: "NotFound", Message: "Repo not found"}`, which missed the terminal-state checks, fell through to the generic `OnFail` path, was classified as `ErrorClassUnknown`, counted via `incFailed()`, and retried.

## Change

- `isRepoNotFoundError` now also matches `Name == "NotFound"` when the message confirms a missing repo, gated by a `repo not found` regex so an unrelated generic `NotFound` (missing record/blob) is not misclassified.
- These now route to terminal `StatusComplete` — not retried, not counted as failed — same as canonical `RepoNotFound`.
- Added unit coverage for the production variant, the wrapped form, and negative cases. Full `./internal/ingest/backfill` suite and `go vet` pass.

## Notes

The same hosts may also send non-canonical names for the *unavailable* set (deactivated/suspended/takendown). I did not widen `isRepoUnavailableError` speculatively; see the issue for the follow-up tell.

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)