### PR TITLE
fix: --plan-max-entries=0 disables the planBackfill cap

### DIFF
--- a/cmd/jetstream/main.go
+++ b/cmd/jetstream/main.go
@@ -293,7 +293,7 @@ func serveCommand() *cli.Command {
 			},
 			&cli.IntFlag{
 				Name:    "plan-max-entries",
-				Usage:   "Maximum response work entries planBackfill may return before failing with PlanTooLarge.",
+				Usage:   "Maximum response work entries planBackfill may return before failing with PlanTooLarge. 0 disables the limit (unbounded plan size).",
 				Sources: cli.EnvVars("JETSTREAM_PLAN_MAX_ENTRIES"),
 				Value:   xrpcapi.DefaultPlanMaxEntries,
 			},

--- a/internal/jetstreamd/runtime.go
+++ b/internal/jetstreamd/runtime.go
@@ -110,8 +110,8 @@ func Build(ctx context.Context, opts Options) (*Runtime, error) {
 	if opts.PlanMaxCollections < 0 {
 		return nil, fmt.Errorf("serve: --plan-max-collections must be >= 0 (PlanMaxCollections must be >= 0), got %d", opts.PlanMaxCollections)
 	}
-	if opts.PlanMaxEntries <= 0 {
-		return nil, fmt.Errorf("serve: --plan-max-entries must be positive (PlanMaxEntries must be positive), got %d", opts.PlanMaxEntries)
+	if opts.PlanMaxEntries < 0 {
+		return nil, fmt.Errorf("serve: --plan-max-entries must be >= 0 (PlanMaxEntries must be >= 0), got %d", opts.PlanMaxEntries)
 	}
 	if opts.PlanWholeSegmentThreshold <= 0 || opts.PlanWholeSegmentThreshold > 1 {
 		return nil, fmt.Errorf("serve: --plan-whole-segment-threshold must be > 0 and <= 1 (PlanWholeSegmentThreshold must be > 0 and <= 1), got %g", opts.PlanWholeSegmentThreshold)

--- a/internal/jetstreamd/runtime_test.go
+++ b/internal/jetstreamd/runtime_test.go
@@ -91,6 +91,20 @@ func TestOptionsValidateRejectsNegativeCompactionRewriteWorkers(t *testing.T) {
 	require.ErrorContains(t, err, "CompactionRewriteWorkers must be >= 0")
 }
 
+func TestOptionsValidateAcceptsZeroPlanMaxEntries(t *testing.T) {
+	t.Parallel()
+
+	// 0 disables the planBackfill entry cap (unbounded plan size). It must
+	// build successfully rather than being rejected as a misconfiguration.
+	opts := testOptions(t)
+	opts.PlanMaxEntries = 0
+	rt, err := Build(t.Context(), opts)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, rt.Close(context.Background()))
+	})
+}
+
 func TestOptionsValidateRejectsInvalidPlanLimits(t *testing.T) {
 	t.Parallel()
 
@@ -110,14 +124,9 @@ func TestOptionsValidateRejectsInvalidPlanLimits(t *testing.T) {
 			want: "PlanMaxCollections must be >= 0",
 		},
 		{
-			name: "zero entries",
-			edit: func(opts *Options) { opts.PlanMaxEntries = 0 },
-			want: "PlanMaxEntries must be positive",
-		},
-		{
 			name: "negative entries",
 			edit: func(opts *Options) { opts.PlanMaxEntries = -1 },
-			want: "PlanMaxEntries must be positive",
+			want: "PlanMaxEntries must be >= 0",
 		},
 		{
 			name: "zero threshold",

--- a/internal/manifest/plan.go
+++ b/internal/manifest/plan.go
@@ -36,6 +36,9 @@ type PlanBackfillRequest struct {
 	BeforeSeq    uint64
 	HasBeforeSeq bool
 
+	// MaxEntries caps the number of work entries a plan may accumulate before
+	// failing with ErrPlanTooLarge. 0 means unlimited (no cap); a negative
+	// value is a malformed limit and is rejected with ErrInvalidPlanRequest.
 	MaxEntries            int
 	WholeSegmentThreshold float64
 }
@@ -77,10 +80,11 @@ func (m *Manifest) PlanBackfill(req PlanBackfillRequest) (PlanBackfillResult, er
 	if req.HasAfterSeq && req.HasBeforeSeq && req.BeforeSeq <= req.AfterSeq {
 		return PlanBackfillResult{}, ErrInvalidPlanRequest
 	}
-	// MaxEntries <= 0 is a malformed limit, not an oversized plan. Returning
-	// ErrPlanTooLarge here would mislabel a misconfigured caller; reserve that
-	// sentinel for an actually-exceeded valid limit below.
-	if req.MaxEntries <= 0 {
+	// MaxEntries == 0 means unlimited; a negative value is a malformed limit,
+	// not an oversized plan. Returning ErrPlanTooLarge for it would mislabel a
+	// misconfigured caller; reserve that sentinel for an actually-exceeded
+	// positive limit below.
+	if req.MaxEntries < 0 {
 		return PlanBackfillResult{}, ErrInvalidPlanRequest
 	}
 	if req.WholeSegmentThreshold <= 0 || req.WholeSegmentThreshold > 1 {
@@ -152,7 +156,7 @@ func (m *Manifest) PlanBackfill(req PlanBackfillRequest) (PlanBackfillResult, er
 			planned.Blocks = coalesceBlocks(selected)
 			result.Stats.Entries += len(planned.Blocks)
 		}
-		if result.Stats.Entries > req.MaxEntries {
+		if req.MaxEntries > 0 && result.Stats.Entries > req.MaxEntries {
 			return PlanBackfillResult{}, ErrPlanTooLarge
 		}
 		result.Segments = append(result.Segments, planned)

--- a/internal/manifest/plan_test.go
+++ b/internal/manifest/plan_test.go
@@ -297,7 +297,31 @@ func TestPlanBackfill_InvalidRequest(t *testing.T) {
 	require.ErrorIs(t, err, manifest.ErrInvalidPlanRequest)
 
 	req = planReq()
-	req.MaxEntries = 0
+	req.MaxEntries = -1
 	_, err = m.PlanBackfill(req)
 	require.ErrorIs(t, err, manifest.ErrInvalidPlanRequest)
+}
+
+func TestPlanBackfill_ZeroMaxEntriesIsUnlimited(t *testing.T) {
+	t.Parallel()
+
+	// MaxEntries == 0 disables the cap: a plan that would exceed any positive
+	// limit must still succeed and return all matched work.
+	dir := t.TempDir()
+	writePlanSegment(t, dir, 0, 1,
+		planEvent(1, planDID, postNSID),
+		planEvent(2, otherDID, postNSID),
+		planEvent(3, planDID, postNSID),
+		planEvent(4, otherDID, postNSID),
+		planEvent(5, planDID, postNSID),
+	)
+	m := openManifestDir(t, dir)
+	req := planReq()
+	req.DIDs = []string{planDID}
+	req.MaxEntries = 0
+
+	got, err := m.PlanBackfill(req)
+	require.NoError(t, err)
+	require.NotEmpty(t, got.Segments)
+	require.Equal(t, 3, got.Stats.Entries)
 }

--- a/internal/xrpcapi/planbackfill.go
+++ b/internal/xrpcapi/planbackfill.go
@@ -31,9 +31,9 @@ type PlanConfig struct {
 }
 
 func (c PlanConfig) withDefaults() PlanConfig {
-	if c.MaxEntries == 0 {
-		c.MaxEntries = DefaultPlanMaxEntries
-	}
+	// MaxEntries is intentionally not defaulted here: 0 is a meaningful value
+	// (unlimited), so remapping it would clobber an operator's explicit choice.
+	// The CLI flag supplies DefaultPlanMaxEntries when the operator omits it.
 	if c.WholeSegmentThreshold == 0 {
 		c.WholeSegmentThreshold = DefaultPlanWholeSegmentThreshold
 	}
@@ -50,8 +50,8 @@ func (c PlanConfig) validate() error {
 	if c.MaxCollections < 0 {
 		return fmt.Errorf("plan max collections must be >= 0, got %d", c.MaxCollections)
 	}
-	if c.MaxEntries <= 0 {
-		return fmt.Errorf("plan max entries must be positive, got %d", c.MaxEntries)
+	if c.MaxEntries < 0 {
+		return fmt.Errorf("plan max entries must be >= 0, got %d", c.MaxEntries)
 	}
 	if c.WholeSegmentThreshold <= 0 || c.WholeSegmentThreshold > 1 {
 		return fmt.Errorf("plan whole segment threshold must be > 0 and <= 1, got %g", c.WholeSegmentThreshold)

--- a/internal/xrpcapi/planbackfill_test.go
+++ b/internal/xrpcapi/planbackfill_test.go
@@ -594,3 +594,23 @@ func TestPlanBackfill_PlanTooLarge(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	require.Equal(t, "PlanTooLarge", readXRPCError(t, resp))
 }
+
+func TestPlanBackfill_ZeroMaxEntriesDisablesCap(t *testing.T) {
+	t.Parallel()
+
+	// MaxEntries == 0 disables the cap: the same workload that returns
+	// PlanTooLarge under a positive limit must succeed unbounded.
+	cfg := defaultPlanTestConfig()
+	cfg.MaxEntries = 0
+	ts := newPlanTestServer(t, cfg,
+		planEvent(1, "did:plc:target", "app.bsky.feed.post"),
+		planEvent(2, "did:plc:other", "app.bsky.feed.post"),
+		planEvent(3, "did:plc:target", "app.bsky.feed.post"),
+		planEvent(4, "did:plc:other", "app.bsky.feed.post"),
+		planEvent(5, "did:plc:target", "app.bsky.feed.post"),
+	)
+
+	status, out := postPlan(t, ts, map[string]any{"dids": []string{"did:plc:target"}})
+	require.Equal(t, http.StatusOK, status)
+	require.NotEmpty(t, out.Segments)
+}


### PR DESCRIPTION
Fixes #154.

## What

`--plan-max-entries=0` now disables the planBackfill response-size cap (unbounded plan), matching the "0 disables the limit" convention already used by `--plan-max-dids` and `--plan-max-collections`. Only negative values are a misconfiguration.

## Why

`0` previously meant three contradictory things across layers — startup rejected it, `withDefaults()` silently remapped it to the default (100000), and both the xrpcapi `validate()` and the planner rejected it. The result was the startup error in #154.

## Changes

- `internal/jetstreamd/runtime.go` — startup validation rejects only `< 0` (was `<= 0`); error text updated to "must be >= 0".
- `internal/xrpcapi/planbackfill.go` — removed the `withDefaults()` remap that turned an explicit `0` into `DefaultPlanMaxEntries` (the CLI flag's `Value` still supplies the default when the flag is omitted); `validate()` rejects only `< 0`.
- `internal/manifest/plan.go` — planner rejects only `MaxEntries < 0`; the `PlanTooLarge` check is guarded by `MaxEntries > 0`, so `0` is unlimited. Field doc updated.
- `cmd/jetstream/main.go` — flag usage documents "0 disables the limit (unbounded plan size)."

## Tests (TDD — all fail before the change)

- `manifest`: switched the invalid-request case from `0` to `-1`; added `TestPlanBackfill_ZeroMaxEntriesIsUnlimited`.
- `xrpcapi`: added `TestPlanBackfill_ZeroMaxEntriesDisablesCap` (HTTP layer: the same workload that returns `PlanTooLarge` under a positive cap succeeds at `0`).
- `jetstreamd`: dropped the "zero entries → error" case, kept negative, added `TestOptionsValidateAcceptsZeroPlanMaxEntries`.

## Operational note

With the cap disabled there is no backstop against a single `planBackfill` request materializing the entire archive's segment/block list into one response. Archive-bounded, not truly unbounded, but worth flagging. Happy to add a follow-up for a separate hard ceiling if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
