### PR TITLE
status: resolve account handles on demand

### DIFF
--- a/internal/jetstreamd/runtime.go
+++ b/internal/jetstreamd/runtime.go
@@ -202,26 +202,6 @@ func Build(ctx context.Context, opts Options) (*Runtime, error) {
 	// returns 503, so the nil-pointer window is harmless.
 	var writerPtr atomic.Pointer[ingest.Writer]
 
-	statusCollector, err := status.New(status.Options{
-		Store:          metaStore,
-		DataDir:        opts.DataDir,
-		Manifest:       mft,
-		CursorLookback: opts.CursorLookback,
-	})
-	if err != nil {
-		return fail(fmt.Errorf("serve: build status collector: %w", err))
-	}
-
-	statusHandler, err := web.New(web.Options{
-		Snapshotter:                statusCollector,
-		RepoActions:                web.NewRepoActions(opts.DataDir, opts.RelayURL, newManifestSelector(mft), pendingEventsForDID(&writerPtr)),
-		DisableRepoActionRateLimit: opts.DisableRepoActionRateLimits,
-		Logger:                     processLogger,
-	})
-	if err != nil {
-		return fail(fmt.Errorf("serve: build status handler: %w", err))
-	}
-
 	// Verifier setup (shared across phases). The verifier itself is
 	// owned by the orchestrator's per-phase live consumers, but we
 	// construct it here because its async-error drain is a sibling
@@ -252,6 +232,27 @@ func Build(ctx context.Context, opts Options) (*Runtime, error) {
 		Resolver:               resolver,
 		Cache:                  identcache.New(metaStore, identcache.DefaultTTL),
 		SkipHandleVerification: true,
+	}
+
+	statusCollector, err := status.New(status.Options{
+		Store:            metaStore,
+		DataDir:          opts.DataDir,
+		Manifest:         mft,
+		CursorLookback:   opts.CursorLookback,
+		IdentityResolver: resolver,
+	})
+	if err != nil {
+		return fail(fmt.Errorf("serve: build status collector: %w", err))
+	}
+
+	statusHandler, err := web.New(web.Options{
+		Snapshotter:                statusCollector,
+		RepoActions:                web.NewRepoActions(opts.DataDir, opts.RelayURL, newManifestSelector(mft), pendingEventsForDID(&writerPtr)),
+		DisableRepoActionRateLimit: opts.DisableRepoActionRateLimits,
+		Logger:                     processLogger,
+	})
+	if err != nil {
+		return fail(fmt.Errorf("serve: build status handler: %w", err))
 	}
 
 	stateStore := syncstate.New(metaStore)

--- a/internal/status/collect.go
+++ b/internal/status/collect.go
@@ -22,6 +22,7 @@ import (
 	"github.com/bluesky-social/jetstream/segment"
 	"github.com/cockroachdb/pebble"
 	"github.com/jcalabro/atmos"
+	"github.com/jcalabro/atmos/identity"
 )
 
 // keyspacePrefixes lists the pebble prefixes the status page exposes
@@ -154,16 +155,25 @@ func normalizeRequest(req Request) Request {
 	default:
 		req.Tab = "summary"
 	}
+	req.Account = strings.TrimSpace(req.Account)
 	req.DID = strings.TrimSpace(req.DID)
 	req.Handle = strings.TrimSpace(req.Handle)
 	if req.Tab != "accounts" {
+		req.Account = ""
 		req.DID = ""
 		req.Handle = ""
 		return req
 	}
-	if req.DID != "" {
-		req.Handle = ""
+	if req.Account == "" {
+		switch {
+		case req.DID != "":
+			req.Account = req.DID
+		case req.Handle != "":
+			req.Account = req.Handle
+		}
 	}
+	req.DID = ""
+	req.Handle = ""
 	return req
 }
 
@@ -231,23 +241,27 @@ func hostRowFromBackfill(hs *backfill.HostStatus) HostRow {
 	return row
 }
 
-func collectAccount(s *store.Store, req Request) AccountLookup {
+func collectAccount(ctx context.Context, s *store.Store, resolver identity.Resolver, req Request) AccountLookup {
 	acct := AccountLookup{}
 	var did atmos.DID
 	var ok bool
 	var err error
 
-	switch {
-	case req.DID != "":
+	account := strings.TrimSpace(req.Account)
+	if account == "" {
+		return acct
+	}
+
+	if strings.HasPrefix(strings.ToLower(account), "did:") {
 		acct.QueryKind = "did"
-		acct.Query = req.DID
-		did, err = atmos.ParseDID(req.DID)
+		acct.Query = account
+		did, err = atmos.ParseDID(account)
 		if err != nil {
 			acct.Error = fmt.Sprintf("invalid DID: %v", err)
 			return acct
 		}
-	case req.Handle != "":
-		handle := strings.TrimPrefix(req.Handle, "@")
+	} else {
+		handle := strings.TrimPrefix(account, "@")
 		acct.QueryKind = "handle"
 		acct.Query = handle
 		parsed, err := atmos.ParseHandle(handle)
@@ -257,16 +271,22 @@ func collectAccount(s *store.Store, req Request) AccountLookup {
 		}
 		handle = string(parsed.Normalize())
 		acct.Query = handle
-		did, ok, err = backfill.LookupDIDByHandle(s, handle)
-		if err != nil {
-			acct.Error = err.Error()
-			return acct
+		if resolver != nil {
+			did, err = resolver.ResolveHandle(ctx, parsed.Normalize())
+			if err != nil {
+				acct.Error = fmt.Sprintf("resolve handle %q: %v", handle, err)
+				return acct
+			}
+		} else {
+			did, ok, err = backfill.LookupDIDByHandle(s, handle)
+			if err != nil {
+				acct.Error = err.Error()
+				return acct
+			}
+			if !ok {
+				return acct
+			}
 		}
-		if !ok {
-			return acct
-		}
-	default:
-		return acct
 	}
 
 	rs, found, err := backfill.LoadRepoStatus(s, did)
@@ -639,7 +659,7 @@ func buildForRequest(ctx context.Context, opts Options, startedAt time.Time, req
 		}
 		snap.Hosts = hosts
 	case "accounts":
-		snap.Account = collectAccount(opts.Store, req)
+		snap.Account = collectAccount(ctx, opts.Store, opts.IdentityResolver, req)
 	}
 
 	return snap, nil

--- a/internal/status/collect_test.go
+++ b/internal/status/collect_test.go
@@ -3,6 +3,7 @@ package status_test
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"io"
 	"log/slog"
 	"os"
@@ -19,11 +20,32 @@ import (
 	"github.com/bluesky-social/jetstream/internal/store"
 	"github.com/bluesky-social/jetstream/segment"
 	"github.com/jcalabro/atmos"
+	"github.com/jcalabro/atmos/identity"
 	"github.com/jcalabro/atmos/repo"
 	atmossync "github.com/jcalabro/atmos/sync"
 	"github.com/jcalabro/atmos/xrpc"
 	"github.com/stretchr/testify/require"
 )
+
+type fakeIdentityResolver struct {
+	handles map[atmos.Handle]atmos.DID
+	err     error
+}
+
+func (r *fakeIdentityResolver) ResolveDID(_ context.Context, _ atmos.DID) (*identity.DIDDocument, error) {
+	return nil, nil
+}
+
+func (r *fakeIdentityResolver) ResolveHandle(_ context.Context, handle atmos.Handle) (atmos.DID, error) {
+	if r.err != nil {
+		return "", r.err
+	}
+	did, ok := r.handles[handle]
+	if !ok {
+		return "", errors.New("handle not found")
+	}
+	return did, nil
+}
 
 func TestCollect_FreshDataDir(t *testing.T) {
 	t.Parallel()
@@ -311,6 +333,99 @@ func TestCollect_AccountLookupByHandle(t *testing.T) {
 	require.Equal(t, int64(1024), snap.Account.TotalBytes)
 	require.NotNil(t, snap.Account.HostContext)
 	require.Equal(t, uint64(2), snap.Account.HostContext.Failed)
+}
+
+func TestCollect_AccountLookupByHandleResolverFallback(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+	st, err := store.Open(dataDir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	did := atmos.DID("did:plc:resolved")
+	enc, err := backfill.EncodeRepoStatus(&backfill.RepoStatus{
+		Backfill: backfill.RepoBackfillStatus{Status: backfill.StatusComplete},
+		Host:     "pds.example.com",
+		Active:   true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, st.Set(backfill.RepoKey(string(did)), enc, store.SyncWrites))
+
+	c, err := status.New(status.Options{
+		Store:   st,
+		DataDir: dataDir,
+		IdentityResolver: &fakeIdentityResolver{handles: map[atmos.Handle]atmos.DID{
+			atmos.Handle("calabro.io"): did,
+		}},
+	})
+	require.NoError(t, err)
+	snap, err := c.SnapshotForRequest(t.Context(), status.Request{Tab: "accounts", Account: "Calabro.IO"})
+	require.NoError(t, err)
+
+	require.True(t, snap.Account.Found)
+	require.Equal(t, string(did), snap.Account.DID)
+	require.Equal(t, "calabro.io", snap.Account.Query)
+	require.Equal(t, "handle", snap.Account.QueryKind)
+	require.Equal(t, "complete", snap.Account.Backfill)
+}
+
+func TestCollect_AccountLookupByHandlePrefersResolverOverLocalIndex(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+	st, err := store.Open(dataDir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	staleDID := atmos.DID("did:plc:stale")
+	freshDID := atmos.DID("did:plc:fresh")
+	for _, did := range []atmos.DID{staleDID, freshDID} {
+		enc, err := backfill.EncodeRepoStatus(&backfill.RepoStatus{
+			Backfill: backfill.RepoBackfillStatus{Status: backfill.StatusComplete},
+			Active:   true,
+		})
+		require.NoError(t, err)
+		require.NoError(t, st.Set(backfill.RepoKey(string(did)), enc, store.SyncWrites))
+	}
+	require.NoError(t, st.Set([]byte("handle/alice.test"), []byte(staleDID), store.SyncWrites))
+
+	c, err := status.New(status.Options{
+		Store:   st,
+		DataDir: dataDir,
+		IdentityResolver: &fakeIdentityResolver{handles: map[atmos.Handle]atmos.DID{
+			atmos.Handle("alice.test"): freshDID,
+		}},
+	})
+	require.NoError(t, err)
+	snap, err := c.SnapshotForRequest(t.Context(), status.Request{Tab: "accounts", Account: "alice.test"})
+	require.NoError(t, err)
+
+	require.True(t, snap.Account.Found)
+	require.Equal(t, string(freshDID), snap.Account.DID)
+}
+
+func TestCollect_AccountLookupResolvedHandleWithMissingLocalMetadata(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+	st, err := store.Open(dataDir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	did := atmos.DID("did:plc:missinglocal")
+	c, err := status.New(status.Options{
+		Store:   st,
+		DataDir: dataDir,
+		IdentityResolver: &fakeIdentityResolver{handles: map[atmos.Handle]atmos.DID{
+			atmos.Handle("missing.test"): did,
+		}},
+	})
+	require.NoError(t, err)
+	snap, err := c.SnapshotForRequest(t.Context(), status.Request{Tab: "accounts", Account: "missing.test"})
+	require.NoError(t, err)
+
+	require.False(t, snap.Account.Found)
+	require.Equal(t, string(did), snap.Account.DID)
+	require.Equal(t, "missing.test", snap.Account.Query)
+	require.Equal(t, "handle", snap.Account.QueryKind)
 }
 
 func TestCollect_LiveCursors(t *testing.T) {

--- a/internal/status/collector.go
+++ b/internal/status/collector.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bluesky-social/jetstream/internal/manifest"
 	"github.com/bluesky-social/jetstream/internal/store"
+	"github.com/jcalabro/atmos/identity"
 	"golang.org/x/sync/singleflight"
 )
 
@@ -28,6 +29,10 @@ type Options struct {
 	// duration. Zero means cursor replay is disabled; the snapshot
 	// reports zero values for the cursor-lookback panel.
 	CursorLookback time.Duration
+
+	// IdentityResolver resolves one operator-supplied handle on the accounts
+	// tab. Optional; nil means handle lookup is limited to the local index.
+	IdentityResolver identity.Resolver
 }
 
 // Collector builds Snapshots on demand. Concurrent callers share one
@@ -90,7 +95,7 @@ func (c *Collector) SnapshotForRequest(ctx context.Context, req Request) (*Snaps
 }
 
 func requestSingleflightKey(req Request) string {
-	return "status:" + lengthPrefixed(req.Tab) + lengthPrefixed(req.DID) + lengthPrefixed(req.Handle)
+	return "status:" + lengthPrefixed(req.Tab) + lengthPrefixed(req.Account) + lengthPrefixed(req.DID) + lengthPrefixed(req.Handle)
 }
 
 func lengthPrefixed(s string) string {

--- a/internal/status/snapshot.go
+++ b/internal/status/snapshot.go
@@ -25,9 +25,10 @@ type Snapshot struct {
 
 // Request selects the status-page view and optional account lookup.
 type Request struct {
-	Tab    string
-	DID    string
-	Handle string
+	Tab     string
+	Account string
+	DID     string
+	Handle  string
 }
 
 // ProcessInfo carries the per-process build + uptime context.
@@ -92,8 +93,7 @@ type HostErrorRow struct {
 	Error       string
 }
 
-// AccountLookup is the account diagnostics panel for one DID or local
-// declared-handle query.
+// AccountLookup is the account diagnostics panel for one DID or handle query.
 type AccountLookup struct {
 	Query           string
 	QueryKind       string

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -163,9 +163,10 @@ func (h *Handler) serveStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	reqStatus := status.Request{
-		Tab:    r.URL.Query().Get("tab"),
-		DID:    r.URL.Query().Get("did"),
-		Handle: r.URL.Query().Get("handle"),
+		Tab:     r.URL.Query().Get("tab"),
+		Account: r.URL.Query().Get("account"),
+		DID:     r.URL.Query().Get("did"),
+		Handle:  r.URL.Query().Get("handle"),
 	}
 
 	snap, err := h.src.SnapshotForRequest(r.Context(), reqStatus)

--- a/internal/web/handler_test.go
+++ b/internal/web/handler_test.go
@@ -317,7 +317,7 @@ func TestHandler_RendersHostsTab(t *testing.T) {
 	require.Contains(t, body, "host-filter")
 	require.Contains(t, body, "sample-did")
 	require.Contains(t, body, "account-link")
-	require.Contains(t, body, `href="/status?tab=accounts&amp;did=did%3aplc%3aaaaaaaaaaaaaaaaaaaaaaaaa&amp;handle="`)
+	require.Contains(t, body, `href="/status?tab=accounts&amp;account=did%3aplc%3aaaaaaaaaaaaaaaaaaaaaaaaa"`)
 	require.Contains(t, body, `target="_blank"`)
 	require.Contains(t, body, "pds.example.com")
 	require.Contains(t, body, "did:plc:aaaaaaaaaaaaaaaaaaaaaaaa")
@@ -328,7 +328,7 @@ func TestHandler_RendersHostsTab(t *testing.T) {
 func TestHandler_RendersAccountsTabWithHandleQuery(t *testing.T) {
 	t.Parallel()
 	s := newFixtureSnap()
-	s.Request = status.Request{Tab: "accounts", Handle: "alice.test"}
+	s.Request = status.Request{Tab: "accounts", Account: "alice.test"}
 	s.Account = status.AccountLookup{
 		Query:     "alice.test",
 		QueryKind: "handle",
@@ -349,13 +349,17 @@ func TestHandler_RendersAccountsTabWithHandleQuery(t *testing.T) {
 	require.NoError(t, err)
 
 	rr := httptest.NewRecorder()
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/status?tab=accounts&handle=alice.test", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/status?tab=accounts&account=alice.test", nil)
 	h.ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusOK, rr.Code)
-	require.Equal(t, status.Request{Tab: "accounts", Handle: "alice.test"}, src.lastReq)
+	require.Equal(t, status.Request{Tab: "accounts", Account: "alice.test"}, src.lastReq)
 	body := rr.Body.String()
 	require.Contains(t, body, "did:plc:aaaaaaaaaaaaaaaaaaaaaaaa")
+	require.Contains(t, body, `name="account"`)
+	require.Contains(t, body, `placeholder="DID or handle"`)
+	require.NotContains(t, body, `name="did" class="lookup-input"`)
+	require.NotContains(t, body, `name="handle" class="lookup-input"`)
 	require.Contains(t, body, "declared handle")
 	require.Contains(t, body, "pds.example.com")
 	require.Contains(t, body, "Host context")

--- a/internal/web/templates/status.html
+++ b/internal/web/templates/status.html
@@ -353,7 +353,7 @@ document.addEventListener("input", function (event) {
           <ul class="samples">
             {{range .RecentErrors}}
             <li>
-              <span class="sample-did"><code>{{.DID}}</code></span><a class="account-link" href="/status?tab=accounts&amp;did={{.DID}}&amp;handle=" target="_blank" rel="noopener">view</a>
+              <span class="sample-did"><code>{{.DID}}</code></span><a class="account-link" href="/status?tab=accounts&amp;account={{.DID}}" target="_blank" rel="noopener">view</a>
               <span class="sample-meta">{{relativeTime .AttemptedAt $.Now}} {{if .Class}}<code>{{.Class}}</code>{{end}}</span>
               <span class="sample-error">{{.Error}}</span>
             </li>
@@ -377,8 +377,7 @@ document.addEventListener("input", function (event) {
   <h2>Accounts</h2>
   <form method="get" action="/status" class="toolbar">
     <input type="hidden" name="tab" value="accounts">
-    <input name="did" class="lookup-input" placeholder="did:plc:..." value="{{.Request.DID}}">
-    <input name="handle" class="lookup-input" placeholder="declared handle" value="{{.Request.Handle}}">
+    <input name="account" class="lookup-input" placeholder="DID or handle" value="{{.Request.Account}}">
     <button type="submit">Lookup</button>
   </form>
 
@@ -442,7 +441,7 @@ document.addEventListener("input", function (event) {
   {{else if .Account.Query}}
   <p class="sub">No local account metadata found for <code>{{.Account.Query}}</code>.</p>
   {{else}}
-  <p class="sub">Lookup reads local DID and declared-handle metadata only.</p>
+  <p class="sub">Lookup accepts a DID or handle.</p>
   {{end}}
 </section>
 {{end}}


### PR DESCRIPTION
## Summary
- collapse the account tab lookup form to one DID-or-handle field
- resolve handle inputs on demand through the configured identity resolver
- preserve old did= and handle= query params as compatibility aliases
- add regression coverage for resolver lookup, stale local index avoidance, missing local metadata, and rendering

## Verification
- just test ./internal/status ./internal/web ./internal/jetstreamd
- just test ./...
- just lint

Closes #137