### PR TITLE
oracle: exercise durable intermediates across a crash + enforce merge-tail no-straddle (#114)

### DIFF
--- a/internal/oracle/restart_crash_chain_test.go
+++ b/internal/oracle/restart_crash_chain_test.go
@@ -1,0 +1,223 @@
+package oracle
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/bluesky-social/jetstream/internal/crashpoint"
+	"github.com/bluesky-social/jetstream/segment"
+	"github.com/stretchr/testify/require"
+)
+
+// runChainThroughCrash drives the seed-derived durable-intermediate chain
+// through a SIGKILL crash at the given enumerated crashpoint, then recovers
+// it with a second merge child that exits cleanly at the after-merge
+// barrier. It is the crash-tier analogue of runChainToMergeNoCrash: the
+// chainCoordinator (installed as the simulator's OnGetRepoServed hook) and
+// the simulator server are owned by the PARENT, so they persist across both
+// children — generation happens exactly once on the first child's getRepo
+// (sync.Once) and the recovered live_segments carry the chain into the
+// second child's re-run merge.
+//
+// This closes the gap #114 names: TestOracle_RestartCrashPointsDoNotLoseRecords
+// wires a nil coordinator, so no durable update/delete/tombstone was ever
+// subjected to crash + recovery. Here the chain's tombstones/updates straddle
+// the crash boundary.
+//
+// nolint:paralleltest
+func runChainThroughCrash(t *testing.T, label string, seedIdx int, point crashpoint.Point) recoveredChainRun {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping restart oracle under -short")
+	}
+
+	cfg := Config{
+		Mode:                "restart",
+		Seed:                restartSeed(seedIdx),
+		Accounts:            4,
+		MinInitialRecords:   1,
+		MaxInitialRecords:   4,
+		LiveEventsBootstrap: 4,
+		LiveEventsSteady:    4,
+	}
+	trace, _, closeTrace := newOracleTrace(t, "restart-chain-crash-"+label+".jsonl")
+	t.Cleanup(closeTrace)
+
+	spec := deriveChainSpec(cfg.Seed, cfg.Accounts)
+	recordTraceOrError(t, trace, "run_start", map[string]any{
+		"mode":          cfg.Mode,
+		"seed":          cfg.Seed,
+		"go_version":    runtime.Version(),
+		"gomaxprocs":    runtime.GOMAXPROCS(0),
+		"accounts":      cfg.Accounts,
+		"case":          label,
+		"crash_point":   point.String(),
+		"chain_did_idx": spec.chainAccountIdx(),
+		"chain_records": len(spec.records),
+	})
+
+	w := newRestartWorld(t, cfg)
+	t.Cleanup(func() { require.NoError(t, w.Close()) })
+
+	coord := newChainCoordinator(t, w, spec)
+	srv := newRestartServer(t, w, coord.onGetRepoServed)
+	t.Cleanup(srv.Close)
+
+	dataDir := t.TempDir()
+	markersDir := t.TempDir()
+	markerPath := filepath.Join(markersDir, point.String())
+	mergeDonePath := filepath.Join(markersDir, "after-merge")
+
+	// First child: backfill serves the chain DID's getRepo (coordinator
+	// generates the chain over the live firehose), the merge drains it
+	// durably, then we SIGKILL mid-recovery at the crashpoint.
+	first := runRestartChild(t, restartChildArgs{
+		dataDir:         dataDir,
+		relayURL:        srv.URL,
+		markerPath:      markerPath,
+		crashPoint:      point,
+		killAfterMarker: true,
+		timeout:         30 * time.Second,
+		trace:           trace,
+		runLabel:        "first-" + label,
+	})
+	recordTraceOrError(t, trace, "restart_child_result", traceRestartChildResult("first", first))
+	require.Truef(t, wasSIGKILL(first.err), "first child should be killed at %s: err=%v\n%s", point, first.err, first.output)
+
+	// Second child: re-run the merge idempotently to a clean after-merge
+	// exit. The coordinator does NOT regenerate (sync.Once already fired on
+	// the first child's getRepo, and the chain ops are durable in the world).
+	second := runRestartChild(t, restartChildArgs{
+		dataDir:       dataDir,
+		relayURL:      srv.URL,
+		mergeDonePath: mergeDonePath,
+		timeout:       30 * time.Second,
+		trace:         trace,
+		runLabel:      "second-" + label,
+	})
+	recordTraceOrError(t, trace, "restart_child_result", traceRestartChildResult("second", second))
+	require.NoErrorf(t, second.err, "restart child should exit cleanly\n%s", second.output)
+	require.FileExistsf(t, mergeDonePath, "restart child must reach after-merge barrier before exiting")
+
+	return recoveredChainRun{cfg: cfg, spec: spec, w: w, coord: coord, dataDir: dataDir}
+}
+
+// maxDurableSeq returns the highest jetstream seq among observed on-disk
+// events, or 0 if there are none.
+func maxDurableSeq(events []ObservedEvent) uint64 {
+	var maxSeq uint64
+	for _, ev := range events {
+		if ev.Seq > maxSeq {
+			maxSeq = ev.Seq
+		}
+	}
+	return maxSeq
+}
+
+// TestOracle_RestartChainShapeB_NoStraddleAfterMergeTailCrash makes the
+// RESULTS.md "reachability correction" (2026-06-20, commit 8ca4df1) an
+// enforced invariant rather than prose.
+//
+// #114's original premise was a convergence-hiding over-drop on the
+// restart/merge-tail crash path: a create <= W independently superseded by a
+// delete > W (the "straddle"), where a compaction over-drop is invisible to
+// final-state Compare but caught by event-log coverage. That straddle CANNOT
+// form in merge-tail: the pass runs at a quiescent point after the merge has
+// sealed every segment, so its targetWatermark spans the whole durable stream
+// and every durable row sits at or below W. The convergence-hiding property
+// is real but lives in the STEADY tier (mutant m025, KILLED@stress), where a
+// delete can land in the fresh active segment above the force-rotate
+// watermark.
+//
+// This test crashes shape B (R_bf create@backfill -> live delete) at
+// AfterCompactionRewriteBeforeWatermark — the exact crashpoint #114 named —
+// recovers, and asserts the no-straddle invariant: every durable row is <= W,
+// so no create<=W/delete>W straddle exists on disk. If a future merge-tail
+// refactor ever let a durable row outrun the watermark, this goes red and the
+// "B-crash is infeasible" claim must be revisited.
+//
+// nolint:paralleltest
+func TestOracle_RestartChainShapeB_NoStraddleAfterMergeTailCrash(t *testing.T) {
+	run := runChainThroughCrash(t, "shape-b-nostraddle", 0, crashpoint.AfterCompactionRewriteBeforeWatermark)
+
+	// Final state still converges after the crash.
+	assertOracleMatches(t, run.dataDir, run.w, run.cfg, "shape-b-nostraddle")
+
+	// cov.events carries the real on-disk jetstream seqs (cov.got/.want are
+	// seq-zeroed for key-based coverage comparison, so seq checks MUST read
+	// cov.events, not cov.got).
+	cov := chainCoverage(t, run.dataDir, run.coord)
+	rc := recordChainForShape(t, run.spec, shapeBfCreateDelete)
+
+	// Anti-vacuity: a merge-tail compaction pass committed a real watermark.
+	require.Greater(t, cov.watermark, uint64(0),
+		"no-straddle test is vacuous unless a merge-tail watermark was committed")
+
+	// Anti-vacuity: the shape-B live delete tombstone is durable at/below W
+	// (the fixture actually landed and the seam under test is exercised), and
+	// the backfilled create is compacted away by it (matching no-crash shape B).
+	tombstoneDurable := false
+	for _, ev := range cov.events {
+		if ev.Collection != rc.collection || ev.Rkey != rc.rkey {
+			continue
+		}
+		switch ev.Kind {
+		case segment.KindDelete:
+			require.LessOrEqualf(t, ev.Seq, cov.watermark,
+				"shape-b delete tombstone seq=%d must be <= W=%d", ev.Seq, cov.watermark)
+			tombstoneDurable = true
+		case segment.KindCreate:
+			t.Fatalf("shape-b backfilled create %s/%s must be compacted away, but survived on disk at seq=%d",
+				rc.collection, rc.rkey, ev.Seq)
+		}
+	}
+	require.True(t, tombstoneDurable,
+		"shape-b live delete tombstone must be durable on disk after crash recovery")
+
+	// The invariant: every durable row is at or below the watermark. No
+	// create<=W/delete>W straddle can exist, so the convergence-hiding
+	// over-drop #114 contemplated is structurally unreachable here.
+	maxSeq := maxDurableSeq(cov.events)
+	t.Logf("no-straddle: watermark W=%d maxDurableSeq=%d events=%d", cov.watermark, maxSeq, len(cov.events))
+	require.LessOrEqualf(t, maxSeq, cov.watermark,
+		"merge-tail no-straddle invariant violated: max durable seq=%d exceeds watermark W=%d "+
+			"(a create<=W/delete>W straddle would be reachable — revisit the B-crash infeasibility finding)",
+		maxSeq, cov.watermark)
+}
+
+// TestOracle_RestartChainCrashConsistency is the real value #114 delivers:
+// the durable-intermediate chain (creates, updates, delete tombstones, a
+// delete->recreate, the R_bf survival boundary) is subjected to a SIGKILL
+// mid-recovery and must survive crash + re-merge intact. The pre-existing
+// crash tier (TestOracle_RestartCrashPointsDoNotLoseRecords) wires a nil
+// coordinator, so it only ever lands surviving creates — no update/delete/
+// tombstone is exposed to a crash. This test closes that gap by running the
+// full assertChainDurable bundle (at-least-once coverage, compaction
+// contract, no-permanent-tombstone) over the recovered segments.
+//
+// Crash timing is wall-clock nondeterministic; the assertions are
+// seq-agnostic and the coverage comparator is at-least-once (>=), which
+// tolerates the benign re-merge duplicate a crash between dst-flush and
+// source-commit can produce (plan §6 run-level edge cases).
+//
+// nolint:paralleltest
+func TestOracle_RestartChainCrashConsistency(t *testing.T) {
+	run := runChainThroughCrash(t, "crash-consistency", 0, crashpoint.AfterCompactionRewriteBeforeWatermark)
+
+	// Final state converges after crash + recovery.
+	assertOracleMatches(t, run.dataDir, run.w, run.cfg, "crash-consistency")
+
+	// The chain's durable intermediates survived the crash: every expected
+	// durable row is present at least once, the compaction contract holds at
+	// the recovered watermark, and the delete->recreate record is visible.
+	assertChainDurable(t, run.dataDir, run.coord, "crash-consistency")
+
+	// Red-first power check: losing the shape-B live delete tombstone across
+	// the crash boundary must break coverage. Ties the crash test's power to
+	// the actual recovered fixture (mirrors the no-crash shape-B power test).
+	rc := recordChainForShape(t, run.spec, shapeBfCreateDelete)
+	cov := chainCoverage(t, run.dataDir, run.coord)
+	assertCoverageFailsWithoutRow(t, cov, "delete", rc.collection, rc.rkey)
+}

