### PR TITLE
backfill: index selected repo declared handles

### DIFF
--- a/internal/ingest/backfill/run.go
+++ b/internal/ingest/backfill/run.go
@@ -21,6 +21,7 @@ import (
 	"github.com/bluesky-social/jetstream/internal/store"
 	"github.com/jcalabro/atmos"
 	atmosbackfill "github.com/jcalabro/atmos/backfill"
+	atmosidentity "github.com/jcalabro/atmos/identity"
 	atmossync "github.com/jcalabro/atmos/sync"
 	"github.com/jcalabro/atmos/xrpc"
 	"github.com/jcalabro/gt"
@@ -87,6 +88,12 @@ type Config struct {
 	// The normal Store, Handler, retry, verification, and completion
 	// paths are still used; only discovery is replaced.
 	BackfillRepos []atmos.DID
+
+	// IdentityResolver resolves selected BackfillRepos DIDs so status
+	// diagnostics can persist declared handle and PDS metadata without
+	// walking listRepos. Required when BackfillRepos is non-empty; normal
+	// whole-network backfill does not use it.
+	IdentityResolver atmosidentity.Resolver
 
 	// MaxRetries, RetryBaseDelay, and RetryMaxDelay tune the engine's
 	// per-DID retry/backoff loop for transient getRepo failures. A zero
@@ -221,14 +228,15 @@ func Run(ctx context.Context, cfg Config) error {
 				"repos", len(cfg.BackfillRepos),
 			)
 			err := runSelectedRepos(runCtx, selectedReposConfig{
-				Repos:          cfg.BackfillRepos,
-				Store:          st,
-				Handler:        handler,
-				SyncClient:     sc,
-				Metrics:        cfg.Metrics,
-				MaxRetries:     cfg.MaxRetries,
-				RetryBaseDelay: cfg.RetryBaseDelay,
-				RetryMaxDelay:  cfg.RetryMaxDelay,
+				Repos:            cfg.BackfillRepos,
+				Store:            st,
+				Handler:          handler,
+				SyncClient:       sc,
+				IdentityResolver: cfg.IdentityResolver,
+				Metrics:          cfg.Metrics,
+				MaxRetries:       cfg.MaxRetries,
+				RetryBaseDelay:   cfg.RetryBaseDelay,
+				RetryMaxDelay:    cfg.RetryMaxDelay,
 				OnError: func(did atmos.DID, err error) {
 					if !shouldLogBackfillError(err) {
 						return
@@ -359,6 +367,9 @@ func (cfg Config) validate() error {
 	}
 	if cfg.BackfillBatchSize < 0 {
 		return fmt.Errorf("backfill: Config.BackfillBatchSize must be >= 0")
+	}
+	if len(cfg.BackfillRepos) > 0 && cfg.IdentityResolver == nil {
+		return fmt.Errorf("backfill: Config.IdentityResolver is required when Config.BackfillRepos is set")
 	}
 	if cfg.Logger == nil {
 		return fmt.Errorf("backfill: Config.Logger is required")

--- a/internal/ingest/backfill/run_test.go
+++ b/internal/ingest/backfill/run_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/jcalabro/atmos"
 	atmosbackfill "github.com/jcalabro/atmos/backfill"
 	"github.com/jcalabro/atmos/crypto"
+	atmosidentity "github.com/jcalabro/atmos/identity"
 	"github.com/jcalabro/atmos/mst"
 	atmosrepo "github.com/jcalabro/atmos/repo"
 	"github.com/stretchr/testify/require"
@@ -95,6 +96,20 @@ func TestRun_RejectsInvalidConfig(t *testing.T) {
 			},
 			errPart: "Config.Logger",
 		},
+		{
+			name: "missing IdentityResolver for selected repos",
+			build: func(t *testing.T) Config {
+				return Config{
+					Store:         &store.Store{},
+					Writer:        newWriter(t),
+					HTTPClient:    httpClient,
+					RelayURL:      "x",
+					Logger:        logger,
+					BackfillRepos: []atmos.DID{"did:plc:selected"},
+				}
+			},
+			errPart: "Config.IdentityResolver",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -110,6 +125,57 @@ func TestRun_RejectsInvalidConfig(t *testing.T) {
 type repoFixture struct {
 	did atmos.DID
 	car []byte
+}
+
+type stubIdentityResolver struct {
+	docs map[atmos.DID]*atmosidentity.DIDDocument
+	err  error
+}
+
+func (r *stubIdentityResolver) ResolveDID(_ context.Context, did atmos.DID) (*atmosidentity.DIDDocument, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	doc, ok := r.docs[did]
+	if !ok {
+		return nil, errors.New("identity: DID not found")
+	}
+	return doc, nil
+}
+
+func (r *stubIdentityResolver) ResolveHandle(_ context.Context, _ atmos.Handle) (atmos.DID, error) {
+	return "", errors.New("stubIdentityResolver: ResolveHandle not implemented")
+}
+
+func didDocumentForTest(did atmos.DID, handle string, pds string) *atmosidentity.DIDDocument {
+	return &atmosidentity.DIDDocument{
+		ID:          string(did),
+		AlsoKnownAs: []string{"at://" + handle},
+		VerificationMethod: []atmosidentity.VerificationMethod{{
+			ID:                 string(did) + "#atproto",
+			Type:               "Multikey",
+			Controller:         string(did),
+			PublicKeyMultibase: "zQ3shQo7n7VdGV9XEvjyXEFy3sCvi5R8VC2sXkqMfV3oRUDoY",
+		}},
+		Service: []atmosidentity.Service{{
+			ID:              "#atproto_pds",
+			Type:            "AtprotoPersonalDataServer",
+			ServiceEndpoint: pds,
+		}},
+	}
+}
+
+func selectedResolverForFixtures(fixtures map[atmos.DID]repoFixture, pds string) *stubIdentityResolver {
+	dids := make([]atmos.DID, 0, len(fixtures))
+	for did := range fixtures {
+		dids = append(dids, did)
+	}
+	slices.Sort(dids)
+	docs := make(map[atmos.DID]*atmosidentity.DIDDocument, len(dids))
+	for i, did := range dids {
+		docs[did] = didDocumentForTest(did, "selected-"+string(rune('a'+i))+".test", pds)
+	}
+	return &stubIdentityResolver{docs: docs}
 }
 
 // buildRepoFixture constructs a single-record repo for did, signs it
@@ -348,7 +414,7 @@ func (s *stubServer) eventIndex(event string, n int) int {
 // the integration entry point for our run_test.go.
 func runWithStub(t *testing.T, ctx context.Context, srv *stubServer, db *store.Store) error {
 	t.Helper()
-	return runWithStubResolverAndRepos(t, ctx, srv, db, nil)
+	return runWithStubResolverAndRepos(t, ctx, srv, db, nil, nil)
 }
 
 func runWithStubRepos(
@@ -359,7 +425,7 @@ func runWithStubRepos(
 	repos []atmos.DID,
 ) error {
 	t.Helper()
-	return runWithStubResolverAndRepos(t, ctx, srv, db, repos)
+	return runWithStubResolverAndRepos(t, ctx, srv, db, repos, selectedResolverForFixtures(srv.fixtures, srv.srv.URL))
 }
 
 func runWithStubResolverAndRepos(
@@ -368,6 +434,7 @@ func runWithStubResolverAndRepos(
 	srv *stubServer,
 	db *store.Store,
 	repos []atmos.DID,
+	resolver atmosidentity.Resolver,
 ) error {
 	t.Helper()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -383,12 +450,13 @@ func runWithStubResolverAndRepos(
 	t.Cleanup(func() { _ = w.Close() })
 
 	cfg := Config{
-		Store:         db,
-		HTTPClient:    &http.Client{Timeout: 5 * time.Second},
-		Writer:        w,
-		RelayURL:      srv.srv.URL,
-		Logger:        logger,
-		BackfillRepos: repos,
+		Store:            db,
+		HTTPClient:       &http.Client{Timeout: 5 * time.Second},
+		Writer:           w,
+		RelayURL:         srv.srv.URL,
+		Logger:           logger,
+		BackfillRepos:    repos,
+		IdentityResolver: resolver,
 	}
 	return Run(ctx, cfg)
 }
@@ -651,6 +719,71 @@ func TestRun_BackfillReposDownloadsSelectedDIDsWithoutListRepos(t *testing.T) {
 	require.Empty(t, cursor, "selected backfill must clear stale merge discovery state")
 }
 
+func TestRun_BackfillReposIndexesDeclaredHandle(t *testing.T) {
+	t.Parallel()
+
+	did := atmos.DID("did:plc:selectedhandle")
+	fixtures := map[atmos.DID]repoFixture{did: buildRepoFixture(t, did)}
+	srv := newStubServer(t, fixtures)
+	resolver := &stubIdentityResolver{docs: map[atmos.DID]*atmosidentity.DIDDocument{
+		did: didDocumentForTest(did, "Alice.Example.COM", "https://pds.example.com"),
+	}}
+
+	db, err := store.Open(t.TempDir(), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	require.NoError(t, runWithStubResolverAndRepos(t, t.Context(), srv, db, []atmos.DID{did}, resolver))
+
+	got, ok, err := lookupDIDByHandle(db, "alice.example.com")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, did, got)
+
+	rs, ok, err := LoadRepoStatus(db, did)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "alice.example.com", rs.Handle)
+	require.Equal(t, "https://pds.example.com", rs.PDS)
+}
+
+func TestRun_BackfillReposRepairsCompletedDeclaredHandleMetadata(t *testing.T) {
+	t.Parallel()
+
+	did := atmos.DID("did:plc:selectedrepair")
+	fixtures := map[atmos.DID]repoFixture{did: buildRepoFixture(t, did)}
+	srv := newStubServer(t, fixtures)
+	resolver := &stubIdentityResolver{docs: map[atmos.DID]*atmosidentity.DIDDocument{
+		did: didDocumentForTest(did, "repair.test", "https://repair-pds.example.com"),
+	}}
+
+	db, err := store.Open(t.TempDir(), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	bf := NewStore(db, nil)
+	require.NoError(t, bf.putRepoStatus(did, &RepoStatus{
+		Backfill: RepoBackfillStatus{Status: StatusComplete, Rev: "rev-complete"},
+		Active:   true,
+		Host:     "old-pds.example.com",
+	}))
+
+	require.NoError(t, runWithStubResolverAndRepos(t, t.Context(), srv, db, []atmos.DID{did}, resolver))
+	require.Equal(t, int64(0), srv.getRepoHit.Load(), "complete selected DID must not be redownloaded while repairing metadata")
+
+	got, ok, err := lookupDIDByHandle(db, "repair.test")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, did, got)
+
+	rs, ok, err := LoadRepoStatus(db, did)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "repair.test", rs.Handle)
+	require.Equal(t, "https://repair-pds.example.com", rs.PDS)
+	require.Equal(t, "rev-complete", rs.Backfill.Rev)
+}
+
 func TestRun_BackfillReposRetriesTransientGetRepoFailure(t *testing.T) {
 	t.Parallel()
 
@@ -676,14 +809,15 @@ func TestRun_BackfillReposRetriesTransientGetRepoFailure(t *testing.T) {
 	t.Cleanup(func() { _ = w.Close() })
 
 	require.NoError(t, Run(t.Context(), Config{
-		Store:          db,
-		HTTPClient:     &http.Client{Timeout: 5 * time.Second},
-		Writer:         w,
-		RelayURL:       srv.srv.URL,
-		Logger:         logger,
-		BackfillRepos:  []atmos.DID{did},
-		RetryBaseDelay: time.Millisecond,
-		RetryMaxDelay:  10 * time.Millisecond,
+		Store:            db,
+		HTTPClient:       &http.Client{Timeout: 5 * time.Second},
+		Writer:           w,
+		RelayURL:         srv.srv.URL,
+		Logger:           logger,
+		BackfillRepos:    []atmos.DID{did},
+		IdentityResolver: selectedResolverForFixtures(fixtures, srv.srv.URL),
+		RetryBaseDelay:   time.Millisecond,
+		RetryMaxDelay:    10 * time.Millisecond,
 	}))
 
 	got, err := NewStore(db, nil).Lookup(t.Context(), did)

--- a/internal/ingest/backfill/selected.go
+++ b/internal/ingest/backfill/selected.go
@@ -11,18 +11,20 @@ import (
 
 	"github.com/jcalabro/atmos"
 	atmosbackfill "github.com/jcalabro/atmos/backfill"
+	atmosidentity "github.com/jcalabro/atmos/identity"
 	atmosrepo "github.com/jcalabro/atmos/repo"
 	atmossync "github.com/jcalabro/atmos/sync"
 	"github.com/jcalabro/atmos/xrpc"
 )
 
 type selectedReposConfig struct {
-	Repos      []atmos.DID
-	Store      *Store
-	Handler    *SegmentHandler
-	SyncClient *atmossync.Client
-	Metrics    *Metrics
-	OnError    func(atmos.DID, error)
+	Repos            []atmos.DID
+	Store            *Store
+	Handler          *SegmentHandler
+	SyncClient       *atmossync.Client
+	IdentityResolver atmosidentity.Resolver
+	Metrics          *Metrics
+	OnError          func(atmos.DID, error)
 
 	MaxRetries     int
 	RetryBaseDelay time.Duration
@@ -74,11 +76,52 @@ func (r *selectedRunner) reconcileAndProcess(ctx context.Context, did atmos.DID)
 		}
 	}
 
+	if err := r.recordIdentityMetadata(ctx, did); err != nil {
+		return err
+	}
 	if rec.State == atmosbackfill.StateComplete {
 		return nil
 	}
 	r.processRepo(ctx, did)
 	return nil
+}
+
+func (r *selectedRunner) recordIdentityMetadata(ctx context.Context, did atmos.DID) error {
+	doc, err := r.cfg.IdentityResolver.ResolveDID(ctx, did)
+	if err != nil {
+		r.reportIdentityMetadataError(did, fmt.Errorf("backfill: resolve selected repo identity: %w", err))
+		return nil
+	}
+	ident, err := atmosidentity.IdentityFromDocument(doc)
+	if err != nil {
+		r.reportIdentityMetadataError(did, fmt.Errorf("backfill: parse selected repo identity: %w", err))
+		return nil
+	}
+
+	pds := ident.PDSEndpoint()
+	host, ok := normalizeHostBucket(pds)
+	if !ok {
+		host = HostBucketInvalidPDS
+	}
+
+	handle := ""
+	if ident.Handle != "" && ident.Handle != atmos.HandleInvalid {
+		handle = string(ident.Handle)
+	}
+	if err := r.cfg.Store.recordIdentityResolution(ctx, did, IdentityResolution{
+		Handle: handle,
+		PDS:    pds,
+		Host:   host,
+	}); err != nil {
+		return fmt.Errorf("selected repo backfill: record identity metadata %s: %w", did, err)
+	}
+	return nil
+}
+
+func (r *selectedRunner) reportIdentityMetadataError(did atmos.DID, err error) {
+	if r.cfg.OnError != nil {
+		r.cfg.OnError(did, err)
+	}
 }
 
 // processRepo mirrors the atmos engine's two-budget retry loop (see

--- a/internal/ingest/orchestrator/bootstrap.go
+++ b/internal/ingest/orchestrator/bootstrap.go
@@ -115,6 +115,7 @@ func (o *Orchestrator) runBootstrap(ctx context.Context) error {
 				BackfillWorkers:   o.cfg.BackfillWorkers,
 				BackfillBatchSize: o.cfg.BackfillBatchSize,
 				BackfillRepos:     o.cfg.BackfillRepos,
+				IdentityResolver:  o.cfg.Directory.Resolver,
 				RetryBaseDelay:    o.cfg.BackfillRetryBaseDelay,
 				AfterRepoComplete: o.cfg.AfterRepoComplete,
 				CrashInjector:     o.cfg.CrashInjector,


### PR DESCRIPTION
## Summary
- resolve selected backfill DIDs and persist declared handle/PDS metadata for status diagnostics
- pass the configured identity resolver into selected backfill mode
- add regression coverage for fresh selected backfill and repair of already-complete selected rows

## Verification
- reproduced before fix: account tab DID lookup showed `Backfill=complete`, while `handle=calabro.io` returned no local account metadata
- after fix: `just clean && just run-prod serve --backfill-repos=did:plc:4uz2445cjiw7w4nobfgnu35f` lets `handle=calabro.io` resolve on the account tab
- `just test ./...`
- `just lint`

Closes #135