### PR TITLE
oracle: bisect served CheckCompacted failures into a disk-vs-serving verdict

### DIFF
--- a/internal/oracle/bisect.go
+++ b/internal/oracle/bisect.go
@@ -1,0 +1,135 @@
+package oracle
+
+import "fmt"
+
+// CompactedFailureVerdict classifies WHY a served /subscribe replay tripped
+// CheckCompacted, by re-running the identical contract check against the
+// on-disk segments at the same watermark.
+//
+// The served replay and the on-disk segments are two independent observation
+// surfaces of the same compaction contract (docs/README.md §3.3). When the
+// served surface reports a superseded survivor, the on-disk surface tells us
+// which side is actually wrong:
+//
+//   - on-disk ALSO violates  -> Jetstream physically persisted a superseded
+//     row: a durable storage/compaction defect (highest severity).
+//   - on-disk is CLEAN       -> the bytes are correct; the violation is a
+//     serving-path artifact, e.g. a long /subscribe replay reading a
+//     pre-compaction prefix and a post-compaction suffix across many
+//     un-pinned cold batches. This points at the live-tail-transport misuse
+//     for sealed history tracked in #77, not a storage bug.
+//
+// A clean on-disk result is only trustworthy when no compaction pass mutated
+// the segment directory during the scan: a rename mid-scan can hide or
+// fabricate rows, so a clean-but-raced scan is reported INCONCLUSIVE rather
+// than SERVING. A disk VIOLATION, by contrast, is durable regardless of a
+// racing pass, because a pass can only remove rows (segment.Rewrite is
+// strictly subtractive), so a surviving superseded row is real.
+type CompactedFailureVerdict struct {
+	// Verdict is the classification.
+	Verdict Verdict
+	// ServedErr is the original served-replay CheckCompacted failure that
+	// triggered the bisection. Always non-nil.
+	ServedErr error
+	// DiskErr is the result of CheckCompacted over the on-disk segments at
+	// the same watermark. nil means the durable segments satisfy the
+	// contract.
+	DiskErr error
+	// CompactionRacedScan is true when one or more compaction passes
+	// completed while the on-disk scan was running, so a clean DiskErr is
+	// not a coherent point-in-time snapshot.
+	CompactionRacedScan bool
+	// Watermark is the compaction watermark both checks were run at.
+	Watermark uint64
+}
+
+// Verdict is the bisection outcome.
+type Verdict string
+
+const (
+	// VerdictDurableDefect: the on-disk segments violate the compaction
+	// contract. Jetstream persisted wrong bytes. Highest severity.
+	VerdictDurableDefect Verdict = "DURABLE_DEFECT"
+	// VerdictServingDefect: on-disk is clean and the scan was not raced, so
+	// the violation lives only in the served replay surface (serving/transport).
+	VerdictServingDefect Verdict = "SERVING_DEFECT"
+	// VerdictInconclusive: on-disk is clean but a compaction pass raced the
+	// scan, so the clean result cannot be trusted to rule out a durable defect.
+	VerdictInconclusive Verdict = "INCONCLUSIVE"
+)
+
+// ClassifyCompactedFailure bisects a served-replay CheckCompacted failure.
+// servedErr MUST be the non-nil error returned by CheckCompacted over the
+// served replay; disk is the on-disk segment stream observed at the same
+// watermark; passesDuringScan is the number of compaction passes that
+// completed while the on-disk scan ran (0 means the scan was not raced).
+//
+// PRECONDITION on watermark capture: watermark MUST be captured no later than
+// the scan's first segment read. The DURABLE verdict's soundness under a race
+// rests on it. The compactor commits a chunk's rewrites to disk before it
+// advances the committed watermark (orchestrator applyCompactionChunk then
+// saveCompactionWatermark), so "watermark >= S" implies the rewrite that drops
+// S already renamed into place. With watermark captured first, a survivor at
+// seq S <= watermark seen on disk therefore provably persisted past its
+// compaction deadline -> a real durable defect, and a later racing pass can
+// only drop more rows, never resurrect S. If a caller instead captured the
+// watermark AFTER the scan, a row legitimately present at the read-time
+// watermark but dropped by a pass that then advanced the watermark past S
+// could be mislabeled DURABLE_DEFECT -- so don't.
+//
+// It panics if servedErr is nil: the bisection is only meaningful after the
+// served check has already failed, and a nil error would yield a misleadingly
+// clean verdict.
+func ClassifyCompactedFailure(servedErr error, disk []ObservedEvent, watermark uint64, passesDuringScan int) CompactedFailureVerdict {
+	if servedErr == nil {
+		panic("oracle: ClassifyCompactedFailure called with nil servedErr; bisection only runs after the served check fails")
+	}
+
+	v := CompactedFailureVerdict{
+		ServedErr:           servedErr,
+		DiskErr:             CheckCompacted(disk, watermark),
+		CompactionRacedScan: passesDuringScan > 0,
+		Watermark:           watermark,
+	}
+
+	switch {
+	case v.DiskErr != nil:
+		// A surviving superseded row on disk is real even if the scan was
+		// raced: compaction only ever removes rows.
+		v.Verdict = VerdictDurableDefect
+	case v.CompactionRacedScan:
+		// Clean on disk, but the scan was not isolated from a concurrent
+		// rewrite, so we cannot trust "clean" to mean "no durable defect".
+		v.Verdict = VerdictInconclusive
+	default:
+		v.Verdict = VerdictServingDefect
+	}
+	return v
+}
+
+// Err renders the verdict as a single diagnostic error suitable for a test
+// failure message. It always returns a non-nil error: ClassifyCompactedFailure
+// is only ever constructed from a real served failure.
+func (v CompactedFailureVerdict) Err() error {
+	switch v.Verdict {
+	case VerdictDurableDefect:
+		return fmt.Errorf("compaction bisection: %s at watermark=%d: on-disk segments ALSO violate the compaction contract -> Jetstream persisted a superseded row (storage/compaction defect, NOT a serving artifact). served=[%w] disk=[%w]",
+			v.Verdict, v.Watermark, v.ServedErr, v.DiskErr)
+	case VerdictServingDefect:
+		return fmt.Errorf("compaction bisection: %s at watermark=%d: on-disk segments are clean but the served /subscribe replay surfaced a superseded row -> serving/transport inconsistency (e.g. un-pinned multi-batch cold replay of sealed history; see #77), NOT a storage defect. served=[%w]",
+			v.Verdict, v.Watermark, v.ServedErr)
+	case VerdictInconclusive:
+		return fmt.Errorf("compaction bisection: %s at watermark=%d: served replay surfaced a superseded row and on-disk segments are clean, BUT a compaction pass raced the on-disk scan so the clean result cannot rule out a durable defect. Re-run with the compaction trigger quiesced around the scan, or capture the on-disk segments under a paused compactor. served=[%w]",
+			v.Verdict, v.Watermark, v.ServedErr)
+	default:
+		return fmt.Errorf("compaction bisection: unknown verdict %q at watermark=%d: served=[%w] disk=[%s]",
+			v.Verdict, v.Watermark, v.ServedErr, errorString(v.DiskErr))
+	}
+}
+
+func errorString(err error) string {
+	if err == nil {
+		return "<nil>"
+	}
+	return err.Error()
+}

