### PR TITLE
client: optional typed record consumption decoded on the parallel workers (#146)

### DIFF
--- a/cmd/client/subscribe.go
+++ b/cmd/client/subscribe.go
@@ -69,6 +69,10 @@ func subscribeCommand() *cli.Command {
 				Name:  "print",
 				Usage: "Print each event as JSON instead of throughput stats",
 			},
+			&cli.BoolFlag{
+				Name:  "typed-likes-client",
+				Usage: "Decode records via the typed fast path (skips the generic map). Requires exactly --collection=app.bsky.feed.like; reports typed-decode throughput.",
+			},
 			&cli.DurationFlag{
 				Name:  "report-interval",
 				Usage: "How often to print throughput stats (when not --print)",
@@ -178,6 +182,19 @@ func runSubscribe(ctx context.Context, cmd *cli.Command) error {
 		opts = append(opts, jetstream.WithLiveBuffer(buf))
 	}
 
+	// --typed-likes-client decodes records straight into bsky.FeedLike via the
+	// raw-record fast path (no generic map). It only makes sense for a single
+	// known record type, so require exactly --collection=app.bsky.feed.like, and
+	// enable WithRawRecords so the engine skips the map build on the workers.
+	typedLikes := cmd.Bool("typed-likes-client")
+	if typedLikes {
+		cols := cmd.StringSlice("collection")
+		if len(cols) != 1 || cols[0] != "app.bsky.feed.like" {
+			return fmt.Errorf("--typed-likes-client requires exactly --collection=app.bsky.feed.like")
+		}
+		opts = append(opts, jetstream.WithRawRecords())
+	}
+
 	client, err := jetstream.Subscribe(cmd.String("host"), opts...)
 	if err != nil {
 		return err
@@ -204,6 +221,9 @@ func runSubscribe(ctx context.Context, cmd *cli.Command) error {
 	}
 	defer stopDebug()
 
+	if typedLikes {
+		return reportTypedLikeThroughput(runCtx, out, client, cmd.Duration("report-interval"))
+	}
 	if cmd.Bool("print") {
 		return printEvents(runCtx, out, client)
 	}

--- a/cmd/client/typed.go
+++ b/cmd/client/typed.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/bluesky-social/jetstream"
+	"github.com/jcalabro/atmos/api/bsky"
+)
+
+// reportTypedLikeThroughput consumes the stream via the typed fast path
+// (jetstream.TypedEvents[bsky.FeedLike]) and prints periodic throughput, plus
+// how many records actually decoded vs. failed. It mirrors reportThroughput but
+// over typed batches, and exists to measure the typed-decode path end to end:
+// it touches a decoded field so the compiler cannot elide the decode.
+func reportTypedLikeThroughput(ctx context.Context, out io.Writer, client *jetstream.Client, interval time.Duration) error {
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+	var events, decoded, decodeErrs uint64
+	var lastCursor uint64
+	var subjectChars uint64 // touched so the decode isn't dead-code-eliminated
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	start := time.Now()
+	lastAt := start
+	lastEvents := uint64(0)
+	report := func(label string) {
+		now := time.Now()
+		secs := now.Sub(lastAt).Seconds()
+		if secs <= 0 {
+			secs = 1
+		}
+		eps := uint64(float64(events-lastEvents)/secs + 0.5)
+		_, _ = fmt.Fprintf(out, "%s elapsed=%s events=%s events_per_second=%s decoded=%s decode_errs=%s last_cursor=%d\n",
+			label, now.Sub(start).Round(time.Second), formatCount(events), formatCount(eps),
+			formatCount(decoded), formatCount(decodeErrs), lastCursor)
+		lastAt = now
+		lastEvents = events
+	}
+
+	done := ctx.Done()
+	stream, stop := typedIterPull(jetstream.TypedEvents[bsky.FeedLike](ctx, client, "app.bsky.feed.like"))
+	defer stop()
+	for {
+		select {
+		case <-done:
+			report("final")
+			return nil
+		case <-ticker.C:
+			report("stats")
+		case item, ok := <-stream:
+			if !ok {
+				report("final")
+				return nil
+			}
+			if item.err != nil {
+				if errors.Is(item.err, jetstream.ErrFatal) {
+					report("final")
+					return fmt.Errorf("event stream aborted: %w", item.err)
+				}
+				fmt.Fprintln(os.Stderr, "event error:", item.err)
+				continue
+			}
+			evs := item.batch.Events()
+			events += uint64(len(evs))
+			for i := range evs {
+				switch {
+				case evs[i].DecodeErr != nil:
+					decodeErrs++
+				case evs[i].Record != nil:
+					decoded++
+					subjectChars += uint64(len(evs[i].Record.Subject.URI))
+				}
+			}
+			if c := item.batch.LastCursor(); c > lastCursor {
+				lastCursor = c
+			}
+		}
+	}
+}
+
+// typedStreamItem carries one typed-batch-or-error from the pump.
+type typedStreamItem struct {
+	batch *jetstream.TypedBatch[bsky.FeedLike]
+	err   error
+}
+
+// typedIterPull is iterPull for the typed iterator (see iterPull).
+func typedIterPull(seq func(func(*jetstream.TypedBatch[bsky.FeedLike], error) bool)) (<-chan typedStreamItem, func()) {
+	ch := make(chan typedStreamItem)
+	done := make(chan struct{})
+	go func() {
+		defer close(ch)
+		seq(func(b *jetstream.TypedBatch[bsky.FeedLike], err error) bool {
+			select {
+			case ch <- typedStreamItem{batch: b, err: err}:
+				return true
+			case <-done:
+				return false
+			}
+		})
+	}()
+	return ch, func() { close(done) }
+}

--- a/engine.go
+++ b/engine.go
@@ -35,15 +35,18 @@ func newEngine(host string, cfg config) (engine, error) {
 			HasBeforeSeq: cfg.hasBeforeSeq,
 			BeforeSeq:    cfg.beforeSeq,
 		},
-		Backfill:     cfg.backfillRequested(),
-		BackfillOnly: cfg.backfillOnly,
-		LiveCursor:   cfg.liveCursor,
-		BatchSize:    cfg.batchSize,
-		Concurrency:  cfg.downloadConc,
-		Buffer:       bufAdapter,
-		XRPC:         newXRPCClient(host, cfg, xrpc.ATProtoOpts(30*time.Second)),
-		BulkXRPC:     newXRPCClient(host, cfg, xrpc.BulkDownloadOpts()),
-		Logger:       cfg.logger,
+		Backfill:         cfg.backfillRequested(),
+		BackfillOnly:     cfg.backfillOnly,
+		LiveCursor:       cfg.liveCursor,
+		BatchSize:        cfg.batchSize,
+		Concurrency:      cfg.downloadConc,
+		Buffer:           bufAdapter,
+		XRPC:             newXRPCClient(host, cfg, xrpc.ATProtoOpts(30*time.Second)),
+		BulkXRPC:         newXRPCClient(host, cfg, xrpc.BulkDownloadOpts()),
+		Logger:           cfg.logger,
+		RawRecords:       cfg.rawRecords,
+		RawRecordsCopied: cfg.rawRecordsCopied,
+		RawRecordCIDs:    cfg.rawRecordCIDs,
 	}
 	// ownBuf gates whether close() calls buf.Close(); only true when we created
 	// the buffer ourselves. When buf is nil (backfill-only, no caller buffer)
@@ -88,9 +91,12 @@ type realEngine struct {
 	closed    bool               // Close was called; a later run starts cancelled
 }
 
-func (e *realEngine) run(ctx context.Context, yield func(*Batch, error) bool) {
-	// Derive a cancelable ctx so Close can unwind a running tail. If Close
-	// already happened, start cancelled so the run returns promptly.
+// driveRun runs the engine with the caller's emit/error closures and backfill
+// sink, wrapping it in the Close cancellation handshake: it derives a cancelable
+// ctx, publishes the cancel so a concurrent Close can unwind the run, and clears
+// it on return. Both the default (*Batch) run and the generic typed run share
+// this; the only difference between them is the closures + sink they build.
+func (e *realEngine) driveRun(ctx context.Context, emitBatch func([]iclient.Event) bool, emitErr func(error) bool, bf iclient.BackfillSink) {
 	runCtx, cancel := context.WithCancel(ctx)
 	e.mu.Lock()
 	if e.closed {
@@ -106,8 +112,10 @@ func (e *realEngine) run(ctx context.Context, yield func(*Batch, error) bool) {
 		e.mu.Unlock()
 		cancel()
 	}()
+	e.eng.RunWithBackfill(runCtx, emitBatch, emitErr, bf)
+}
 
-	ctx = runCtx
+func (e *realEngine) run(ctx context.Context, yield func(*Batch, error) bool) {
 	stopped := false
 
 	// Backfill fast path: convert + batch each decoded block ON the parallel
@@ -163,7 +171,7 @@ func (e *realEngine) run(ctx context.Context, yield func(*Batch, error) bool) {
 		},
 	}
 
-	e.eng.RunWithBackfill(ctx,
+	e.driveRun(ctx,
 		func(batch []iclient.Event) bool {
 			if stopped {
 				return false

--- a/internal/client/decode.go
+++ b/internal/client/decode.go
@@ -20,7 +20,7 @@ import (
 // bytes retained in the returned Event (notably RecordCBOR) are copied.
 func decodeSegmentEvent(ev *segment.Event) (Event, error) {
 	var commit Commit
-	return decodeSegmentEventInto(ev, &commit)
+	return decodeSegmentEventInto(ev, &commit, recordDecodeMode{})
 }
 
 // decodeSegmentEventInto is decodeSegmentEvent but writes a commit row's data
@@ -31,7 +31,8 @@ func decodeSegmentEvent(ev *segment.Event) (Event, error) {
 // identity/account/sync rows it is ignored and those shapes are allocated
 // individually (they are comparatively rare). The caller MUST ensure commit's
 // backing slab is not grown/reallocated while the returned Event is reachable.
-func decodeSegmentEventInto(ev *segment.Event, commit *Commit) (Event, error) {
+// mode is forwarded to decodeCommitInto (raw vs. map record materialization).
+func decodeSegmentEventInto(ev *segment.Event, commit *Commit, mode recordDecodeMode) (Event, error) {
 	out := Event{
 		DID:    ev.DID,
 		Seq:    ev.Seq,
@@ -39,7 +40,7 @@ func decodeSegmentEventInto(ev *segment.Event, commit *Commit) (Event, error) {
 	}
 	switch ev.Kind {
 	case segment.KindCreate, segment.KindUpdate, segment.KindDelete, segment.KindCreateResync:
-		if err := decodeCommitInto(ev, commit); err != nil {
+		if err := decodeCommitInto(ev, commit, mode); err != nil {
 			return Event{}, err
 		}
 		out.Kind = KindCommit
@@ -76,7 +77,7 @@ func decodeSegmentEventInto(ev *segment.Event, commit *Commit) (Event, error) {
 // tests and single-event callers.
 func decodeCommit(ev *segment.Event) (*Commit, error) {
 	commit := &Commit{}
-	if err := decodeCommitInto(ev, commit); err != nil {
+	if err := decodeCommitInto(ev, commit, recordDecodeMode{}); err != nil {
 		return nil, err
 	}
 	return commit, nil
@@ -85,7 +86,17 @@ func decodeCommit(ev *segment.Event) (*Commit, error) {
 // decodeCommitInto fills *commit from a commit row. On error *commit may hold
 // partial data, but the caller discards the event (and the slab slot is never
 // read) on a decode failure, so the partial write is harmless.
-func decodeCommitInto(ev *segment.Event, commit *Commit) error {
+//
+// mode selects record materialization. In the default (map) mode it builds the
+// generic Record map[string]any, computes the CID, and clones RecordCBOR so the
+// caller may retain it. In raw mode it SKIPS the map build entirely (the
+// dominant decode allocation): Record stays nil, RecordCBOR aliases ev.Payload
+// zero-copy, and the CID is computed only if mode.wantCIDs. The raw aliasing is
+// safe because ev.Payload aliases the decompressed block buffer, which outlives
+// the batch (the segment events already alias it for DID/Collection/Rkey/Rev);
+// the contract — valid for the batch lifetime, copy to retain — is the same one
+// the default Record (built via UnmarshalNoCopy) already carries.
+func decodeCommitInto(ev *segment.Event, commit *Commit, mode recordDecodeMode) error {
 	*commit = Commit{
 		Operation:  commitOperation(ev.Kind),
 		Collection: ev.Collection,
@@ -93,6 +104,18 @@ func decodeCommitInto(ev *segment.Event, commit *Commit) error {
 		Rev:        ev.Rev,
 	}
 	if ev.Kind == segment.KindDelete {
+		return nil
+	}
+
+	if mode.raw {
+		if mode.wantCIDs {
+			commit.CID = cbor.ComputeCID(cbor.CodecDagCBOR, ev.Payload).String()
+		}
+		if mode.copyCBOR {
+			commit.RecordCBOR = bytes.Clone(ev.Payload) // safe to retain (WithRawRecordsCopied)
+		} else {
+			commit.RecordCBOR = ev.Payload // zero-copy alias; see doc + WithRawRecords contract
+		}
 		return nil
 	}
 

--- a/internal/client/downloader.go
+++ b/internal/client/downloader.go
@@ -53,12 +53,21 @@ type Downloader struct {
 	// unchanged (direct Download callers / unit tests). A nil return for a block
 	// means "nothing to emit" (empty/filtered), matching the len(events)>0 skip.
 	transform func(entryIdx int, evs []Event) any
+	// mode controls how commit records are materialized (raw vs. map[string]any).
+	// Zero value = the default map-building path, so existing callers/tests are
+	// unaffected. Set via SetRecordMode.
+	mode recordDecodeMode
 }
 
 // SetTransform installs the per-block worker-side transform (see Downloader.transform).
 // It is set separately from NewDownloader so the constructor signature stays
 // stable for the many direct callers/tests that do not need it.
 func (d *Downloader) SetTransform(fn func(entryIdx int, evs []Event) any) { d.transform = fn }
+
+// SetRecordMode selects raw vs. map record decode (see recordDecodeMode). The
+// zero value (default map build) applies when unset, keeping existing callers
+// unchanged.
+func (d *Downloader) SetRecordMode(m recordDecodeMode) { d.mode = m }
 
 // NewDownloader returns a Downloader using xc for getSegment/getBlock calls.
 // concurrency bounds in-flight downloads; values < 1 are clamped to 1.
@@ -488,7 +497,7 @@ func (d *Downloader) decodeFrame(frame []byte, segName string, blockIdx int) ([]
 			commit = &commits[ci]
 			ci++
 		}
-		ev, err := decodeSegmentEventInto(&rows[i], commit)
+		ev, err := decodeSegmentEventInto(&rows[i], commit, d.mode)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/client/engine.go
+++ b/internal/client/engine.go
@@ -68,6 +68,33 @@ type Config struct {
 	// the package default; tests set a tiny value to avoid real-time waits.
 	LiveBackoffMin time.Duration
 	Logger         *slog.Logger
+	// RawRecords, when true, makes commit decode SKIP building the generic
+	// Record map[string]any (decodeRecordMap — the dominant decode allocation at
+	// scale). Commit.Record is left nil and Commit.RecordCBOR is populated so a
+	// caller can decode it into a typed struct itself. See the root WithRawRecords
+	// option and TypedEvents.
+	RawRecords bool
+	// RawRecordsCopied, alongside RawRecords, clones RecordCBOR (backfill path)
+	// instead of aliasing the internal buffer, so it is safe to retain past the
+	// batch. See WithRawRecordsCopied.
+	RawRecordsCopied bool
+	// RawRecordCIDs, when true alongside RawRecords, still computes Commit.CID
+	// (sha256+base32 of the payload) on the backfill path. Default false in raw
+	// mode: CID is real per-record work the typed fast path avoids by default.
+	RawRecordCIDs bool
+}
+
+// recordDecodeMode captures how commit records are materialized, derived from
+// Config. It is passed down the decode paths (backfill + live) so the gating is
+// one value rather than scattered bools.
+type recordDecodeMode struct {
+	raw      bool // skip decodeRecordMap; leave Record nil, set RecordCBOR
+	copyCBOR bool // in raw mode, clone RecordCBOR instead of aliasing the buffer
+	wantCIDs bool // in raw mode, still compute Commit.CID
+}
+
+func (c Config) recordMode() recordDecodeMode {
+	return recordDecodeMode{raw: c.RawRecords, copyCBOR: c.RawRecordsCopied, wantCIDs: c.RawRecordCIDs}
 }
 
 // bulkClient returns the client for segment/block downloads, falling back to
@@ -187,6 +214,7 @@ func (e *Engine) runLiveOnly(ctx context.Context, emitBatch func([]Event) bool, 
 		dial:        e.cfg.Dial,
 		logger:      e.logger,
 		backoffMin:  e.cfg.LiveBackoffMin,
+		mode:        e.cfg.recordMode(),
 	})
 	// Route both events and errors through the batcher so the downstream yield
 	// is serialized against the flusher goroutine, and an error the consumer
@@ -350,6 +378,7 @@ func (e *Engine) runBackfillOnly(ctx context.Context, emitBatch func([]Event) bo
 	// arrive during a dump).
 	b := newBatcher(e.cfg.BatchSize, emitBatch, emitErr)
 	dl := NewDownloader(e.cfg.bulkClient(), e.cfg.Concurrency, newRowSelector(e.matcher, e.suppressor))
+	dl.SetRecordMode(e.cfg.recordMode())
 	emit, _ := e.backfillEmitFunc(b, bf, dl)
 	_ = dl.Download(ctx, plan.Entries, emit)
 
@@ -413,7 +442,7 @@ func (e *Engine) runBackfillThenLive(ctx context.Context, emitBatch func([]Event
 	if backfillCoveredNothing {
 		dedupFloor = gt.None[uint64]()
 	}
-	sink := newLiveSink(e.cfg.Buffer, e.suppressor, e.matcher)
+	sink := newLiveSink(e.cfg.Buffer, e.suppressor, e.matcher, e.cfg.recordMode())
 	liveCtx, stopLive := context.WithCancel(ctx)
 	defer stopLive()
 	consumer := newLiveConsumer(liveConfig{
@@ -434,6 +463,7 @@ func (e *Engine) runBackfillThenLive(ctx context.Context, emitBatch func([]Event
 		dial:        e.cfg.Dial,
 		logger:      e.logger,
 		backoffMin:  e.cfg.LiveBackoffMin,
+		mode:        e.cfg.recordMode(),
 	})
 	var liveWG sync.WaitGroup
 	liveWG.Go(func() {
@@ -452,6 +482,7 @@ func (e *Engine) runBackfillThenLive(ctx context.Context, emitBatch func([]Event
 	// returns only after the reassembler drains — so the cutover in phase 5 still
 	// installs the live forward path strictly AFTER the last backfill batch.
 	dl := NewDownloader(e.cfg.bulkClient(), e.cfg.Concurrency, newRowSelector(e.matcher, e.suppressor))
+	dl.SetRecordMode(e.cfg.recordMode())
 	emit, backfillStopped := e.backfillEmitFunc(b, bf, dl)
 	derr := dl.Download(ctx, plan.Entries, emit)
 	if derr != nil { // ctx cancelled

--- a/internal/client/live.go
+++ b/internal/client/live.go
@@ -83,6 +83,9 @@ type liveConfig struct {
 	// the package defaults. Tests set tiny values to avoid real-time waits.
 	backoffMin time.Duration
 	backoffMax time.Duration
+	// mode selects raw vs. map record materialization for live commits. Zero
+	// value = the default map build.
+	mode recordDecodeMode
 }
 
 func (c liveConfig) minBackoff() time.Duration {
@@ -196,7 +199,7 @@ func (c *liveConsumer) session(ctx context.Context, emit func(*Event, []byte, er
 		if typ != websocket.MessageText {
 			continue // jetstream frames are text JSON; ignore stray binary
 		}
-		ev, derr := decodeLiveFrame(data)
+		ev, derr := decodeLiveFrame(data, c.cfg.mode)
 		if errors.Is(derr, errSkipFrame) {
 			continue
 		}

--- a/internal/client/live_test.go
+++ b/internal/client/live_test.go
@@ -133,10 +133,10 @@ func TestLiveSinkAccountDeleteSuppressesDespiteCollectionFilter(t *testing.T) {
 	suppressor := NewSuppressor()
 	// Collection filter set: account/identity are not delivered.
 	matcher := NewMatcher(PlanRequest{Collections: []string{"app.bsky.feed.post"}})
-	sink := newLiveSink(&memBuffer{}, suppressor, matcher)
+	sink := newLiveSink(&memBuffer{}, suppressor, matcher, recordDecodeMode{})
 
 	// A live account-delete for did:plc:a at seq 100 arrives during buffering.
-	acctDel, err := decodeLiveFrame(liveAccountFrame(100, "did:plc:a", false, "deleted"))
+	acctDel, err := decodeLiveFrame(liveAccountFrame(100, "did:plc:a", false, "deleted"), recordDecodeMode{})
 	require.NoError(t, err)
 
 	// Buffering phase: onLive must fold the tombstone (it returns true to keep

--- a/internal/client/livedecode.go
+++ b/internal/client/livedecode.go
@@ -64,8 +64,10 @@ type liveSync struct {
 
 // decodeLiveFrame parses one extended JSON frame into an engine Event. It
 // returns errSkipFrame for control frames and unknown kinds, and a wrapped
-// error for malformed data frames or server error frames.
-func decodeLiveFrame(data []byte) (Event, error) {
+// error for malformed data frames or server error frames. mode selects raw vs.
+// map record materialization (see recordDecodeMode), matching the backfill path
+// so a typed consumer sees the same shape across the cutover.
+func decodeLiveFrame(data []byte, mode recordDecodeMode) (Event, error) {
 	var f liveFrame
 	if err := json.Unmarshal(data, &f); err != nil {
 		return Event{}, fmt.Errorf("jetstream: decode live frame: %w", err)
@@ -84,7 +86,7 @@ func decodeLiveFrame(data []byte) (Event, error) {
 
 	switch Kind(f.Kind) {
 	case KindCommit:
-		commit, err := liveCommitToEvent(f.Commit)
+		commit, err := liveCommitToEvent(f.Commit, mode)
 		if err != nil {
 			return Event{}, err
 		}
@@ -116,7 +118,7 @@ func decodeLiveFrame(data []byte) (Event, error) {
 	return out, nil
 }
 
-func liveCommitToEvent(c *liveCommit) (*Commit, error) {
+func liveCommitToEvent(c *liveCommit, mode recordDecodeMode) (*Commit, error) {
 	if c == nil {
 		return nil, fmt.Errorf("jetstream: live commit frame missing commit payload")
 	}
@@ -136,12 +138,18 @@ func liveCommitToEvent(c *liveCommit) (*Commit, error) {
 		if err != nil {
 			return nil, fmt.Errorf("jetstream: decode live record_cbor (collection=%s rkey=%s): %w", c.Collection, c.Rkey, err)
 		}
-		record, err := decodeRecordMap(raw)
-		if err != nil {
-			return nil, fmt.Errorf("jetstream: decode live record (collection=%s rkey=%s): %w", c.Collection, c.Rkey, err)
-		}
-		commit.Record = record
+		// raw is a fresh base64-decoded buffer (already owned), so it is safe to
+		// retain regardless of mode. In raw mode we skip the map build and leave
+		// Record nil; the consumer decodes RecordCBOR into a typed struct. CID is
+		// already on the wire here, so raw mode keeps it (no extra work).
 		commit.RecordCBOR = raw
+		if !mode.raw {
+			record, err := decodeRecordMap(raw)
+			if err != nil {
+				return nil, fmt.Errorf("jetstream: decode live record (collection=%s rkey=%s): %w", c.Collection, c.Rkey, err)
+			}
+			commit.Record = record
+		}
 	case OpDelete:
 		// No record payload on deletes.
 	default:

--- a/internal/client/livedecode_fuzz_test.go
+++ b/internal/client/livedecode_fuzz_test.go
@@ -28,7 +28,7 @@ func FuzzDecodeLiveFrame(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		// Must not panic. The return values are all acceptable; we only assert
 		// the absence of a crash and basic invariants on success.
-		ev, err := decodeLiveFrame(data)
+		ev, err := decodeLiveFrame(data, recordDecodeMode{})
 		if err != nil {
 			return
 		}

--- a/internal/client/livedecode_test.go
+++ b/internal/client/livedecode_test.go
@@ -46,7 +46,7 @@ func liveAccountFrame(seq uint64, did string, active bool, status string) []byte
 
 func TestDecodeLiveFrameCommit(t *testing.T) {
 	t.Parallel()
-	ev, err := decodeLiveFrame(liveCommitFrame(t, 42, "did:plc:a", "create", "app.bsky.feed.post", "r1", true))
+	ev, err := decodeLiveFrame(liveCommitFrame(t, 42, "did:plc:a", "create", "app.bsky.feed.post", "r1", true), recordDecodeMode{})
 	require.NoError(t, err)
 	require.Equal(t, KindCommit, ev.Kind)
 	require.EqualValues(t, 42, ev.Seq)
@@ -59,7 +59,7 @@ func TestDecodeLiveFrameCommit(t *testing.T) {
 
 func TestDecodeLiveFrameDelete(t *testing.T) {
 	t.Parallel()
-	ev, err := decodeLiveFrame(liveCommitFrame(t, 7, "did:plc:a", "delete", "app.bsky.feed.post", "r1", false))
+	ev, err := decodeLiveFrame(liveCommitFrame(t, 7, "did:plc:a", "delete", "app.bsky.feed.post", "r1", false), recordDecodeMode{})
 	require.NoError(t, err)
 	require.Equal(t, OpDelete, ev.Commit.Operation)
 	require.Nil(t, ev.Commit.Record)
@@ -69,27 +69,27 @@ func TestDecodeLiveFrameDelete(t *testing.T) {
 func TestDecodeLiveFrameCreateMissingCBOR(t *testing.T) {
 	t.Parallel()
 	// A create without record_cbor (i.e. not extended mode) must error.
-	_, err := decodeLiveFrame(liveCommitFrame(t, 1, "did:plc:a", "create", "c", "r", false))
+	_, err := decodeLiveFrame(liveCommitFrame(t, 1, "did:plc:a", "create", "c", "r", false), recordDecodeMode{})
 	require.ErrorContains(t, err, "record_cbor")
 }
 
 func TestDecodeLiveFrameAccountIdentitySync(t *testing.T) {
 	t.Parallel()
 	acct := []byte(`{"did":"did:plc:a","time_us":1,"seq":5,"kind":"account","account":{"did":"did:plc:a","active":false,"status":"deleted","seq":5,"time":"t"}}`)
-	ev, err := decodeLiveFrame(acct)
+	ev, err := decodeLiveFrame(acct, recordDecodeMode{})
 	require.NoError(t, err)
 	require.Equal(t, KindAccount, ev.Kind)
 	require.False(t, ev.Account.Active)
 	require.Equal(t, "deleted", ev.Account.Status)
 
 	id := []byte(`{"did":"did:plc:a","time_us":1,"seq":6,"kind":"identity","identity":{"did":"did:plc:a","handle":"alice.test","seq":6,"time":"t"}}`)
-	ev, err = decodeLiveFrame(id)
+	ev, err = decodeLiveFrame(id, recordDecodeMode{})
 	require.NoError(t, err)
 	require.Equal(t, KindIdentity, ev.Kind)
 	require.Equal(t, "alice.test", ev.Identity.Handle)
 
 	sync := []byte(`{"did":"did:plc:a","time_us":1,"seq":8,"kind":"sync","sync":{"did":"did:plc:a","rev":"rev1","seq":8,"time":"t"}}`)
-	ev, err = decodeLiveFrame(sync)
+	ev, err = decodeLiveFrame(sync, recordDecodeMode{})
 	require.NoError(t, err)
 	require.Equal(t, KindSync, ev.Kind)
 	require.Equal(t, "rev1", ev.Sync.Rev)
@@ -98,14 +98,14 @@ func TestDecodeLiveFrameAccountIdentitySync(t *testing.T) {
 func TestDecodeLiveFrameUnknownKindSkips(t *testing.T) {
 	t.Parallel()
 	for _, kind := range []string{"heartbeat", "segment_sealed", "segment_compacted", "future_thing"} {
-		_, err := decodeLiveFrame([]byte(`{"kind":"` + kind + `","seq":1}`))
+		_, err := decodeLiveFrame([]byte(`{"kind":"`+kind+`","seq":1}`), recordDecodeMode{})
 		require.ErrorIs(t, err, errSkipFrame, "kind %q must be skipped, not errored", kind)
 	}
 }
 
 func TestDecodeLiveFrameErrorFrame(t *testing.T) {
 	t.Parallel()
-	_, err := decodeLiveFrame([]byte(`{"error":"FutureCursor","message":"cursor in the future"}`))
+	_, err := decodeLiveFrame([]byte(`{"error":"FutureCursor","message":"cursor in the future"}`), recordDecodeMode{})
 	require.ErrorContains(t, err, "FutureCursor")
 	require.NotErrorIs(t, err, errSkipFrame)
 }
@@ -113,7 +113,7 @@ func TestDecodeLiveFrameErrorFrame(t *testing.T) {
 func TestDecodeLiveFrameSeqFallbackToCursor(t *testing.T) {
 	t.Parallel()
 	// A frame with only cursor (no seq) still yields a usable seq.
-	ev, err := decodeLiveFrame([]byte(`{"did":"did:plc:a","cursor":99,"kind":"account","account":{"did":"did:plc:a","active":true,"seq":99,"time":"t"}}`))
+	ev, err := decodeLiveFrame([]byte(`{"did":"did:plc:a","cursor":99,"kind":"account","account":{"did":"did:plc:a","active":true,"seq":99,"time":"t"}}`), recordDecodeMode{})
 	require.NoError(t, err)
 	require.EqualValues(t, 99, ev.Seq)
 }

--- a/internal/client/livesink.go
+++ b/internal/client/livesink.go
@@ -26,6 +26,7 @@ type liveSink struct {
 	buf        Buffer
 	suppressor *Suppressor
 	matcher    *Matcher
+	mode       recordDecodeMode // raw vs. map record decode for drained buffered frames
 
 	mu         sync.Mutex
 	forwarding bool
@@ -37,8 +38,8 @@ type liveSink struct {
 	fatalErr error
 }
 
-func newLiveSink(buf Buffer, suppressor *Suppressor, matcher *Matcher) *liveSink {
-	return &liveSink{buf: buf, suppressor: suppressor, matcher: matcher}
+func newLiveSink(buf Buffer, suppressor *Suppressor, matcher *Matcher, mode recordDecodeMode) *liveSink {
+	return &liveSink{buf: buf, suppressor: suppressor, matcher: matcher, mode: mode}
 }
 
 // onLive is the live consumer's emit callback. raw is the verbatim JSON frame
@@ -118,7 +119,7 @@ func (s *liveSink) flipAndDrain(ctx context.Context, coveredThrough gt.Option[ui
 		if err != nil {
 			return err
 		}
-		ev, decErr := decodeLiveFrame(fr.Data)
+		ev, decErr := decodeLiveFrame(fr.Data, s.mode)
 		if decErr != nil {
 			emitErr(fmt.Errorf("jetstream: corrupt buffered live frame seq=%d: %w", fr.Seq, decErr))
 			continue

--- a/internal/oracle/client_observer_test.go
+++ b/internal/oracle/client_observer_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bluesky-social/jetstream/internal/jetstreamd"
 	"github.com/bluesky-social/jetstream/internal/simulator/world"
 	"github.com/bluesky-social/jetstream/segment"
+	"github.com/jcalabro/atmos/api/bsky"
 	"github.com/jcalabro/atmos/api/comatproto"
 	"github.com/jcalabro/gt"
 	"github.com/stretchr/testify/require"
@@ -227,6 +228,88 @@ func assertClientBackfillCompacted(t *testing.T, cfg Config, run *runtimeRun, tr
 
 	t.Logf("%s: client backfill matched ground truth over %d emitted events (window=%d watermark=%d) in mode=%s seed=%d",
 		phase, len(res.events), len(window), watermark, cfg.Mode, cfg.Seed)
+}
+
+// assertTypedLikeBackfill drives the REAL public client through the typed fast
+// path (jetstream.TypedEvents[bsky.FeedLike] over WithRawRecords) against the
+// running server, decoding every app.bsky.feed.like create on the parallel
+// decode workers. It is the end-to-end guard for #146's worker-parallel typed
+// decode: it asserts the typed path reaches the watermark, decodes likes with
+// ZERO decode errors, that every decoded like carries the well-formed subject
+// strongref the simulator generated, and — the correctness crux — that the SET
+// of (DID,rkey) likes the typed path surfaces equals what the map path observes
+// from the same server. Run as a bounded backfill-only dump so it terminates.
+func assertTypedLikeBackfill(t *testing.T, cfg Config, run *runtimeRun, baseURL string, beforeSeq uint64) {
+	t.Helper()
+
+	client, err := jetstream.Subscribe(baseURL,
+		jetstream.WithCollections([]string{"app.bsky.feed.like"}),
+		jetstream.WithAfterSeq(0),
+		jetstream.WithBeforeSeq(beforeSeq),
+		jetstream.WithBackfillOnly(),
+		jetstream.WithRawRecords(),
+	)
+	require.NoErrorf(t, err, "typed subscribe: mode=%s seed=%d", cfg.Mode, cfg.Seed)
+	t.Cleanup(func() { _ = client.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), oracleWaitTimeout(cfg))
+	defer cancel()
+	go func() {
+		select {
+		case <-run.exited:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	typedLikes := map[string]string{} // did/rkey -> subject URI (decoded via the typed path)
+	var decoded, decodeErrs, maxSeq uint64
+	for tb, err := range jetstream.TypedEvents[bsky.FeedLike](ctx, client, "app.bsky.feed.like") {
+		require.NoErrorf(t, err, "typed backfill stream: mode=%s seed=%d", cfg.Mode, cfg.Seed)
+		for _, te := range tb.Events() {
+			if te.Event.Seq > maxSeq {
+				maxSeq = te.Event.Seq
+			}
+			require.NoErrorf(t, te.DecodeErr, "typed like decode error seq=%d", te.Event.Seq)
+			if te.Record == nil {
+				// Only like creates decode; deletes (no record) pass through.
+				continue
+			}
+			decoded++
+			require.NotEmpty(t, te.Record.Subject.URI, "decoded like must carry its subject URI (worker-parallel typed decode)")
+			typedLikes[te.Event.DID+"/"+te.Event.Commit.Rkey] = te.Record.Subject.URI
+		}
+	}
+	require.Zerof(t, decodeErrs, "typed backfill had %d decode errors", decodeErrs)
+	require.Positivef(t, decoded, "typed backfill decoded no likes: mode=%s seed=%d", cfg.Mode, cfg.Seed)
+
+	// Cross-check against the MAP path over the same bounded range: the set of
+	// surviving like creates must match exactly, proving the worker-parallel
+	// typed decode neither drops, duplicates, nor mis-decodes vs. the default.
+	mapClient, err := jetstream.Subscribe(baseURL,
+		jetstream.WithCollections([]string{"app.bsky.feed.like"}),
+		jetstream.WithAfterSeq(0),
+		jetstream.WithBeforeSeq(beforeSeq),
+		jetstream.WithBackfillOnly(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mapClient.Close() })
+	mapLikes := map[string]string{}
+	for batch, err := range mapClient.Events(ctx) {
+		require.NoError(t, err)
+		for _, ev := range batch.Events() {
+			if ev.Kind != jetstream.KindCommit || ev.Commit == nil || ev.Commit.Operation == jetstream.OpDelete {
+				continue
+			}
+			subj, _ := ev.Commit.Record["subject"].(map[string]any)
+			uri, _ := subj["uri"].(string)
+			mapLikes[ev.DID+"/"+ev.Commit.Rkey] = uri
+		}
+	}
+	require.Equal(t, mapLikes, typedLikes,
+		"typed fast path must surface exactly the same like set (DID/rkey -> subject URI) as the map path; mode=%s seed=%d", cfg.Mode, cfg.Seed)
+	t.Logf("typed-like-backfill: decoded %d likes via worker-parallel typed path, matched map path exactly (max_seq=%d) mode=%s seed=%d",
+		decoded, maxSeq, cfg.Mode, cfg.Seed)
 }
 
 // observedEventFromClient adapts a decoded public jetstream.Event into the

--- a/internal/oracle/harness_test.go
+++ b/internal/oracle/harness_test.go
@@ -296,6 +296,11 @@ func TestOracle_DefaultLifecycle(t *testing.T) {
 	// serving/client artifact.
 	assertClientBackfillCompacted(t, cfg, run, trace, dataDir, w, compaction, publicURL, steadyCompaction.Watermark, "steady-state-client-backfill")
 
+	// #146: drive the REAL client through the typed fast path (worker-parallel
+	// decode into bsky.FeedLike) over the same sealed range and assert it decodes
+	// likes cleanly and surfaces exactly the same like set as the map path.
+	assertTypedLikeBackfill(t, cfg, run, publicURL, steadyCompaction.Watermark)
+
 	// Exercise the overlay's DID-tombstone section inside the live overlay
 	// window. The earlier bootstrap account-delete and sync tombstones are
 	// usually at or below W by this point, so a mutation that drops DID

--- a/options.go
+++ b/options.go
@@ -34,6 +34,13 @@ type config struct {
 	// (initial + retries) the XRPC clients make per request. 0 (unset)
 	// leaves xrpc on its default retry policy. See WithMaxDownloadAttempts.
 	maxDownloadAttempts int
+	// rawRecords skips building Commit.Record map[string]any (see WithRawRecords);
+	// rawRecordsCopied additionally clones RecordCBOR so it is safe to retain
+	// (see WithRawRecordsCopied); rawRecordCIDs keeps computing Commit.CID in raw
+	// mode (see WithRawRecordCIDs).
+	rawRecords       bool
+	rawRecordsCopied bool
+	rawRecordCIDs    bool
 }
 
 // Defaults applied when an option is not supplied.
@@ -228,4 +235,50 @@ func WithLogger(l *slog.Logger) Option {
 			c.logger = l
 		}
 	}
+}
+
+// WithRawRecords makes commit decoding SKIP building the generic
+// Commit.Record map[string]any. Instead, Commit.Record is left nil and
+// Commit.RecordCBOR is populated with the record's raw DAG-CBOR bytes, which the
+// caller decodes itself — typically into a typed struct via the generic
+// TypedEvents helper. Building the generic map dominates decode CPU and
+// allocations at scale (#142), so skipping it is the main lever for high-volume
+// backfills of a single record type (e.g. app.bsky.feed.like).
+//
+// Deletes (no record), identity/account/sync events, and the default Commit
+// fields (Operation/Collection/Rkey/Rev) are unaffected. Commit.CID is left
+// empty in raw mode unless WithRawRecordCIDs is also set (computing it is real
+// per-record work this fast path avoids by default).
+//
+// Aliasing/lifetime contract: in raw mode Commit.RecordCBOR aliases the
+// client's internal decompressed buffer on the backfill path (zero-copy), valid
+// only for the lifetime of the Batch that delivered it — the same contract the
+// default Record already carries. Anything decoded from it that retains slices
+// or strings (typed structs whose string fields alias the input) is likewise
+// valid only for the batch; copy it to retain longer. Use WithRawRecordsCopied
+// for a safe (cloned) variant that still skips the map build.
+func WithRawRecords() Option {
+	return func(c *config) { c.rawRecords = true }
+}
+
+// WithRawRecordsCopied is like WithRawRecords but Commit.RecordCBOR is a private
+// copy of the record bytes (not an alias of the internal buffer), so it — and
+// anything decoded from it — is safe to retain past the delivering Batch. It
+// still skips the generic map build; the only cost over WithRawRecords is one
+// allocation + copy of the raw bytes per commit. Use this when the consumer
+// keeps records around; use WithRawRecords for maximum throughput when records
+// are processed within the iteration.
+func WithRawRecordsCopied() Option {
+	return func(c *config) {
+		c.rawRecords = true
+		c.rawRecordsCopied = true
+	}
+}
+
+// WithRawRecordCIDs keeps computing Commit.CID (the record's content identifier,
+// a sha256 + base32 of the payload) when raw-record mode is enabled. Without it,
+// raw mode leaves Commit.CID empty to avoid the per-record hashing cost. No
+// effect unless WithRawRecords or WithRawRecordsCopied is also set.
+func WithRawRecordCIDs() Option {
+	return func(c *config) { c.rawRecordCIDs = true }
 }

--- a/typed.go
+++ b/typed.go
@@ -1,0 +1,235 @@
+package jetstream
+
+import (
+	"context"
+	"fmt"
+	"iter"
+
+	iclient "github.com/bluesky-social/jetstream/internal/client"
+)
+
+// TypedEvent pairs a delivered Event with its record decoded into the caller's
+// type T. It is produced by TypedEvents.
+//
+//   - For a create/update commit whose Collection matches the requested NSID and
+//     whose record decoded cleanly, Record is non-nil and DecodeErr is nil.
+//   - For a commit whose record failed to decode into T, Record is nil and
+//     DecodeErr is set (the Event is still delivered; nothing is dropped).
+//   - For a delete, a non-commit event (identity/account/sync), or a commit of a
+//     different collection, Record and DecodeErr are both nil — inspect Event.
+//
+// Event always carries the full envelope (DID/Seq/TimeUS/Kind and, for commits,
+// Operation/Collection/Rkey/Rev/CID/RecordCBOR). In the raw-record modes that
+// TypedEvents requires, Event.Commit.Record (the generic map) is nil by design.
+type TypedEvent[T any] struct {
+	Event     Event
+	Record    *T
+	DecodeErr error
+}
+
+// TypedBatch is a batch of TypedEvents, mirroring Batch.
+type TypedBatch[T any] struct {
+	events []TypedEvent[T]
+}
+
+// Events returns the typed events in this batch. The slice — and any non-nil
+// Record in it — is owned by the caller for the lifetime of the loop iteration;
+// do not retain past the next iteration without copying (see the aliasing note
+// on TypedEvents).
+func (b *TypedBatch[T]) Events() []TypedEvent[T] { return b.events }
+
+// LastCursor returns the highest Seq in the batch, suitable for persisting as a
+// resume point. Returns 0 for an empty batch.
+func (b *TypedBatch[T]) LastCursor() uint64 {
+	var maxSeq uint64
+	for i := range b.events {
+		if b.events[i].Event.Seq > maxSeq {
+			maxSeq = b.events[i].Event.Seq
+		}
+	}
+	return maxSeq
+}
+
+// TypedEvents adapts a Client's event stream into records decoded as type T,
+// avoiding the generic map[string]any decode that dominates the client's CPU
+// and allocations at scale (#142). The client MUST have been built with
+// WithRawRecords or WithRawRecordsCopied so the expensive map build is skipped
+// on the parallel decode workers; TypedEvents then decodes each matching record
+// straight into a *T via PT.UnmarshalCBOR.
+//
+// T is a lexicon record type and PT its pointer, constrained to implement
+// UnmarshalCBOR — exactly the shape atmos's generated record types satisfy, so
+// the call site is just:
+//
+//	for tb, err := range jetstream.TypedEvents[bsky.FeedLike](ctx, c, "app.bsky.feed.like") {
+//		for _, te := range tb.Events() {
+//			if te.Record != nil { /* te.Record is *bsky.FeedLike */ }
+//		}
+//	}
+//
+// collection is the NSID whose commits are decoded into T; it MUST be non-empty
+// and MUST match the type T. Only create/update commits of that collection are
+// decoded — every other event (deletes, other collections, identity/account/
+// sync) passes through with a nil Record (see TypedEvent). Requiring the
+// collection is a safety measure: feeding one record type's bytes to another's
+// UnmarshalCBOR can silently produce a garbage struct rather than an error, so
+// TypedEvents never guesses. Pair it with WithCollections([]string{collection})
+// on the Client so the server/engine only deliver that collection.
+//
+// Errors from the underlying stream are forwarded verbatim (with a nil batch),
+// preserving the ErrFatal contract. Per-record decode failures are surfaced as
+// TypedEvent.DecodeErr, not as stream errors, so one bad record does not abort
+// iteration.
+//
+// Aliasing/lifetime: with WithRawRecords (the zero-copy default), a decoded *T
+// may alias the client's internal buffer through Event.Commit.RecordCBOR — its
+// string/byte fields are valid only for the current loop iteration. Copy what
+// you need to retain, or build the Client with WithRawRecordsCopied for records
+// that are safe to keep.
+func TypedEvents[T any, PT interface {
+	*T
+	UnmarshalCBOR([]byte) error
+}](ctx context.Context, c *Client, collection string) iter.Seq2[*TypedBatch[T], error] {
+	return func(yield func(*TypedBatch[T], error) bool) {
+		if collection == "" {
+			yield(nil, fmt.Errorf("jetstream: TypedEvents requires a non-empty collection matching the record type"))
+			return
+		}
+		if c == nil || c.engine == nil {
+			yield(nil, errClientNotInitialized)
+			return
+		}
+		if c.closed.Load() {
+			yield(nil, fmt.Errorf("jetstream: client is closed"))
+			return
+		}
+		// Fast path: when the client is backed by the real engine, run the typed
+		// record decode ON the parallel decode workers (via the engine's backfill
+		// transform seam) instead of in this single consumer goroutine. Decoding
+		// the whole archive's records into T on one goroutine is the bottleneck at
+		// high core counts (#146); fanning it across the worker pool is the point.
+		if re, ok := c.engine.(*realEngine); ok {
+			typedRun[T, PT](ctx, re, collection, yield)
+			return
+		}
+		// Fallback (test fakes / non-real engines): assemble typed batches in this
+		// goroutine over the public Events stream. Identical output to the fast
+		// path — both call assembleTyped — just not parallel.
+		for batch, err := range c.Events(ctx) {
+			if err != nil {
+				if !yield(nil, err) {
+					return
+				}
+				continue
+			}
+			if !yield(assembleTyped[T, PT](batch.Events(), collection), nil) {
+				return
+			}
+		}
+	}
+}
+
+// typedRun drives the real engine with a TYPED backfill sink: the per-block
+// transform runs on the decode-worker pool, converting each block's events to
+// public events and decoding matching records into *T (so the expensive typed
+// UnmarshalCBOR is parallel, not serial in the consumer). The reassembler then
+// hands the ready *TypedBatch[T] to Emit in seq order. The live-tail/error
+// closures assemble typed batches in the (single) emit goroutine — fine because
+// the live path is low-volume — so the consumer sees one uniform typed stream
+// across the backfill→live cutover.
+func typedRun[T any, PT interface {
+	*T
+	UnmarshalCBOR([]byte) error
+}](ctx context.Context, re *realEngine, collection string, yield func(*TypedBatch[T], error) bool) {
+	stopped := false
+	bf := iclient.BackfillSink{
+		Transform: func(_ int, evs []iclient.Event) any {
+			if len(evs) == 0 {
+				return nil
+			}
+			// Convert to public events (slab-allocated) then decode records into T,
+			// all on this worker goroutine. One *TypedBatch[T] per block, boxed as
+			// any so internal/client never names T.
+			return assembleTyped[T, PT](toPublicEvents(evs), collection)
+		},
+		Emit: func(res iclient.EntryResult) bool {
+			if stopped {
+				return false
+			}
+			tb, _ := res.Payload.(*TypedBatch[T])
+			if tb == nil {
+				return true // empty/filtered block
+			}
+			if !yield(tb, nil) {
+				stopped = true
+				return false
+			}
+			return true
+		},
+	}
+	emitBatch := func(batch []iclient.Event) bool {
+		if stopped {
+			return false
+		}
+		if !yield(assembleTyped[T, PT](toPublicEvents(batch), collection), nil) {
+			stopped = true
+			return false
+		}
+		return true
+	}
+	emitErr := func(err error) bool {
+		if stopped {
+			return false
+		}
+		if !yield(nil, err) {
+			stopped = true
+			return false
+		}
+		return true
+	}
+	re.driveRun(ctx, emitBatch, emitErr, bf)
+}
+
+// assembleTyped turns a slice of public events into a TypedBatch[T], decoding
+// each create/update commit of collection into a *T drawn from a per-batch slab.
+// It is the single shared assembler used by both the worker-parallel fast path
+// and the serial fallback, so their output is identical by construction.
+func assembleTyped[T any, PT interface {
+	*T
+	UnmarshalCBOR([]byte) error
+}](src []Event, collection string) *TypedBatch[T] {
+	out := make([]TypedEvent[T], len(src))
+	// One records slab per batch, presized and indexed by a counter so the
+	// &records[i] handed to each TypedEvent stays stable (never grown). It is
+	// dropped to GC with the batch and never pooled — same lifetime rule as the
+	// rest of the client's slabs.
+	records := make([]T, len(src))
+	ri := 0
+	for i := range src {
+		ev := src[i]
+		te := TypedEvent[T]{Event: ev}
+		if decodable(ev, collection) {
+			rec := &records[ri]
+			ri++
+			if derr := PT(rec).UnmarshalCBOR(ev.Commit.RecordCBOR); derr != nil {
+				te.DecodeErr = fmt.Errorf("jetstream: decode %s record (rkey=%s seq=%d): %w",
+					collection, ev.Commit.Rkey, ev.Seq, derr)
+			} else {
+				te.Record = rec
+			}
+		}
+		out[i] = te
+	}
+	return &TypedBatch[T]{events: out}
+}
+
+// decodable reports whether ev is a create/update commit of the requested
+// collection carrying record bytes — i.e. a row TypedEvents should decode into
+// T. Deletes (no record), other collections, and non-commit events are not.
+func decodable(ev Event, collection string) bool {
+	return ev.Kind == KindCommit &&
+		ev.Commit != nil &&
+		(ev.Commit.Operation == OpCreate || ev.Commit.Operation == OpUpdate) &&
+		ev.Commit.Collection == collection &&
+		len(ev.Commit.RecordCBOR) > 0
+}

--- a/typed_test.go
+++ b/typed_test.go
@@ -1,0 +1,218 @@
+package jetstream
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jcalabro/atmos/api/bsky"
+	comatproto "github.com/jcalabro/atmos/api/comatproto"
+	"github.com/jcalabro/atmos/cbor"
+	"github.com/stretchr/testify/require"
+)
+
+// scriptEngine is a fake engine that yields a fixed sequence of batches (then
+// ends), for exercising the public typed/iterator layer without a real server.
+type scriptEngine struct {
+	batches []*Batch
+}
+
+func (e *scriptEngine) run(_ context.Context, yield func(*Batch, error) bool) {
+	for _, b := range e.batches {
+		if !yield(b, nil) {
+			return
+		}
+	}
+}
+func (e *scriptEngine) close() error { return nil }
+
+func clientWithBatches(batches ...*Batch) *Client {
+	return &Client{engine: &scriptEngine{batches: batches}}
+}
+
+// likeCBOR builds the raw DAG-CBOR for an app.bsky.feed.like record, as the
+// engine would deliver in RecordCBOR under WithRawRecords.
+func likeCBOR(t *testing.T, uri, cid string) []byte {
+	t.Helper()
+	rec := &bsky.FeedLike{
+		CreatedAt: "2024-11-20T15:27:04.328Z",
+		Subject:   comatproto.RepoStrongRef{URI: uri, CID: cid},
+	}
+	raw, err := rec.MarshalCBOR()
+	require.NoError(t, err)
+	return raw
+}
+
+func likeCommit(t *testing.T, seq uint64, rkey, uri, cid string) Event {
+	t.Helper()
+	return Event{
+		DID: "did:plc:a", Seq: seq, Kind: KindCommit,
+		Commit: &Commit{Operation: OpCreate, Collection: "app.bsky.feed.like", Rkey: rkey, RecordCBOR: likeCBOR(t, uri, cid)},
+	}
+}
+
+// TestTypedEventsDecodesLikes is the happy path: create commits of the requested
+// collection decode into *bsky.FeedLike with correct fields, in order.
+func TestTypedEventsDecodesLikes(t *testing.T) {
+	t.Parallel()
+	b := &Batch{events: []Event{
+		likeCommit(t, 1, "r1", "at://did:plc:x/app.bsky.feed.post/p1", "bafy1"),
+		likeCommit(t, 2, "r2", "at://did:plc:y/app.bsky.feed.post/p2", "bafy2"),
+	}}
+	c := clientWithBatches(b)
+
+	var got []*bsky.FeedLike
+	for tb, err := range TypedEvents[bsky.FeedLike](context.Background(), c, "app.bsky.feed.like") {
+		require.NoError(t, err)
+		for _, te := range tb.Events() {
+			require.NoError(t, te.DecodeErr)
+			require.NotNil(t, te.Record)
+			got = append(got, te.Record)
+		}
+	}
+	require.Len(t, got, 2)
+	require.Equal(t, "at://did:plc:x/app.bsky.feed.post/p1", got[0].Subject.URI)
+	require.Equal(t, "at://did:plc:y/app.bsky.feed.post/p2", got[1].Subject.URI)
+	// Distinct slab slots (no aliasing of one record across events).
+	require.NotSame(t, got[0], got[1])
+}
+
+// TestTypedEventsPassesThroughNonDecodable verifies deletes, other collections,
+// and non-commit events are delivered with a nil Record and nil DecodeErr —
+// never dropped, never mis-decoded.
+func TestTypedEventsPassesThroughNonDecodable(t *testing.T) {
+	t.Parallel()
+	b := &Batch{events: []Event{
+		likeCommit(t, 1, "r1", "at://x/y/z", "bafy"),
+		{DID: "did:plc:a", Seq: 2, Kind: KindCommit, Commit: &Commit{Operation: OpDelete, Collection: "app.bsky.feed.like", Rkey: "r1"}},                           // delete: no record
+		{DID: "did:plc:a", Seq: 3, Kind: KindCommit, Commit: &Commit{Operation: OpCreate, Collection: "app.bsky.feed.post", Rkey: "p1", RecordCBOR: []byte{0xa0}}}, // other collection
+		{DID: "did:plc:a", Seq: 4, Kind: KindIdentity, Identity: &Identity{DID: "did:plc:a", Handle: "h.test"}},                                                    // non-commit
+	}}
+	c := clientWithBatches(b)
+
+	var decoded, passthrough int
+	for tb, err := range TypedEvents[bsky.FeedLike](context.Background(), c, "app.bsky.feed.like") {
+		require.NoError(t, err)
+		for _, te := range tb.Events() {
+			require.NoError(t, te.DecodeErr, "no passthrough event should produce a decode error")
+			if te.Record != nil {
+				decoded++
+			} else {
+				passthrough++
+			}
+		}
+	}
+	require.Equal(t, 1, decoded, "only the like create decodes")
+	require.Equal(t, 3, passthrough, "delete, other-collection, and identity pass through with nil Record")
+}
+
+// TestTypedEventsSurfacesDecodeError verifies a corrupt record of the requested
+// collection yields DecodeErr (never a zero-value record presented as success),
+// while the surrounding good records still decode.
+func TestTypedEventsSurfacesDecodeError(t *testing.T) {
+	t.Parallel()
+	bad := Event{DID: "did:plc:a", Seq: 2, Kind: KindCommit,
+		Commit: &Commit{Operation: OpCreate, Collection: "app.bsky.feed.like", Rkey: "bad", RecordCBOR: []byte{0xff, 0x00, 0x13}}} // not valid CBOR map
+	b := &Batch{events: []Event{
+		likeCommit(t, 1, "r1", "at://x/y/z", "bafy"),
+		bad,
+		likeCommit(t, 3, "r3", "at://a/b/c", "bafy3"),
+	}}
+	c := clientWithBatches(b)
+
+	var ok, errs int
+	for tb, err := range TypedEvents[bsky.FeedLike](context.Background(), c, "app.bsky.feed.like") {
+		require.NoError(t, err)
+		for _, te := range tb.Events() {
+			if te.DecodeErr != nil {
+				errs++
+				require.Nil(t, te.Record, "a decode error must not also present a record")
+				require.Equal(t, uint64(2), te.Event.Seq)
+			} else if te.Record != nil {
+				ok++
+			}
+		}
+	}
+	require.Equal(t, 2, ok, "the two good likes decode")
+	require.Equal(t, 1, errs, "the corrupt like surfaces exactly one decode error")
+}
+
+// TestTypedEventsRejectsEmptyCollection guards the mis-decode safety measure: an
+// empty collection is rejected up front rather than decoding everything.
+func TestTypedEventsRejectsEmptyCollection(t *testing.T) {
+	t.Parallel()
+	c := clientWithBatches(&Batch{events: []Event{likeCommit(t, 1, "r1", "at://x/y/z", "bafy")}})
+	var sawErr error
+	var batches int
+	for tb, err := range TypedEvents[bsky.FeedLike](context.Background(), c, "") {
+		if err != nil {
+			sawErr = err
+			continue
+		}
+		_ = tb
+		batches++
+	}
+	require.Error(t, sawErr, "empty collection must be rejected")
+	require.Zero(t, batches, "no batches delivered on the rejection path")
+}
+
+// TestTypedEventsForwardsStreamError verifies an underlying recoverable error is
+// forwarded (nil batch) and iteration continues, preserving the Events contract.
+func TestTypedEventsForwardsStreamError(t *testing.T) {
+	t.Parallel()
+	// scriptEngine yields only batches; use a dedicated engine that yields an error.
+	c := &Client{engine: &errThenBatchEngine{
+		err:   context.Canceled,
+		batch: &Batch{events: []Event{likeCommit(t, 5, "r5", "at://x/y/z", "bafy")}},
+	}}
+	var sawErr error
+	var decoded int
+	for tb, err := range TypedEvents[bsky.FeedLike](context.Background(), c, "app.bsky.feed.like") {
+		if err != nil {
+			sawErr = err
+			continue
+		}
+		for _, te := range tb.Events() {
+			if te.Record != nil {
+				decoded++
+			}
+		}
+	}
+	require.ErrorIs(t, sawErr, context.Canceled)
+	require.Equal(t, 1, decoded, "iteration continues past a recoverable error")
+}
+
+type errThenBatchEngine struct {
+	err   error
+	batch *Batch
+}
+
+func (e *errThenBatchEngine) run(_ context.Context, yield func(*Batch, error) bool) {
+	if !yield(nil, e.err) {
+		return
+	}
+	yield(e.batch, nil)
+}
+func (e *errThenBatchEngine) close() error { return nil }
+
+// TestTypedBatchLastCursor mirrors Batch.LastCursor for the typed batch.
+func TestTypedBatchLastCursor(t *testing.T) {
+	t.Parallel()
+	var empty TypedBatch[bsky.FeedLike]
+	require.Zero(t, empty.LastCursor())
+	tb := TypedBatch[bsky.FeedLike]{events: []TypedEvent[bsky.FeedLike]{
+		{Event: Event{Seq: 3}}, {Event: Event{Seq: 9}}, {Event: Event{Seq: 5}},
+	}}
+	require.EqualValues(t, 9, tb.LastCursor())
+}
+
+// sanity: the constraint accepts the atmos generated type and round-trips.
+func TestFeedLikeUnmarshalSanity(t *testing.T) {
+	t.Parallel()
+	raw := likeCBOR(t, "at://x/y/z", "bafy")
+	var fl bsky.FeedLike
+	require.NoError(t, fl.UnmarshalCBOR(raw))
+	require.Equal(t, "at://x/y/z", fl.Subject.URI)
+	// confirm the bytes are what cbor expects (no panic, valid map)
+	_, err := cbor.UnmarshalNoCopy(raw)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Adds an optional, generic typed-record consumption path that decodes records straight into a caller-chosen lexicon struct, skipping the `map[string]any` build. That generic map was the client's dominant decode allocation, and at 256 cores its allocator contention capped the backfill at ~10M events/s using ~30 of 256 cores. The typed path removes that wall **and** keeps decode parallel: **~10.4M → ~26M events/s on a 256-core host**, scaling near-linearly to ~16 cores.

## Public API (additive; the default map path is byte-for-byte unchanged)
- `WithRawRecords()` / `WithRawRecordsCopied()` / `WithRawRecordCIDs()` — skip the generic map build. `Commit.Record` stays nil; `Commit.RecordCBOR` is populated (zero-copy by default, cloned under `…Copied`); `CID` is off unless `…CIDs`. Threaded through both the backfill and live decode paths so a typed consumer sees one uniform stream across the cutover.
- `TypedEvents[T any, PT interface{ *T; UnmarshalCBOR([]byte) error }](ctx, *Client, collection) iter.Seq2[*TypedBatch[T], error]` — decodes each create/update commit of the (required, non-empty) `collection` into a `*T`. Deletes, other collections, and non-commit events pass through with a nil `Record`; a per-record decode failure surfaces as `TypedEvent.DecodeErr` (never a zero-value record presented as success, never a dropped event). The `PT` constraint makes "wrong type" a compile error and needs no decoder func — `bsky.FeedLike` et al. satisfy it directly.

## The key design point: decode on the workers, not the consumer
The typed `UnmarshalCBOR` runs **on the parallel decode-worker pool**, not the single consumer goroutine. A first cut that decoded in the consumer loop *regressed* at scale (serial decode starved the workers: 5.6M vs 10.4M map on the 256-core box). `TypedEvents` detects the real engine and installs a typed `BackfillSink` whose worker-side transform converts the block and decodes records into a per-batch `[]T` slab, handing a ready `*TypedBatch[T]` to the ordered reassembler. A serial fallback (the same `assembleTyped` function) covers non-real engines / tests, so the two are identical by construction. The Close-cancellation handshake is factored into `realEngine.driveRun` and shared.

## Measurements (app.bsky.feed.like backfill)

32-core workstation: ~4.2M (map) → ~5.0M eps; decode allocations ~590M → ~6.5M per 12s window (the `unmarshalMap`/value-boxing alloc is gone).

256-core cpu2-pop3, typed path, `--download-concurrency=64`, GOMAXPROCS sweep (steady-state eps):

| GOMAXPROCS | events/s | scaling vs 1 |
|---|---|---|
| 1 | ~1.28M | 1.0x |
| 2 | ~2.4M | 1.9x |
| 4 | ~5.3M | 4.1x |
| 8 | ~10.3M | 8.0x |
| 16 | ~18.6M | 14.5x |
| 32 | ~26M | 20x |
| 64 | ~26M | 20x |
| 128 | ~26M | 20x |
| 256 | ~26M | 20x |

Near-linear to ~16 cores; knee at ~32; plateau ~26M beyond that. For contrast, the **map** path on the same box peaks ~10.4M. A CPU profile at the plateau shows the work is now dominated by real, irreducible cost — zstd decompression ~38% (`sequenceDecs` + `huff0`), tombstone-suppression map lookup ~8%, `FeedLike.UnmarshalCBOR` ~12%, internal→public conversion ~12% — with **no allocator/GC contention** (the old `mcache.refill`/`mcentral` wall is gone). The path is decompression-bound, which is the physical floor.

Over a full bounded backfill the typed path decoded 628M likes; a single malformed record in the real archive was correctly isolated as a per-record `DecodeErr` (no drop, no crash) — visible as `decode_errs=1` in the sweep above.

## cmd/client
`--typed-likes-client` (requires `--collection=app.bsky.feed.like`) drives the typed path with `T=bsky.FeedLike` and reports throughput + decoded/decode_errs; it produced the numbers above.

## Testing (all under -race)
- Root `typed_test.go`: decode, passthrough (deletes / other-collection / non-commit), in-order per-record decode errors, empty-collection rejection, stream-error forwarding, distinct slab slots.
- The oracle's non-short lifecycle now drives the **real worker-parallel typed path over real sealed segments** and asserts it surfaces exactly the same like set (DID/rkey → subject URI) as the map path — no drop, dup, or mis-decode.
- Full suite + oracle (short + non-short) green; the default map path is unchanged.

## Follow-ups (not in this PR)
The remaining ceiling is decompression-bound. Tracked separately: the tombstone `ShouldDrop` map lookup (~8%) and a leaner typed-specific assembly that skips materializing the public `Commit` for rows decoded into `T` (~12% conversion layer) are the next candidate micro-optimizations; #143 (stream the segment body) is the adjacent larger one.

Closes #146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)