--- a/specs/notes/2026-06-20-restart-tier-intermediates-plan.md
+++ b/specs/notes/2026-06-20-restart-tier-intermediates-plan.md
@@ -422,17 +422,33 @@ Two sub-checks, both over the post-restart durable segments:
   same coverage, simpler plumbing.) The served wire path stays covered by the
   steady-state + client-driven tiers.
 
-### 4.4 #100 convergence-hiding over-drop mutant (NEW, mutation catalog)
-Per the m024 patch note: the unique power (an over-drop hidden by final-state
-convergence) needs "a survivor dropped at/below W but independently superseded
-ABOVE W … where W need not cover everything." The crash-mid-compaction-pass
-restart provides exactly this: crash at `AfterCompactionRewriteBeforeWatermark`
-(`compact_deletes.go:165`) leaves a rewritten segment with the watermark NOT
-advanced, so on restart W does not cover the just-rewritten rows. With a durable
-record created ≤W but deleted >W, an over-drop of that record is invisible to
-final-state `Compare` (it's deleted in the end anyway) but caught by event-log
-coverage (the create row is missing). We add a crash case at that crashpoint and
-a mutation entry (or re-point m024's tier) — verify it KILLS.
+### 4.4 #100 convergence-hiding over-drop mutant — SUPERSEDED 2026-06-26
+**This subsection's premise was refuted during implementation.** The hypothesis
+below — that crash-mid-compaction-pass on the restart path yields a `create ≤W /
+delete >W` straddle — does not hold: merge-tail compaction runs at a quiescent
+point after the merge has sealed every segment, so `targetWatermark` spans the
+whole durable stream and every durable row is ≤W. Crashing at
+`AfterCompactionRewriteBeforeWatermark` leaves W un-advanced for that *chunk*, but
+the recovered re-merge recomputes a complete snapshot — there is no above-scope
+row to over-drop invisibly. This is now **enforced** by
+`TestOracle_RestartChainShapeB_NoStraddleAfterMergeTailCrash` (`maxDurableSeq ≤
+W`). The convergence-hiding over-drop proof lives in the **steady tier** (m025,
+KILLED@stress), where a delete *can* land in the fresh active segment above the
+force-rotate watermark. No restart-tier over-drop mutant is added. See
+`testing/mutation/RESULTS.md` 2026-06-20 reachability correction + 2026-06-26
+update.
+
+Original (refuted) hypothesis, kept for the audit trail:
+
+> Per the m024 patch note: the unique power (an over-drop hidden by final-state
+> convergence) needs "a survivor dropped at/below W but independently superseded
+> ABOVE W … where W need not cover everything." The crash-mid-compaction-pass
+> restart provides exactly this: crash at `AfterCompactionRewriteBeforeWatermark`
+> leaves a rewritten segment with the watermark NOT advanced, so on restart W
+> does not cover the just-rewritten rows. With a durable record created ≤W but
+> deleted >W, an over-drop of that record is invisible to final-state `Compare`
+> but caught by event-log coverage. We add a crash case at that crashpoint and a
+> mutation entry — verify it KILLS.
 
 ---
 
@@ -519,7 +535,7 @@ crashpoint):
 
 | ID | what | crashpoint | distinct seam |
 |----|------|-----------|----------------|
-| B-crash (#100) | shape B with create ≤W, delete >W, crash mid-compaction-rewrite | `AfterCompactionRewriteBeforeWatermark` (`compact_deletes.go:165`) | the deferred #100 convergence-hiding over-drop: a survivor dropped ≤W but superseded >W is invisible to final-state `Compare` but caught by coverage. Verify it KILLS the m024-class over-drop mutant. |
+| B-crash (#114) — RESOLVED 2026-06-26 | shape B crashed mid-compaction-rewrite | `AfterCompactionRewriteBeforeWatermark` (`compact_deletes.go:178`) | The convergence-hiding over-drop framing was **withdrawn as infeasible in merge-tail** (the `create ≤W / delete >W` straddle cannot form — the pass spans the whole sealed stream; see `testing/mutation/RESULTS.md` 2026-06-20 reachability correction). That infeasibility is now an **enforced test** (`TestOracle_RestartChainShapeB_NoStraddleAfterMergeTailCrash`: `maxDurableSeq ≤ W`). The convergence-hiding over-drop proof stays in the **steady tier** (m025, KILLED@stress). The real restart-tier value — durable intermediates surviving a crash — is delivered by `TestOracle_RestartChainCrashConsistency` (full `assertChainDurable` bundle over the recovered segments, red-first power check). No new restart-tier mutant. |
 
 DID-level shapes:
 

--- a/testing/mutation/RESULTS.md
+++ b/testing/mutation/RESULTS.md
@@ -577,6 +577,42 @@ restart-tier B-crash variant contemplated by #113's plan was withdrawn as
 structurally infeasible. The exploratory restart-tier merge-segment plumbing
 added during that investigation was reverted to keep the harness lean.
 
+## Update 2026-06-26 (#114 — infeasibility now enforced; crash tier exercises durable intermediates)
+
+The 2026-06-20 "reachability correction" above was prose: it asserted the
+restart/merge-tail path cannot host the `(create ≤ W, delete > W)` straddle, but
+nothing enforced it. #114 (filed after that finding, re-challenging it) is
+resolved by turning the claim into a test and closing the genuine adjacent gap.
+
+- **No-straddle invariant, now enforced**
+  (`internal/oracle/restart_crash_chain_test.go`,
+  `TestOracle_RestartChainShapeB_NoStraddleAfterMergeTailCrash`): crashes shape B
+  at `AfterCompactionRewriteBeforeWatermark` — the exact crashpoint #114 named —
+  recovers, and asserts `maxDurableSeq(on-disk) ≤ W` with anti-vacuity (a real
+  merge-tail watermark committed, the shape-B delete tombstone durable ≤ W, the
+  backfilled create compacted away). Observed `W=26, maxDurableSeq=26`: every
+  durable row sits at or below the watermark, so no convergence-hiding straddle
+  exists on disk. If a future merge-tail refactor ever lets a durable row outrun
+  W, this goes red and the B-crash infeasibility finding must be revisited.
+  Verified red-first: tightening the bound to `W-1` fails with the real seqs.
+- **Crash tier now exercises durable intermediates**
+  (`TestOracle_RestartChainCrashConsistency`): the pre-existing crash tier
+  (`TestOracle_RestartCrashPointsDoNotLoseRecords`) wires a `nil` coordinator, so
+  it only ever landed surviving creates — no update/delete/tombstone was exposed
+  to a crash. The new test runs the full seed-derived chain through SIGKILL +
+  re-merge and asserts `assertChainDurable` (at-least-once coverage `≥`,
+  `CheckCompacted`, no-permanent-tombstone) over the recovered segments, with a
+  red-first power check (dropping the recovered shape-B delete tombstone breaks
+  coverage). This is the crash-consistency coverage #114 is really about, distinct
+  from the (infeasible-here) convergence-hiding over-drop.
+
+**Net for the mutation catalog:** unchanged. The #100 convergence-hiding
+over-drop proof remains m025 in the steady tier (KILLED@stress); no new
+restart-tier mutant is added, because the over-drop it would target cannot form
+in merge-tail (now enforced by the no-straddle test rather than asserted in
+prose). m024 (blanket over-drop, KILLED@default via final-state `Compare`) is
+also unaffected.
+
 ## Campaign 2026-06-20 (m005 re-homed to the restart tier — #110)
 
 The 2026-06-20 full campaign found m005_backfill_status_check_inverted had


### PR DESCRIPTION
## Why

#114 asked for a restart-tier **B-crash convergence-hiding over-drop**: crash mid-compaction-rewrite so a `create ≤W` is superseded by a `delete >W` (the straddle), making an over-drop invisible to final-state `Compare` but caught by event-log coverage.

That premise contradicts a verified finding already in the tree — `testing/mutation/RESULTS.md` (2026-06-20, commit `8ca4df1`, the day **before** #114 was filed): the straddle is **structurally infeasible in merge-tail**. Merge-tail compaction runs at a quiescent point after the merge has sealed every segment, so `targetWatermark` spans the whole durable stream and every durable row is `≤W`. Crashing at `AfterCompactionRewriteBeforeWatermark` leaves W un-advanced for that *chunk*, but the recovered re-merge recomputes a complete snapshot — there is no above-scope row to over-drop. The convergence-hiding proof lives in the **steady tier** (mutant `m025`, re-verified **KILLED@stress** on a clean tree at HEAD), where a delete can land in the fresh active segment above the force-rotate watermark.

Per a "TDD-prove infeasibility, then repurpose" decision, this PR turns the prose finding into an **enforced test** and closes the genuine adjacent gap: the existing crash tier (`TestOracle_RestartCrashPointsDoNotLoseRecords`) wires a `nil` `chainCoordinator`, so it only ever lands surviving creates — **no update/delete/tombstone was ever subjected to a crash + recovery**.

## What

New `internal/oracle/restart_crash_chain_test.go`:

- **`runChainThroughCrash`** — crash-tier analogue of `runChainToMergeNoCrash`. Drives the seed-derived durable-intermediate chain through a SIGKILL at an enumerated crashpoint, then recovers via a second re-merge child. Coordinator + sim server are parent-owned, so generation fires exactly once (`sync.Once`) and the chain straddles the crash boundary.
- **`TestOracle_RestartChainShapeB_NoStraddleAfterMergeTailCrash`** — enforces the no-straddle invariant (`maxDurableSeq ≤ W`) at the exact crashpoint #114 named, with anti-vacuity (real watermark committed, shape-B delete tombstone durable `≤W`, backfilled create compacted away). Verified red-first: tightening the bound to `W-1` fails with real on-disk seqs. (TDD caught a real bug in the first draft — seqs were read off the seq-zeroed coverage rows, making the invariant vacuous; seq checks now read `cov.events`.)
- **`TestOracle_RestartChainCrashConsistency`** — the real value. Runs the full chain through SIGKILL + re-merge and asserts `assertChainDurable` (at-least-once coverage `≥`, `CheckCompacted`, no-permanent-tombstone) over the recovered segments, with a red-first power check (dropping the recovered shape-B delete tombstone breaks coverage).

**No mutation-catalog change:** the over-drop a restart-tier mutant would target is unreachable in merge-tail (now enforced by the no-straddle test rather than asserted in prose); `m025` remains the convergence-hiding home in the steady tier.

Docs: `RESULTS.md` 2026-06-26 entry; plan doc §4.4 (refuted hypothesis kept for the audit trail) + the §6 B-crash row.

## Validation

- `internal/oracle` full suite green (default + stress); `-short` skips the tier; full package `-race` clean.
- Crash timing is wall-clock nondeterministic — validated 10× repeat + seeds {7,42,1009,2026} + `-race ×3`, all green (no cutover gating needed).
- `m025` KILLED@stress re-confirmed on a clean tree.

## Note (not in scope)

The `oracle-sweep` recipe runs only `TestOracle_DefaultLifecycle` — the restart tier is unswept. Plan §7 called for adding it to the nightly sweep; deliberately **not** expanded here (broader CI-budget decision).

Closes #114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)