--- a/internal/oracle/bisect_test.go
+++ b/internal/oracle/bisect_test.go
@@ -1,0 +1,106 @@
+package oracle
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/bluesky-social/jetstream/segment"
+	"github.com/stretchr/testify/require"
+)
+
+// A served CheckCompacted failure whose on-disk segments ALSO violate the
+// compaction contract at the same watermark is a durable storage/compaction
+// defect: the bytes Jetstream persisted are wrong, independent of the serving
+// transport.
+func TestClassifyCompactedFailure_DiskAlsoViolates_DurableDefect(t *testing.T) {
+	t.Parallel()
+
+	// did:plc:a/c/r created at seq 1, deleted at seq 2; watermark 2 means
+	// compaction should have physically removed the create. It survived on
+	// disk -> durable defect.
+	disk := []ObservedEvent{
+		{Seq: 1, Kind: segment.KindCreate, DID: "did:plc:a", Collection: "c", Rkey: "r", Payload: []byte("old")},
+		{Seq: 2, Kind: segment.KindDelete, DID: "did:plc:a", Collection: "c", Rkey: "r"},
+	}
+	servedErr := errors.New("oracle: superseded record row survived: did=did:plc:a collection=c rkey=r seq=1 tombstone_seq=2")
+
+	v := ClassifyCompactedFailure(servedErr, disk, 2, 0)
+
+	require.Equal(t, VerdictDurableDefect, v.Verdict)
+	require.Error(t, v.DiskErr)
+	require.ErrorContains(t, v.DiskErr, "superseded record row survived")
+	require.False(t, v.CompactionRacedScan)
+	require.ErrorContains(t, v.Err(), "DURABLE")
+}
+
+// A served failure whose on-disk segments are CLEAN at the same watermark is a
+// serving-path inconsistency (a torn cross-batch /subscribe read), not a
+// storage bug. This is the outcome that points at the live-tail-transport
+// misuse tracked in #77.
+func TestClassifyCompactedFailure_DiskClean_ServingDefect(t *testing.T) {
+	t.Parallel()
+
+	// On disk the create is already gone (compaction removed it); only the
+	// retained delete tombstone remains. Disk is contract-clean at W=2.
+	disk := []ObservedEvent{
+		{Seq: 2, Kind: segment.KindDelete, DID: "did:plc:a", Collection: "c", Rkey: "r"},
+	}
+	servedErr := errors.New("oracle: superseded record row survived: did=did:plc:a collection=c rkey=r seq=1 tombstone_seq=2")
+
+	v := ClassifyCompactedFailure(servedErr, disk, 2, 0)
+
+	require.Equal(t, VerdictServingDefect, v.Verdict)
+	require.NoError(t, v.DiskErr)
+	require.False(t, v.CompactionRacedScan)
+	require.ErrorContains(t, v.Err(), "SERVING")
+}
+
+// When a compaction pass ran concurrently with the on-disk scan, the disk read
+// is not a coherent point-in-time snapshot: a clean disk result cannot be
+// trusted to mean "no durable defect" (a rename mid-scan can hide or fabricate
+// rows). The verdict must say so rather than silently asserting SERVING.
+func TestClassifyCompactedFailure_DiskClean_ButScanRaced_Inconclusive(t *testing.T) {
+	t.Parallel()
+
+	disk := []ObservedEvent{
+		{Seq: 2, Kind: segment.KindDelete, DID: "did:plc:a", Collection: "c", Rkey: "r"},
+	}
+	servedErr := errors.New("oracle: superseded record row survived: seq=1 tombstone_seq=2")
+
+	v := ClassifyCompactedFailure(servedErr, disk, 2, 1 /* passesDuringScan */)
+
+	require.Equal(t, VerdictInconclusive, v.Verdict)
+	require.True(t, v.CompactionRacedScan)
+	require.ErrorContains(t, v.Err(), "INCONCLUSIVE")
+}
+
+// A disk violation is a durable defect regardless of a racing pass: a pass can
+// only remove rows, so a surviving superseded row on disk is real even if the
+// scan was not perfectly isolated.
+func TestClassifyCompactedFailure_DiskViolates_ScanRaced_StillDurable(t *testing.T) {
+	t.Parallel()
+
+	disk := []ObservedEvent{
+		{Seq: 1, Kind: segment.KindCreate, DID: "did:plc:a", Collection: "c", Rkey: "r", Payload: []byte("old")},
+		{Seq: 2, Kind: segment.KindDelete, DID: "did:plc:a", Collection: "c", Rkey: "r"},
+	}
+	servedErr := errors.New("oracle: superseded record row survived: seq=1 tombstone_seq=2")
+
+	v := ClassifyCompactedFailure(servedErr, disk, 2, 3 /* passesDuringScan */)
+
+	require.Equal(t, VerdictDurableDefect, v.Verdict)
+	require.Error(t, v.DiskErr)
+	require.True(t, v.CompactionRacedScan)
+	require.ErrorContains(t, v.Err(), "DURABLE")
+}
+
+// The classifier must never be called with a nil served error; doing so is a
+// caller bug (the bisection only runs after the served check already failed).
+// Guard it loudly rather than returning a misleading clean verdict.
+func TestClassifyCompactedFailure_NilServedErr_Panics(t *testing.T) {
+	t.Parallel()
+
+	require.Panics(t, func() {
+		ClassifyCompactedFailure(nil, nil, 0, 0)
+	})
+}

