### PR TITLE
status: verify repo roots without getRepo

### DIFF
--- a/internal/jetstreamd/runtime.go
+++ b/internal/jetstreamd/runtime.go
@@ -247,7 +247,7 @@ func Build(ctx context.Context, opts Options) (*Runtime, error) {
 
 	statusHandler, err := web.New(web.Options{
 		Snapshotter:                statusCollector,
-		RepoActions:                web.NewRepoActions(opts.DataDir, opts.RelayURL, newManifestSelector(mft), pendingEventsForDID(&writerPtr)),
+		RepoActions:                web.NewRepoActions(opts.DataDir, resolver, newManifestSelector(mft), pendingEventsForDID(&writerPtr)),
 		DisableRepoActionRateLimit: opts.DisableRepoActionRateLimits,
 		Logger:                     processLogger,
 	})

--- a/internal/repoexport/verify.go
+++ b/internal/repoexport/verify.go
@@ -1,12 +1,20 @@
 package repoexport
 
 import (
+	"bufio"
+	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
+	"strings"
 
 	"github.com/bluesky-social/jetstream/segment"
 	"github.com/jcalabro/atmos"
+	"github.com/jcalabro/atmos/car"
+	"github.com/jcalabro/atmos/cbor"
+	"github.com/jcalabro/atmos/identity"
 	"github.com/jcalabro/atmos/repo"
 	atmossync "github.com/jcalabro/atmos/sync"
 	"github.com/jcalabro/atmos/xrpc"
@@ -15,15 +23,18 @@ import (
 )
 
 const (
-	defaultVerifyRelayURL = "https://bsky.network"
-	rootMismatchMessage   = "local reconstructed MST root does not match authoritative repo root"
+	rootMismatchMessage          = "local reconstructed MST root does not match authoritative repo root"
+	maxAuthoritativeCommitBlocks = 8
 )
 
 // VerifyConfig controls authoritative-vs-local repo root verification.
 type VerifyConfig struct {
-	DataDir  string
-	DID      string
-	RelayURL string
+	DataDir string
+	DID     string
+
+	// IdentityResolver resolves DID documents so verification can query the
+	// account's PDS for PDS-only sync endpoints. Nil uses identity.DefaultResolver.
+	IdentityResolver identity.Resolver
 
 	// Selector prunes which segments/blocks reconstruction decodes via the
 	// in-memory manifest blooms. Required; see Config.Selector.
@@ -48,8 +59,8 @@ type VerifyReport struct {
 	Message           string
 }
 
-// Verify downloads cfg.DID's authoritative repo CAR and compares its commit
-// MST root against a locally reconstructed snapshot.
+// Verify compares cfg.DID's authoritative commit root against a locally
+// reconstructed snapshot.
 func Verify(ctx context.Context, cfg VerifyConfig) (VerifyReport, error) {
 	if cfg.DataDir == "" {
 		return VerifyReport{}, errors.New("repoexport: DataDir is required")
@@ -61,12 +72,7 @@ func Verify(ctx context.Context, cfg VerifyConfig) (VerifyReport, error) {
 		return VerifyReport{}, err
 	}
 
-	relayURL := cfg.RelayURL
-	if relayURL == "" {
-		relayURL = defaultVerifyRelayURL
-	}
-
-	authoritativeRev, authoritativeRoot, err := loadAuthoritativeRoot(ctx, relayURL, cfg.DID)
+	authoritativeRev, authoritativeRoot, err := loadAuthoritativeRoot(ctx, cfg.DID, cfg.IdentityResolver)
 	if err != nil {
 		return VerifyReport{}, err
 	}
@@ -103,26 +109,185 @@ func Verify(ctx context.Context, cfg VerifyConfig) (VerifyReport, error) {
 	return report, nil
 }
 
-func loadAuthoritativeRoot(ctx context.Context, relayURL, did string) (string, string, error) {
+func loadAuthoritativeRoot(ctx context.Context, did string, resolver identity.Resolver) (string, string, error) {
+	pdsURL, err := resolvePDSEndpoint(ctx, did, resolver)
+	if err != nil {
+		return "", "", err
+	}
 	xrpcClient := &xrpc.Client{
-		Host:       relayURL,
+		Host:       pdsURL,
 		HTTPClient: gt.Some(jttp.New(xrpc.BulkDownloadOpts()...)),
 	}
 	syncClient := atmossync.NewClient(atmossync.Options{Client: xrpcClient})
 
-	body, err := syncClient.GetRepoStream(ctx, atmos.DID(did), "")
+	rev, commitCID, err := syncClient.GetLatestCommit(ctx, atmos.DID(did))
 	if err != nil {
-		return "", "", fmt.Errorf("repoexport: download authoritative repo CAR for %s: %w", did, err)
+		return "", "", fmt.Errorf("repoexport: get latest authoritative commit for %s: %w", did, err)
+	}
+
+	commit, err := loadAuthoritativeCommit(ctx, xrpcClient, did, rev, commitCID)
+	if err != nil {
+		return "", "", err
+	}
+	return rev, commit.Data.String(), nil
+}
+
+func resolvePDSEndpoint(ctx context.Context, did string, resolver identity.Resolver) (string, error) {
+	parsedDID, err := atmos.ParseDID(did)
+	if err != nil {
+		return "", fmt.Errorf("repoexport: parse DID %q: %w", did, err)
+	}
+	if resolver == nil {
+		resolver = &identity.DefaultResolver{}
+	}
+	doc, err := resolver.ResolveDID(ctx, parsedDID)
+	if err != nil {
+		return "", fmt.Errorf("repoexport: resolve authoritative PDS for %s: %w", did, err)
+	}
+	ident, err := identity.IdentityFromDocument(doc)
+	if err != nil {
+		return "", fmt.Errorf("repoexport: parse authoritative identity for %s: %w", did, err)
+	}
+	pdsURL := strings.TrimRight(ident.PDSEndpoint(), "/")
+	if pdsURL == "" {
+		return "", fmt.Errorf("repoexport: no authoritative PDS endpoint for %s", did)
+	}
+	return pdsURL, nil
+}
+
+func loadAuthoritativeCommit(ctx context.Context, xrpcClient *xrpc.Client, did, rev string, commitCID cbor.CID) (*repo.Commit, error) {
+	body, err := xrpcClient.QueryStream(ctx, "com.atproto.sync.getBlocks", map[string]any{
+		"did":  did,
+		"cids": []string{commitCID.String()},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("repoexport: get authoritative commit block %s for %s: %w", commitCID.String(), did, err)
 	}
 	defer func() { _ = body.Close() }()
 
-	_, commit, err := repo.LoadFromCAR(body)
+	block, err := readAuthoritativeCommitBlock(body, commitCID)
 	if err != nil {
-		return "", "", fmt.Errorf("repoexport: decode authoritative repo CAR for %s: %w", did, err)
-	}
-	if commit.DID != did {
-		return "", "", fmt.Errorf("repoexport: authoritative repo CAR DID mismatch: requested %s, commit DID %s", did, commit.DID)
+		return nil, err
 	}
 
-	return commit.Rev, commit.Data.String(), nil
+	var singleCommitCAR bytes.Buffer
+	if err := car.WriteAll(&singleCommitCAR, []cbor.CID{commitCID}, []car.Block{block}); err != nil {
+		return nil, fmt.Errorf("repoexport: encode authoritative commit block %s: %w", commitCID.String(), err)
+	}
+
+	_, commit, err := repo.LoadFromCAR(bytes.NewReader(singleCommitCAR.Bytes()))
+	if err != nil {
+		return nil, fmt.Errorf("repoexport: decode authoritative commit block %s: %w", commitCID.String(), err)
+	}
+	if commit.DID != did {
+		return nil, fmt.Errorf("repoexport: authoritative commit DID mismatch: latest commit for %s returned commit for %s", did, commit.DID)
+	}
+	if commit.Rev != rev {
+		return nil, fmt.Errorf("repoexport: authoritative commit rev mismatch: getLatestCommit returned %s but commit block contains %s", rev, commit.Rev)
+	}
+	return commit, nil
+}
+
+func readAuthoritativeCommitBlock(r io.Reader, commitCID cbor.CID) (car.Block, error) {
+	br := bufio.NewReader(r)
+
+	if err := readCARHeaderAllowEmptyRoots(br); err != nil {
+		return car.Block{}, fmt.Errorf("repoexport: read authoritative commit CAR: %w", err)
+	}
+	for blocksRead := range maxAuthoritativeCommitBlocks {
+		block, err := readCARBlock(br)
+		if errors.Is(err, io.EOF) {
+			return car.Block{}, fmt.Errorf("repoexport: authoritative commit block %s not found in getBlocks response", commitCID.String())
+		}
+		if err != nil {
+			return car.Block{}, fmt.Errorf("repoexport: read authoritative commit block: %w", err)
+		}
+		if block.CID.Equal(commitCID) {
+			return block, nil
+		}
+		if blocksRead == maxAuthoritativeCommitBlocks-1 {
+			break
+		}
+	}
+
+	return car.Block{}, fmt.Errorf("repoexport: authoritative getBlocks response exceeded %d blocks without commit %s", maxAuthoritativeCommitBlocks, commitCID.String())
+}
+
+func readCARHeaderAllowEmptyRoots(br *bufio.Reader) error {
+	headerLen, err := binary.ReadUvarint(br)
+	if err != nil {
+		return fmt.Errorf("reading header length: %w", err)
+	}
+	if headerLen > car.MaxBlockSize {
+		return fmt.Errorf("header length %d exceeds max size", headerLen)
+	}
+
+	header := make([]byte, headerLen)
+	if _, err := io.ReadFull(br, header); err != nil {
+		return fmt.Errorf("reading header: %w", err)
+	}
+
+	count, pos, err := cbor.ReadMapHeader(header, 0)
+	if err != nil {
+		return fmt.Errorf("header: %w", err)
+	}
+
+	var hasVersion bool
+	for range count {
+		key, newPos, err := cbor.ReadText(header, pos)
+		if err != nil {
+			return fmt.Errorf("header key: %w", err)
+		}
+		pos = newPos
+
+		switch key {
+		case "version":
+			hasVersion = true
+			ver, newPos, err := cbor.ReadUint(header, pos)
+			if err != nil {
+				return fmt.Errorf("header version: %w", err)
+			}
+			if ver != 1 {
+				return fmt.Errorf("unsupported version %d, expected 1", ver)
+			}
+			pos = newPos
+		default:
+			pos, err = cbor.SkipValue(header, pos)
+			if err != nil {
+				return fmt.Errorf("skipping header key %q: %w", key, err)
+			}
+		}
+	}
+	if !hasVersion {
+		return errors.New("header missing 'version'")
+	}
+	return nil
+}
+
+func readCARBlock(br *bufio.Reader) (car.Block, error) {
+	blockLen, err := binary.ReadUvarint(br)
+	if err != nil {
+		return car.Block{}, err
+	}
+	if blockLen == 0 {
+		return car.Block{}, errors.New("zero-length block")
+	}
+	if blockLen > car.MaxBlockSize {
+		return car.Block{}, fmt.Errorf("block length %d exceeds max size", blockLen)
+	}
+
+	buf := make([]byte, blockLen)
+	if _, err := io.ReadFull(br, buf); err != nil {
+		return car.Block{}, fmt.Errorf("reading block: %w", err)
+	}
+	cid, cidLen, err := cbor.ParseCIDPrefix(buf)
+	if err != nil {
+		return car.Block{}, fmt.Errorf("parsing block CID: %w", err)
+	}
+	data := buf[cidLen:]
+	expected := cbor.ComputeCID(cid.Codec(), data)
+	if !expected.Equal(cid) {
+		return car.Block{}, fmt.Errorf("block CID mismatch: claimed %s, computed %s", cid.String(), expected.String())
+	}
+	return car.Block{CID: cid, Data: data}, nil
 }

--- a/internal/repoexport/verify_test.go
+++ b/internal/repoexport/verify_test.go
@@ -2,17 +2,18 @@ package repoexport
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
-	"sort"
 	"testing"
 
 	"github.com/bluesky-social/jetstream/segment"
+	"github.com/jcalabro/atmos"
 	"github.com/jcalabro/atmos/car"
 	"github.com/jcalabro/atmos/cbor"
-	"github.com/jcalabro/atmos/mst"
-	"github.com/jcalabro/atmos/repo"
+	"github.com/jcalabro/atmos/identity"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,17 +26,17 @@ func TestVerify_MatchingRoots(t *testing.T) {
 		createEvent(testDID, "app.bsky.feed.post", "r1", "rev1", payload("1")),
 		createEvent(testDID, "app.bsky.feed.post", "r2", "rev2", payload("2")),
 	}
-	carBytes, authoritativeRoot := authoritativeCAR(t, testDID, testAuthoritativeRev, events)
-	relay := newGetRepoServer(t, testDID, carBytes)
+	authoritativeRoot, _ := expectedRoot(t, events)
+	relay := newAuthoritativeCommitServer(t, testDID, testAuthoritativeRev, authoritativeRoot)
 
 	dataDir, st := newTestDataDir(t)
 	writeSegmentTree(t, st, filepath.Join(dataDir, "segments"), events)
 
 	report, err := Verify(t.Context(), VerifyConfig{
-		DataDir:  dataDir,
-		DID:      testDID,
-		RelayURL: relay.URL,
-		Selector: openSelector(t, dataDir),
+		DataDir:          dataDir,
+		DID:              testDID,
+		IdentityResolver: newTestIdentityResolver(testDID, relay.URL),
+		Selector:         openSelector(t, dataDir),
 	})
 	require.NoError(t, err)
 	require.Equal(t, VerifyReport{
@@ -57,8 +58,8 @@ func TestVerify_PendingEventsMatchAuthoritativeRoot(t *testing.T) {
 		createEvent(testDID, "app.bsky.feed.post", "r1", "rev1", payload("1")),
 		createEvent(testDID, "app.bsky.feed.like", "r2", "rev2", payload("2")),
 	}
-	carBytes, authoritativeRoot := authoritativeCAR(t, testDID, testAuthoritativeRev, authoritativeEvents)
-	relay := newGetRepoServer(t, testDID, carBytes)
+	authoritativeRoot, _ := expectedRoot(t, authoritativeEvents)
+	relay := newAuthoritativeCommitServer(t, testDID, testAuthoritativeRev, authoritativeRoot)
 
 	// Locally, only the first record made it to disk; the second (the
 	// just-created like) is still in the live writer's pending block.
@@ -69,11 +70,11 @@ func TestVerify_PendingEventsMatchAuthoritativeRoot(t *testing.T) {
 	pending := authoritativeEvents[1:]
 
 	report, err := Verify(t.Context(), VerifyConfig{
-		DataDir:       dataDir,
-		DID:           testDID,
-		RelayURL:      relay.URL,
-		Selector:      openSelector(t, dataDir),
-		PendingEvents: pending,
+		DataDir:          dataDir,
+		DID:              testDID,
+		IdentityResolver: newTestIdentityResolver(testDID, relay.URL),
+		Selector:         openSelector(t, dataDir),
+		PendingEvents:    pending,
 	})
 	require.NoError(t, err)
 	require.True(t, report.Match, "expected pending like to close the gap; message=%q", report.Message)
@@ -89,8 +90,8 @@ func TestVerify_MismatchingRootsReturnsReport(t *testing.T) {
 		createEvent(testDID, "app.bsky.feed.post", "r1", "rev1", payload("1")),
 		createEvent(testDID, "app.bsky.feed.post", "r2", "rev2", payload("2")),
 	}
-	carBytes, authoritativeRoot := authoritativeCAR(t, testDID, testAuthoritativeRev, authoritativeEvents)
-	relay := newGetRepoServer(t, testDID, carBytes)
+	authoritativeRoot, _ := expectedRoot(t, authoritativeEvents)
+	relay := newAuthoritativeCommitServer(t, testDID, testAuthoritativeRev, authoritativeRoot)
 
 	localEvents := []segment.Event{
 		createEvent(testDID, "app.bsky.feed.post", "r1", "rev1", payload("1")),
@@ -100,10 +101,10 @@ func TestVerify_MismatchingRootsReturnsReport(t *testing.T) {
 	writeSegmentTree(t, st, filepath.Join(dataDir, "segments"), localEvents)
 
 	report, err := Verify(t.Context(), VerifyConfig{
-		DataDir:  dataDir,
-		DID:      testDID,
-		RelayURL: relay.URL,
-		Selector: openSelector(t, dataDir),
+		DataDir:          dataDir,
+		DID:              testDID,
+		IdentityResolver: newTestIdentityResolver(testDID, relay.URL),
+		Selector:         openSelector(t, dataDir),
 	})
 	require.NoError(t, err)
 	require.Equal(t, VerifyReport{
@@ -124,15 +125,15 @@ func TestVerify_MissingLocalRepoReturnsMismatchReport(t *testing.T) {
 	events := []segment.Event{
 		createEvent(testDID, "app.bsky.feed.post", "r1", "rev1", payload("1")),
 	}
-	carBytes, authoritativeRoot := authoritativeCAR(t, testDID, testAuthoritativeRev, events)
-	relay := newGetRepoServer(t, testDID, carBytes)
+	authoritativeRoot, _ := expectedRoot(t, events)
+	relay := newAuthoritativeCommitServer(t, testDID, testAuthoritativeRev, authoritativeRoot)
 
 	emptyDir := t.TempDir()
 	report, err := Verify(t.Context(), VerifyConfig{
-		DataDir:  emptyDir,
-		DID:      testDID,
-		RelayURL: relay.URL,
-		Selector: openSelector(t, emptyDir),
+		DataDir:          emptyDir,
+		DID:              testDID,
+		IdentityResolver: newTestIdentityResolver(testDID, relay.URL),
+		Selector:         openSelector(t, emptyDir),
 	})
 	require.NoError(t, err)
 	require.Equal(t, testDID, report.DID)
@@ -145,48 +146,75 @@ func TestVerify_MissingLocalRepoReturnsMismatchReport(t *testing.T) {
 	require.Contains(t, report.Message, "no local commit events")
 }
 
-func TestVerify_MalformedAuthoritativeCARReturnsError(t *testing.T) {
+func TestVerify_MalformedLatestCommitCIDReturnsError(t *testing.T) {
 	t.Parallel()
 
-	relay := newGetRepoServer(t, testDID, []byte("not a car"))
+	relay := newMalformedLatestCommitServer(t, testDID)
 
 	_, err := Verify(t.Context(), VerifyConfig{
-		DataDir:  t.TempDir(),
-		DID:      testDID,
-		RelayURL: relay.URL,
+		DataDir:          t.TempDir(),
+		DID:              testDID,
+		IdentityResolver: newTestIdentityResolver(testDID, relay.URL),
 	})
 	require.Error(t, err)
 }
 
-func TestVerify_AuthoritativeDIDMismatchReturnsError(t *testing.T) {
+func TestVerify_MissingAuthoritativeCommitBlockReturnsError(t *testing.T) {
 	t.Parallel()
 
-	authoritativeDID := "did:plc:otherrepo"
-	events := []segment.Event{
-		createEvent(testDID, "app.bsky.feed.post", "r1", "rev1", payload("1")),
-	}
-	carBytes, _ := authoritativeCAR(t, authoritativeDID, testAuthoritativeRev, events)
-	relay := newGetRepoServer(t, testDID, carBytes)
+	root := cbor.ComputeCID(cbor.CodecDagCBOR, []byte("root"))
+	commitCID, _ := authoritativeCommitCAR(t, testDID, testAuthoritativeRev, root)
+	otherCID, otherCAR := authoritativeCommitCAR(t, testDID, testAuthoritativeRev, cbor.ComputeCID(cbor.CodecDagCBOR, []byte("other-root")))
+	require.False(t, otherCID.Equal(commitCID))
+
+	relay := newCommitBlockServer(t, testDID, testAuthoritativeRev, commitCID, otherCAR)
+	_, err := Verify(t.Context(), VerifyConfig{
+		DataDir:          t.TempDir(),
+		DID:              testDID,
+		IdentityResolver: newTestIdentityResolver(testDID, relay.URL),
+	})
+	require.ErrorContains(t, err, "not found in getBlocks response")
+}
+
+func TestVerify_AuthoritativeCommitDIDMismatchReturnsError(t *testing.T) {
+	t.Parallel()
+
+	root := cbor.ComputeCID(cbor.CodecDagCBOR, []byte("root"))
+	commitCID, commitCAR := authoritativeCommitCAR(t, "did:plc:other", testAuthoritativeRev, root)
+	relay := newCommitBlockServer(t, testDID, testAuthoritativeRev, commitCID, commitCAR)
 
 	_, err := Verify(t.Context(), VerifyConfig{
-		DataDir:  t.TempDir(),
-		DID:      testDID,
-		RelayURL: relay.URL,
+		DataDir:          t.TempDir(),
+		DID:              testDID,
+		IdentityResolver: newTestIdentityResolver(testDID, relay.URL),
 	})
-	require.Error(t, err)
-	require.ErrorContains(t, err, testDID)
-	require.ErrorContains(t, err, authoritativeDID)
+	require.ErrorContains(t, err, "authoritative commit DID mismatch")
+}
+
+func TestVerify_AuthoritativeCommitRevMismatchReturnsError(t *testing.T) {
+	t.Parallel()
+
+	root := cbor.ComputeCID(cbor.CodecDagCBOR, []byte("root"))
+	commitCID, commitCAR := authoritativeCommitCAR(t, testDID, "2222222222223", root)
+	relay := newCommitBlockServer(t, testDID, testAuthoritativeRev, commitCID, commitCAR)
+
+	_, err := Verify(t.Context(), VerifyConfig{
+		DataDir:          t.TempDir(),
+		DID:              testDID,
+		IdentityResolver: newTestIdentityResolver(testDID, relay.URL),
+	})
+	require.ErrorContains(t, err, "authoritative commit rev mismatch")
 }
 
 func TestVerify_HTTPFailureReturnsError(t *testing.T) {
 	t.Parallel()
 
-	relay := newGetRepoErrorServer(t, http.StatusInternalServerError)
+	relay := newGetLatestCommitErrorServer(t, http.StatusInternalServerError)
 
 	_, err := Verify(t.Context(), VerifyConfig{
-		DataDir:  t.TempDir(),
-		DID:      testDID,
-		RelayURL: relay.URL,
+		DataDir:          t.TempDir(),
+		DID:              testDID,
+		IdentityResolver: newTestIdentityResolver(testDID, relay.URL),
 	})
 	require.Error(t, err)
 }
@@ -201,54 +229,43 @@ func TestVerify_ValidatesConfig(t *testing.T) {
 	require.ErrorContains(t, err, "DID is required")
 }
 
-func authoritativeCAR(t *testing.T, did, rev string, events []segment.Event) ([]byte, cbor.CID) {
+func newAuthoritativeCommitServer(t *testing.T, did string, rev string, root cbor.CID) *httptest.Server {
 	t.Helper()
 
-	blocks := mst.NewMemBlockStore()
-	tree := mst.NewTree(blocks)
-	for _, ev := range events {
-		key := ev.Collection + "/" + ev.Rkey
-		switch ev.Kind {
-		case segment.KindCreate, segment.KindUpdate, segment.KindCreateResync:
-			cid := cbor.ComputeCID(cbor.CodecDagCBOR, ev.Payload)
-			require.NoError(t, blocks.PutBlock(cid, append([]byte(nil), ev.Payload...)))
-			require.NoError(t, tree.Insert(key, cid))
-		case segment.KindDelete:
-			require.NoError(t, tree.Remove(key))
-		}
-	}
-	root, err := tree.WriteBlocks(blocks)
-	require.NoError(t, err)
-
-	commit := &repo.Commit{
-		DID:     did,
-		Version: 3,
-		Data:    root,
-		Rev:     rev,
-		Sig:     []byte{1, 2, 3},
-	}
-	commitBytes, err := commit.EncodeCBOR()
-	require.NoError(t, err)
-	commitCID := cbor.ComputeCID(cbor.CodecDagCBOR, commitBytes)
-	require.NoError(t, blocks.PutBlock(commitCID, commitBytes))
-
-	carBlocks := make([]car.Block, 0)
-	for cid, data := range blocks.All() {
-		carBlocks = append(carBlocks, car.Block{
-			CID:  cid,
-			Data: append([]byte(nil), data...),
-		})
-	}
-	sort.Slice(carBlocks, func(i, j int) bool {
-		return carBlocks[i].CID.String() < carBlocks[j].CID.String()
-	})
-
-	var buf bytes.Buffer
-	require.NoError(t, car.WriteAll(&buf, []cbor.CID{commitCID}, carBlocks))
-	return buf.Bytes(), root
+	commitCID, commitCAR := authoritativeCommitCAR(t, did, rev, root)
+	return newCommitBlockServer(t, did, rev, commitCID, commitCAR)
 }
 
-func newGetRepoServer(t *testing.T, did string, carBytes []byte) *httptest.Server {
+type testIdentityResolver struct {
+	did    string
+	pdsURL string
+}
+
+func newTestIdentityResolver(did, pdsURL string) *testIdentityResolver {
+	return &testIdentityResolver{did: did, pdsURL: pdsURL}
+}
+
+func (r *testIdentityResolver) ResolveDID(_ context.Context, did atmos.DID) (*identity.DIDDocument, error) {
+	if string(did) != r.did {
+		return nil, identity.ErrDIDNotFound
+	}
+	return &identity.DIDDocument{
+		ID: r.did,
+		Service: []identity.Service{
+			{
+				ID:              r.did + "#atproto_pds",
+				Type:            "AtprotoPersonalDataServer",
+				ServiceEndpoint: r.pdsURL,
+			},
+		},
+	}, nil
+}
+
+func (r *testIdentityResolver) ResolveHandle(_ context.Context, _ atmos.Handle) (atmos.DID, error) {
+	return "", identity.ErrHandleNotFound
+}
+
+func newCommitBlockServer(t *testing.T, did string, rev string, commitCID cbor.CID, commitCAR []byte) *httptest.Server {
 	t.Helper()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
@@ -256,7 +273,98 @@ func newGetRepoServer(t *testing.T, did string, carBytes []byte) *httptest.Serve
 			http.Error(rw, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
-		if r.URL.Path != "/xrpc/com.atproto.sync.getRepo" {
+		switch r.URL.Path {
+		case "/xrpc/com.atproto.sync.getLatestCommit":
+			if got := r.URL.Query().Get("did"); got != did {
+				http.Error(rw, "unexpected did", http.StatusBadRequest)
+				return
+			}
+
+			rw.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(rw).Encode(map[string]string{
+				"rev": rev,
+				"cid": commitCID.String(),
+			})
+		case "/xrpc/com.atproto.sync.getBlocks":
+			if got := r.URL.Query().Get("did"); got != did {
+				http.Error(rw, "unexpected did", http.StatusBadRequest)
+				return
+			}
+			if got := r.URL.Query()["cids"]; len(got) != 1 || got[0] != commitCID.String() {
+				http.Error(rw, "unexpected cids", http.StatusBadRequest)
+				return
+			}
+
+			rw.Header().Set("Content-Type", "application/vnd.ipld.car")
+			_, _ = rw.Write(commitCAR)
+		default:
+			http.NotFound(rw, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func authoritativeCommitCAR(t *testing.T, did string, rev string, root cbor.CID) (cbor.CID, []byte) {
+	t.Helper()
+
+	commitData := cbor.AppendMapHeader(nil, 6)
+	commitData = cbor.AppendText(commitData, "did")
+	commitData = cbor.AppendText(commitData, did)
+	commitData = cbor.AppendText(commitData, "rev")
+	commitData = cbor.AppendText(commitData, rev)
+	commitData = cbor.AppendText(commitData, "sig")
+	commitData = cbor.AppendBytes(commitData, []byte{1, 2, 3})
+	commitData = cbor.AppendText(commitData, "data")
+	commitData = cbor.AppendCIDLink(commitData, &root)
+	commitData = cbor.AppendText(commitData, "prev")
+	commitData = cbor.AppendNull(commitData)
+	commitData = cbor.AppendText(commitData, "version")
+	commitData = cbor.AppendUint(commitData, 3)
+
+	commitCID := cbor.ComputeCID(cbor.CodecDagCBOR, commitData)
+	var buf bytes.Buffer
+	writeCARAllowEmptyRoots(t, &buf, nil, []car.Block{{CID: commitCID, Data: commitData}})
+	return commitCID, buf.Bytes()
+}
+
+func writeCARAllowEmptyRoots(t *testing.T, buf *bytes.Buffer, roots []cbor.CID, blocks []car.Block) {
+	t.Helper()
+
+	header := cbor.AppendMapHeader(nil, 2)
+	header = cbor.AppendText(header, "roots")
+	header = cbor.AppendArrayHeader(header, uint64(len(roots)))
+	for i := range roots {
+		header = cbor.AppendCIDLink(header, &roots[i])
+	}
+	header = cbor.AppendText(header, "version")
+	header = cbor.AppendUint(header, 1)
+
+	_, err := buf.Write(cbor.AppendUvarint(nil, uint64(len(header))))
+	require.NoError(t, err)
+	_, err = buf.Write(header)
+	require.NoError(t, err)
+
+	for _, block := range blocks {
+		blockLen := uint64(cbor.CIDByteLen(&block.CID) + len(block.Data))
+		_, err = buf.Write(cbor.AppendUvarint(nil, blockLen))
+		require.NoError(t, err)
+		_, err = buf.Write(block.CID.AppendBytes(nil))
+		require.NoError(t, err)
+		_, err = buf.Write(block.Data)
+		require.NoError(t, err)
+	}
+}
+
+func newMalformedLatestCommitServer(t *testing.T, did string) *httptest.Server {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(rw, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.Path != "/xrpc/com.atproto.sync.getLatestCommit" {
 			http.NotFound(rw, r)
 			return
 		}
@@ -265,14 +373,17 @@ func newGetRepoServer(t *testing.T, did string, carBytes []byte) *httptest.Serve
 			return
 		}
 
-		rw.Header().Set("Content-Type", "application/vnd.ipld.car")
-		_, _ = rw.Write(carBytes)
+		rw.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(rw).Encode(map[string]string{
+			"rev": testAuthoritativeRev,
+			"cid": "not-a-cid",
+		})
 	}))
 	t.Cleanup(srv.Close)
 	return srv
 }
 
-func newGetRepoErrorServer(t *testing.T, status int) *httptest.Server {
+func newGetLatestCommitErrorServer(t *testing.T, status int) *httptest.Server {
 	t.Helper()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {

--- a/internal/web/repo_actions.go
+++ b/internal/web/repo_actions.go
@@ -5,11 +5,12 @@ import (
 
 	"github.com/bluesky-social/jetstream/internal/repoexport"
 	"github.com/bluesky-social/jetstream/segment"
+	"github.com/jcalabro/atmos/identity"
 )
 
 type repoExportActions struct {
-	dataDir  string
-	relayURL string
+	dataDir          string
+	identityResolver identity.Resolver
 	// selector prunes which segments/blocks reconstruction decodes, backed
 	// by the in-memory manifest. Required for verification to run.
 	selector repoexport.Selector
@@ -26,12 +27,12 @@ type repoExportActions struct {
 // be nil; when set it supplies the live writer's in-memory pending events so
 // verification does not spuriously report a root mismatch for a just-written
 // record.
-func NewRepoActions(dataDir, relayURL string, selector repoexport.Selector, pendingEvents func(did string) []segment.Event) RepoActions {
+func NewRepoActions(dataDir string, identityResolver identity.Resolver, selector repoexport.Selector, pendingEvents func(did string) []segment.Event) RepoActions {
 	return repoExportActions{
-		dataDir:       dataDir,
-		relayURL:      relayURL,
-		selector:      selector,
-		pendingEvents: pendingEvents,
+		dataDir:          dataDir,
+		identityResolver: identityResolver,
+		selector:         selector,
+		pendingEvents:    pendingEvents,
 	}
 }
 
@@ -45,10 +46,10 @@ func (a repoExportActions) gatherPending(did string) []segment.Event {
 
 func (a repoExportActions) VerifyRepo(ctx context.Context, did string) (repoexport.VerifyReport, error) {
 	return repoexport.Verify(ctx, repoexport.VerifyConfig{
-		DataDir:       a.dataDir,
-		DID:           did,
-		RelayURL:      a.relayURL,
-		Selector:      a.selector,
-		PendingEvents: a.gatherPending(did),
+		DataDir:          a.dataDir,
+		DID:              did,
+		IdentityResolver: a.identityResolver,
+		Selector:         a.selector,
+		PendingEvents:    a.gatherPending(did),
 	})
 }

--- a/internal/web/repo_actions_test.go
+++ b/internal/web/repo_actions_test.go
@@ -27,7 +27,7 @@ func TestRepoExportActions_PassesPendingEventsForDID(t *testing.T) {
 		return []segment.Event{{Kind: segment.KindCreate, DID: d, Collection: "app.bsky.feed.like", Rkey: "r1", Rev: "rev1"}}
 	}
 
-	actions, ok := NewRepoActions(t.TempDir(), "http://127.0.0.1:1", stubSelector{}, provider).(repoExportActions)
+	actions, ok := NewRepoActions(t.TempDir(), nil, stubSelector{}, provider).(repoExportActions)
 	require.True(t, ok)
 	require.NotNil(t, actions.pendingEvents)
 
@@ -40,7 +40,7 @@ func TestRepoExportActions_PassesPendingEventsForDID(t *testing.T) {
 func TestRepoExportActions_NilProviderYieldsNoPending(t *testing.T) {
 	t.Parallel()
 
-	actions, ok := NewRepoActions(t.TempDir(), "http://127.0.0.1:1", stubSelector{}, nil).(repoExportActions)
+	actions, ok := NewRepoActions(t.TempDir(), nil, stubSelector{}, nil).(repoExportActions)
 	require.True(t, ok)
 	// VerifyRepo must tolerate a nil provider (offline / pre-steady-state)
 	// without panicking when it gathers pending events.


### PR DESCRIPTION
## Summary
- replace status repo verification full getRepo download with getLatestCommit plus a single getBlocks commit-block fetch
- resolve the account DID to its PDS before calling PDS-only sync endpoints
- tolerate empty-root getBlocks CARs while preserving block CID validation and bounded reads
- add regression coverage for distinct commit CID vs MST root, empty-root CARs, missing blocks, DID mismatch, and rev mismatch

## Verification
- just test ./internal/repoexport -run TestVerify -v
- just test ./internal/web ./internal/status ./internal/jetstreamd
- just test ./...
- just lint
- manual: just clean && just run-prod serve --backfill-repos=did:plc:4uz2445cjiw7w4nobfgnu35f, then account lookup by DID and calabro.io both reported repo verification match

Closes #139