### PR TITLE
testing: refresh stale compaction mutant

### DIFF
--- a/testing/mutation/RESULTS.md
+++ b/testing/mutation/RESULTS.md
@@ -6,15 +6,15 @@ oracle's detection power is visible over time. See
 method and `testing/mutation/run.sh` for the driver.
 
 **Current catalog (keep this line current): 25 active mutants on disk
-(m001–m027; m007 and m010 retired). Latest full campaign: 2026-06-21,
-recorded in `testing/mutation/baseline.json` (commit field `007abab`) —
-18 killed, 7 survived over m001–m027 (the authoritative current scorecard;
-see the dated section at the end of this file). This is the run that seeded
-`testing/mutation/baseline.json` and is now the enforced gate baseline (#108).
-The dated section below was written against commit `df3fc4b`, which a later
-rebase orphaned; `baseline.json`'s commit field is the machine source of truth.
-Counts inside older dated sections describe the catalog *as of that date* and
-are intentionally not back-edited.**
+(m001–m027; m007 and m010 retired). Latest full gate verification: 2026-06-25
+at `b6d3f09` (`just mutation-gate`) matched `testing/mutation/baseline.json`
+exactly — 18 killed, 7 survived over m001–m027. The enforced baseline remains
+`testing/mutation/baseline.json` (commit field `007abab`), seeded by the
+2026-06-21 full campaign and enforced by #108. The dated 2026-06-21 section
+was written against commit `df3fc4b`, which a later rebase orphaned;
+`baseline.json`'s commit field is the machine source of truth. Counts inside
+older dated sections describe the catalog *as of that date* and are
+intentionally not back-edited.**
 
 ## The baseline gate (#108)
 
@@ -64,6 +64,43 @@ remain below so the reasoning is not lost.
 |---|---|---|
 | m007_compaction_chunk_boundary | 2026-06-15 | Invalid/dead under current compaction chunk construction; the modeled corrupt shape cannot be produced by current chunk snapshots. |
 | m010_nextblockoffset_reset | 2026-06-15 | Stale/dead for sealed oracle observations; `Writer.Seal` rebuilds footer block metadata from physical frames. |
+
+## Campaign 2026-06-25 (m025 stale refresh; gate pass)
+
+- commit under test: `b6d3f09`
+- issue: #159
+- driver:
+  - targeted reproduction before refresh: `just mutation-campaign m025`
+  - targeted verification after refresh: `just mutation-campaign m025`
+  - full gate verification: `just mutation-gate`
+- catalog: 25 active mutants; baseline unchanged
+
+The scheduled mutation gate failed on 2026-06-26 UTC because
+`m025_compaction_overdrop_above_watermark` was `STALE`: its patch still targeted
+the old bounded `SnapshotRange(current, targetWatermark)` compaction snapshot
+line. Current compaction no longer uses that in-memory snapshot path; it folds
+sealed segment rows via `collectCompactionTombstones`, so the mutant had drifted
+after the oracle/compaction fixes.
+
+Refreshed m025 to reintroduce the same failure mode at the current mutation
+point: steady compaction still starts with the real sealed-row fold, then the
+mutant replaces the steady-mode snapshot with
+`Tombstones.SnapshotRange(current, ^uint64(0))`. This keeps merge-tail compaction
+on the real path, preserving m025's intended target: a steady-state
+convergence-hiding over-drop that only the pre/post compaction over-drop
+recorder should catch.
+
+Targeted verification after refresh:
+
+| mutant | result | note |
+|---|---|---|
+| m025_compaction_overdrop_above_watermark | KILLED@stress | `steady-state-shutdown-flush`: `compaction over-drop at watermark=30558 (pre=28782 post=28780 survivors=28781 dropped=1)`; missing expected `app.bsky.feed.repost/22bab3wsv...` create at seq 29284 |
+
+Full gate verification passed:
+
+```text
+gate: PASS — 25 mutants match baseline (commit b6d3f09000c578400264db8b3c0b56b553427c7e)
+```
 
 ## Active catalog check 2026-06-15 — retired mutants removed
 

--- a/testing/mutation/mutants/m025_compaction_overdrop_above_watermark.patch
+++ b/testing/mutation/mutants/m025_compaction_overdrop_above_watermark.patch
@@ -1,13 +1,14 @@
 mutant: m025_compaction_overdrop_above_watermark
 target: internal/ingest/orchestrator/compact_deletes.go
 failure-mode: |
-  The steady-state compaction pass collects its tombstone snapshot with an
-  UNBOUNDED high seq (SnapshotRange(current, ^uint64(0))) instead of bounding
-  it at the pass's targetWatermark. A delete that arrived AFTER the active
-  segment was force-rotated (seq > targetWatermark, living in the new active
-  segment) therefore leaks into the snapshot and suppresses its own create —
-  a create at/below the watermark that the pass should have KEPT (its only
-  superseding tombstone is above the watermark, so the create is still a
+  The steady-state compaction pass builds its tombstone snapshot from the live
+  in-memory tombstone set with an UNBOUNDED high seq
+  (SnapshotRange(current, ^uint64(0))) instead of folding sealed rows in the
+  pass's bounded (current, targetWatermark] window. A delete that arrived AFTER
+  the active segment was force-rotated (seq > targetWatermark, living in the
+  new active segment) therefore leaks into the snapshot and suppresses its own
+  create — a create at/below the watermark that the pass should have KEPT (its
+  only superseding tombstone is above the watermark, so the create is still a
   legitimate survivor of this pass). A convergence-hiding compaction over-drop:
   one or more survivors per pass can be wrongly removed (the observed failing
   pass reported dropped=1).
@@ -40,6 +41,9 @@ tiers: stress
 diff --git a/internal/ingest/orchestrator/compact_deletes.go b/internal/ingest/orchestrator/compact_deletes.go
 --- a/internal/ingest/orchestrator/compact_deletes.go
 +++ b/internal/ingest/orchestrator/compact_deletes.go
-@@ -136 +136 @@ func (o *Orchestrator) runDeleteCompaction(ctx context.Context, mode compactionM
--				snap = o.cfg.Tombstones.SnapshotRange(current, targetWatermark)
-+				snap = o.cfg.Tombstones.SnapshotRange(current, ^uint64(0))
+@@ -154 +154,4 @@ func (o *Orchestrator) runDeleteCompaction(ctx context.Context, mode compactionM
+-			snap, chunkEnd, err := o.collectCompactionTombstones(ctx, sealed, current, targetWatermark)
++			snap, chunkEnd, err := o.collectCompactionTombstones(ctx, sealed, current, targetWatermark)
++			if mode == compactionSteady {
++				snap, chunkEnd, err = o.cfg.Tombstones.SnapshotRange(current, ^uint64(0)), targetWatermark, error(nil)
++			}


### PR DESCRIPTION
## Context

The scheduled mutation campaign gate failed in GitHub Actions on `main` because
`m025_compaction_overdrop_above_watermark` reported `STALE`:

https://github.com/bluesky-social/jetstream/actions/runs/28213436974/job/83579396295

Tracked in #159.

This was not an oracle detection regression. The m025 patch had drifted after
the recent oracle/compaction work changed delete compaction from the old
in-memory `SnapshotRange(current, targetWatermark)` snapshot path to sealed-row
folding through `collectCompactionTombstones`. The mutant still modeled a real
and important failure mode, but its mutation point no longer existed.

## Changes

- Refresh `m025_compaction_overdrop_above_watermark` so it applies to the
  current compaction code.
- Keep merge-tail compaction on the production sealed-row fold path.
- Reintroduce the intended bug only for steady compaction by replacing the
  steady-mode snapshot with `Tombstones.SnapshotRange(current, ^uint64(0))`.
- Update `testing/mutation/RESULTS.md` with the local reproduction, diagnosis,
  targeted verification, and full gate result.

## Why This Shape

The first refreshed version I tested was too broad: replacing the snapshot
unconditionally also mutated merge-tail compaction, which caused an earlier
generic compaction-watermark failure. This PR scopes the mutant to
`compactionSteady`, preserving m025's purpose: a steady-state convergence-hiding
over-drop where a delete above the pass watermark suppresses a create at or
below the watermark. That is the case the pre/post compaction over-drop recorder
is meant to catch.

## Verification

- `just mutation-campaign m025` before the refresh reproduced the local failure
  as `STALE`.
- Manual scoped mutant verification failed at `steady-state-shutdown-flush` with
  `compaction over-drop ... dropped=1`, confirming the refreshed mutant is
  killed by the intended oracle property.
- `just mutation-campaign m025` after the refresh: `KILLED@stress`.
- `just mutation-gate`: `PASS - 25 mutants match baseline (commit b6d3f09000c578400264db8b3c0b56b553427c7e)`.

Closes #159