--- a/internal/oracle/harness_test.go
+++ b/internal/oracle/harness_test.go
@@ -268,9 +268,9 @@ func TestOracle_DefaultLifecycle(t *testing.T) {
 		"steady compaction watermark did not advance: mode=%s seed=%d after_merge_watermark=%d steady_watermark=%d",
 		cfg.Mode, cfg.Seed, afterMergeCompaction.Watermark, steadyCompaction.Watermark)
 	served := collectSubscribeReplay(t, cfg, run, trace, publicURL, 0, steadyCompaction.Watermark)
-	require.NoErrorf(t, CheckCompacted(served, steadyCompaction.Watermark),
-		"served subscribe replay compacted check failed: mode=%s seed=%d watermark=%d",
-		cfg.Mode, cfg.Seed, steadyCompaction.Watermark)
+	if servedErr := CheckCompacted(served, steadyCompaction.Watermark); servedErr != nil {
+		bisectServedCompactedFailure(t, trace, dataDir, cfg, compaction, steadyCompaction.Watermark, servedErr)
+	}
 
 	// Exercise the overlay's DID-tombstone section inside the live overlay
 	// window. The earlier bootstrap account-delete and sync tombstones are
@@ -494,6 +494,45 @@ func totalIntMap(values map[string]int) int {
 		total += value
 	}
 	return total
+}
+
+// bisectServedCompactedFailure classifies a served /subscribe replay
+// CheckCompacted failure by re-running the identical check against the
+// on-disk segments at the SAME watermark, then fails with a self-classifying
+// verdict (DURABLE_DEFECT vs SERVING_DEFECT vs INCONCLUSIVE). It snapshots the
+// compaction-pass count around the on-disk scan so a pass that races the scan
+// downgrades a clean disk result to INCONCLUSIVE rather than asserting a
+// (possibly torn) clean read meant "no durable defect". See bisect.go.
+func bisectServedCompactedFailure(
+	t *testing.T,
+	trace *Trace,
+	dataDir string,
+	cfg Config,
+	compaction *compactionPassRecorder,
+	watermark uint64,
+	servedErr error,
+) {
+	t.Helper()
+
+	passesBefore := compaction.Count()
+	disk, err := ObserveSegments(dataDir)
+	require.NoErrorf(t, err, "bisect: observe on-disk segments mode=%s seed=%d watermark=%d", cfg.Mode, cfg.Seed, watermark)
+	disk = EventsSortedBySeq(disk)
+	passesDuringScan := compaction.Count() - passesBefore
+
+	v := ClassifyCompactedFailure(servedErr, disk, watermark, passesDuringScan)
+	recordTraceOrError(t, trace, "compacted_bisection", map[string]any{
+		"mode":               cfg.Mode,
+		"seed":               cfg.Seed,
+		"watermark":          watermark,
+		"verdict":            string(v.Verdict),
+		"served_err":         servedErr.Error(),
+		"disk_err":           traceErr(v.DiskErr),
+		"passes_during_scan": passesDuringScan,
+		"disk_event_count":   len(disk),
+	})
+	require.Failf(t, "served subscribe replay compacted check failed",
+		"mode=%s seed=%d: %v", cfg.Mode, cfg.Seed, v.Err())
 }
 
 func assertOracleMatches(t *testing.T, dataDir string, w *world.World, cfg Config, phase string) {

--- a/internal/oracle/subscribe_replay_test.go
+++ b/internal/oracle/subscribe_replay_test.go
@@ -118,9 +118,31 @@ func collectSubscribeReplay(t *testing.T, cfg Config, run *runtimeRun, trace *Tr
 					targetSeq, cfg.Mode, cfg.Seed, run.err)
 			default:
 			}
+			// The server closed the replay socket mid-stream while the
+			// runtime is still up. This is the SAME fragile observation
+			// point as the CheckCompacted failure (a long from-cursor-0
+			// cold replay of sealed history over the live-tail transport
+			// under heavy concurrent compaction/reconnect load), surfacing
+			// as a torn frame instead of a contract violation. Record where
+			// the replay died so the trace classifies it rather than
+			// leaving an opaque read error. See #77.
+			var lastSeq uint64
+			if len(out) > 0 {
+				lastSeq = out[len(out)-1].Seq
+			}
+			recordTraceOrError(t, trace, "subscribe_replay_read_error", map[string]any{
+				"cursor":      cursor,
+				"target_seq":  targetSeq,
+				"event_count": len(out),
+				"last_seq":    lastSeq,
+				"err":         err.Error(),
+			})
+			t.Fatalf("subscribe replay socket closed mid-stream at seq=%d of target_seq=%d (got %d events) "+
+				"while runtime is up: mode=%s seed=%d err=%v -- this is the live-tail transport serving "+
+				"sealed history (see #77), not a clean read",
+				lastSeq, targetSeq, len(out), cfg.Mode, cfg.Seed, err)
 		}
-		require.NoErrorf(t, err, "read subscribe replay target_seq=%d mode=%s seed=%d", targetSeq, cfg.Mode, cfg.Seed)
-		require.Equal(t, websocket.MessageText, typ, "subscribe replay must emit text frames")
+		require.Equalf(t, websocket.MessageText, typ, "subscribe replay must emit text frames mode=%s seed=%d", cfg.Mode, cfg.Seed)
 
 		var msg subscribeReplayEvent
 		require.NoErrorf(t, json.Unmarshal(body, &msg),


### PR DESCRIPTION
## What

When the served `/subscribe` replay trips `CheckCompacted` in the oracle lifecycle test, re-run the **identical** contract check against the **on-disk segments** at the **same watermark** and classify the failure rather than reporting an opaque "superseded record row survived":

- **`DURABLE_DEFECT`** — on-disk segments also violate the contract → Jetstream persisted wrong bytes (highest severity).
- **`SERVING_DEFECT`** — on-disk is clean → the violation lives only in the served replay surface (the live-tail transport serving sealed history; see #77/#91), not storage.
- **`INCONCLUSIVE`** — on-disk is clean but a compaction pass raced the on-disk scan, so the clean result cannot rule out a durable defect.

This is the "decisive experiment" from the #35 Test Reliability / Triage bucket: it tells us, on the next failure, whether the fix belongs in storage/compaction or in the serving/transport path.

## Why the verdict is asymmetric

A disk violation is durable even under a racing scan — `segment.Rewrite` is strictly subtractive, so a concurrent pass can only *remove* rows, never resurrect a superseded one. A *clean* disk read, by contrast, is only trustworthy when no pass renamed a segment mid-scan (a rename can hide or fabricate rows). So the harness snapshots the compaction-pass count around the on-disk scan and downgrades a clean-but-raced result to `INCONCLUSIVE`. The watermark-capture ordering precondition for the durable verdict is documented on `ClassifyCompactedFailure`.

## Also

While reproducing locally under `-race` (GOMAXPROCS=2), the same fragile observation point also surfaces as a mid-stream `unexpected EOF` (the server closing the long replay socket) instead of a contract violation. That read error is now classified too: it records a `subscribe_replay_read_error` trace event and fails with a message pointing at #77, instead of an opaque read error.

## Implementation notes

- `ClassifyCompactedFailure` is a **pure function** with unit tests; the harness wiring reuses the existing compaction-pass recorder and `ObserveSegments`, so there are **no production code changes** — this is test/diagnostic-only.
- The bisection only runs on the failure path; the green path (default-mode lifecycle that `ci.yml` runs) is unchanged and still passes.
- This does **not** quiesce the harness or mask the failure (per the crash-over-corruption directive); it still hard-fails, now with a self-classifying verdict.

## Testing

- `go test ./internal/oracle/ -run TestClassifyCompactedFailure` — 5 unit tests covering all three verdicts, the raced-scan asymmetry, and the nil-served-error guard.
- `gofmt`/`go vet` clean; default-mode `TestOracle_DefaultLifecycle` passes.
- Validated end-to-end under `-race` (GOMAXPROCS=2, seed 11221226989394939208): the new EOF classification fires with the #77-aware message, and the trace confirms the predicted ~6-pass compaction burst immediately before the failing replay.

Caveat: every local reproduction so far hit the EOF mode, so a live `DURABLE_DEFECT`-vs-`SERVING_DEFECT` verdict on the `CheckCompacted` path is **not yet captured** — that needs the trace-upload + `-race` CI lanes (or a harness tweak to keep the socket alive through the full replay). Tracked in #92.

Closes #92. Refs #35, #25, #77, #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
