### PR TITLE
oracle: cover all crash points in the chain crash tier; split replay-safe invariants (#113)

### DIFF
--- a/internal/oracle/harness_test.go
+++ b/internal/oracle/harness_test.go
@@ -737,12 +737,35 @@ func bisectServedCompactedFailure(
 
 func assertOracleMatches(t *testing.T, dataDir string, w *world.World, cfg Config, phase string) {
 	t.Helper()
+	assertOracleMatchesImpl(t, dataDir, w, cfg, phase, false)
+}
+
+// assertOracleMatchesAfterReplay is the crash-recovery variant: it asserts the
+// same final-state correctness (Compare) but checks only the structural
+// invariants that survive an idempotent at-least-once replay (unique/increasing
+// seq, commit-has-rev), NOT per-DID rev-monotonicity-by-seq. A crash recovered
+// at a merge replay boundary legitimately re-emits already-merged survivors at
+// fresh higher seqs carrying their original lower revs; that is not corruption
+// (Compare still converges), so the strict monotonic check must not run here.
+// Per-record rev correctness and at-least-once coverage are owned by the
+// event-log / chain-coverage tiers.
+func assertOracleMatchesAfterReplay(t *testing.T, dataDir string, w *world.World, cfg Config, phase string) {
+	t.Helper()
+	assertOracleMatchesImpl(t, dataDir, w, cfg, phase, true)
+}
+
+func assertOracleMatchesImpl(t *testing.T, dataDir string, w *world.World, cfg Config, phase string, afterReplay bool) {
+	t.Helper()
 
 	want, err := GroundTruthFromWorld(w)
 	require.NoErrorf(t, err, "%s mode=%s seed=%d: build ground truth", phase, cfg.Mode, cfg.Seed)
 	events, err := ObserveSegments(dataDir)
 	require.NoErrorf(t, err, "%s mode=%s seed=%d: observe segments", phase, cfg.Mode, cfg.Seed)
-	require.NoErrorf(t, CheckInvariants(events), "%s mode=%s seed=%d: check invariants", phase, cfg.Mode, cfg.Seed)
+	if afterReplay {
+		require.NoErrorf(t, CheckStructuralInvariants(events), "%s mode=%s seed=%d: check structural invariants", phase, cfg.Mode, cfg.Seed)
+	} else {
+		require.NoErrorf(t, CheckInvariants(events), "%s mode=%s seed=%d: check invariants", phase, cfg.Mode, cfg.Seed)
+	}
 	got, err := Reconstruct(EventsSortedBySeq(events))
 	require.NoErrorf(t, err, "%s mode=%s seed=%d: reconstruct observed events", phase, cfg.Mode, cfg.Seed)
 	require.NoErrorf(t, Compare(want, got), "%s mode=%s seed=%d: compare oracle model", phase, cfg.Mode, cfg.Seed)

--- a/internal/oracle/invariants.go
+++ b/internal/oracle/invariants.go
@@ -2,12 +2,35 @@ package oracle
 
 import "fmt"
 
-// CheckInvariants validates structural guarantees of an observed event stream:
-// seqs are unique and strictly increasing, commit events carry a rev, and per-DID
-// revs never regress.
+// CheckInvariants validates the full structural guarantees of an observed
+// event stream: seqs are unique and strictly increasing, commit events carry a
+// rev, and per-DID revs never regress. It assumes a NON-replayed stream — one
+// where seq order tracks rev order per DID. Use it for clean (no-crash)
+// observations.
+//
+// For a stream recovered across a crash boundary, the per-DID
+// rev-monotonicity-by-seq guarantee does NOT hold: an idempotent at-least-once
+// replay re-emits already-merged survivors at fresh higher seqs carrying their
+// original (lower) revs, so a later seq can legitimately carry an earlier rev
+// (the AfterMergeDstFlushBeforeSourceCommit contract: "recovery may replay
+// duplicates, but must not lose survivors"). Use CheckStructuralInvariants
+// there — final-state Compare + at-least-once coverage own correctness once
+// replay is in play. Splitting the check keeps the strong per-DID rev-monotonic
+// signal (which kills m005 / backstops m018) intact for every clean-stream
+// caller while not flagging benign replay as corruption.
 func CheckInvariants(events []ObservedEvent) error {
+	if err := CheckStructuralInvariants(events); err != nil {
+		return err
+	}
+	return checkPerDIDRevMonotonic(events)
+}
+
+// CheckStructuralInvariants validates the guarantees that hold for ANY observed
+// stream, replayed or not: seqs are unique and strictly increasing and every
+// commit event carries a non-empty rev. It deliberately omits the per-DID
+// rev-monotonicity check, which only holds for non-replayed streams.
+func CheckStructuralInvariants(events []ObservedEvent) error {
 	seenSeqs := make(map[uint64]struct{}, len(events))
-	lastRevByDID := make(map[string]ObservedEvent)
 
 	var lastSeq uint64
 	for i, ev := range events {
@@ -25,6 +48,15 @@ func CheckInvariants(events []ObservedEvent) error {
 			return fmt.Errorf("oracle: empty rev for commit event at event %d: seq=%d kind=%d did=%s collection=%s rkey=%s",
 				i, ev.Seq, ev.Kind, ev.DID, ev.Collection, ev.Rkey)
 		}
+	}
+	return nil
+}
+
+// checkPerDIDRevMonotonic asserts that, within each DID, rev never regresses as
+// seq increases. Valid only for a non-replayed stream (see CheckInvariants).
+func checkPerDIDRevMonotonic(events []ObservedEvent) error {
+	lastRevByDID := make(map[string]ObservedEvent)
+	for i, ev := range events {
 		if ev.Rev == "" {
 			continue
 		}

--- a/internal/oracle/reconstruct_test.go
+++ b/internal/oracle/reconstruct_test.go
@@ -76,6 +76,51 @@ func TestCheckInvariantsRejectsSeqRegression(t *testing.T) {
 	require.ErrorContains(t, err, "seq")
 }
 
+// TestCheckInvariantsRejectsRevRegression locks in the per-DID
+// rev-monotonicity signal that the full CheckInvariants must keep: it is the
+// kill signal for m005 (backfill_status_check_inverted) and a backstop for
+// m018 (commit_rev_dropped). Splitting the structural checks out (for the
+// crash-replay tier) must not weaken this.
+func TestCheckInvariantsRejectsRevRegression(t *testing.T) {
+	t.Parallel()
+
+	events := []ObservedEvent{
+		{Seq: 1, Kind: segment.KindCreate, DID: "did:plc:a", Collection: "c", Rkey: "r1", Rev: "rev9"},
+		{Seq: 2, Kind: segment.KindCreate, DID: "did:plc:a", Collection: "c", Rkey: "r2", Rev: "rev1"},
+	}
+	require.ErrorContains(t, CheckInvariants(events), "rev regression")
+}
+
+// TestCheckStructuralInvariantsToleratesReplayRevRegression proves the split's
+// contract: a recovered stream where a later seq carries an earlier rev (the
+// benign at-least-once merge replay surfaced by the crash-chain tier) passes
+// the structural check, while the full CheckInvariants still rejects it. The
+// structural check must STILL catch seq duplication / non-increase and empty
+// commit revs.
+func TestCheckStructuralInvariantsToleratesReplayRevRegression(t *testing.T) {
+	t.Parallel()
+
+	// Later seq carries an earlier rev (a replayed survivor): structural OK,
+	// full check rejects.
+	replay := []ObservedEvent{
+		{Seq: 1, Kind: segment.KindCreate, DID: "did:plc:a", Collection: "c", Rkey: "r1", Rev: "rev9"},
+		{Seq: 2, Kind: segment.KindCreate, DID: "did:plc:a", Collection: "c", Rkey: "r2", Rev: "rev1"},
+	}
+	require.NoError(t, CheckStructuralInvariants(replay), "structural check must tolerate replay rev order")
+	require.ErrorContains(t, CheckInvariants(replay), "rev regression", "full check must still flag it")
+
+	// Structural check still catches non-increasing seq.
+	require.ErrorContains(t, CheckStructuralInvariants([]ObservedEvent{
+		{Seq: 2, Kind: segment.KindCreate, DID: "did:plc:a", Collection: "c", Rkey: "r1", Rev: "rev1"},
+		{Seq: 1, Kind: segment.KindCreate, DID: "did:plc:a", Collection: "c", Rkey: "r2", Rev: "rev2"},
+	}), "seq")
+
+	// Structural check still catches an empty rev on a commit kind.
+	require.ErrorContains(t, CheckStructuralInvariants([]ObservedEvent{
+		{Seq: 1, Kind: segment.KindCreate, DID: "did:plc:a", Collection: "c", Rkey: "r1"},
+	}), "empty rev")
+}
+
 func TestCheckInvariantsRejectsEmptyRevOnCommitKind(t *testing.T) {
 	t.Parallel()
 

--- a/internal/oracle/restart_crash_chain_test.go
+++ b/internal/oracle/restart_crash_chain_test.go
@@ -142,8 +142,9 @@ func maxDurableSeq(events []ObservedEvent) uint64 {
 func TestOracle_RestartChainShapeB_NoStraddleAfterMergeTailCrash(t *testing.T) {
 	run := runChainThroughCrash(t, "shape-b-nostraddle", 0, crashpoint.AfterCompactionRewriteBeforeWatermark)
 
-	// Final state still converges after the crash.
-	assertOracleMatches(t, run.dataDir, run.w, run.cfg, "shape-b-nostraddle")
+	// Final state still converges after the crash (replay-aware: a recovered
+	// merge boundary may re-emit survivors out of per-DID rev order).
+	assertOracleMatchesAfterReplay(t, run.dataDir, run.w, run.cfg, "shape-b-nostraddle")
 
 	// cov.events carries the real on-disk jetstream seqs (cov.got/.want are
 	// seq-zeroed for key-based coverage comparison, so seq checks MUST read
@@ -197,6 +198,13 @@ func TestOracle_RestartChainShapeB_NoStraddleAfterMergeTailCrash(t *testing.T) {
 // full assertChainDurable bundle (at-least-once coverage, compaction
 // contract, no-permanent-tombstone) over the recovered segments.
 //
+// It crashes the chain at EVERY enumerated crashpoint (#113 "cover all crash
+// points"), so a durable update/delete/tombstone is exposed to a crash at each
+// merge/backfill/compaction seam, not just one. The crashpoint only affects
+// the FIRST child; the second child always re-runs the merge idempotently to a
+// clean after-merge exit, and the chain ops live in the parent-owned world, so
+// recovery converges regardless of where the first child died.
+//
 // Crash timing is wall-clock nondeterministic; the assertions are
 // seq-agnostic and the coverage comparator is at-least-once (>=), which
 // tolerates the benign re-merge duplicate a crash between dst-flush and
@@ -204,20 +212,43 @@ func TestOracle_RestartChainShapeB_NoStraddleAfterMergeTailCrash(t *testing.T) {
 //
 // nolint:paralleltest
 func TestOracle_RestartChainCrashConsistency(t *testing.T) {
-	run := runChainThroughCrash(t, "crash-consistency", 0, crashpoint.AfterCompactionRewriteBeforeWatermark)
+	// Every crashpoint the restart child can be killed at, spanning the
+	// backfill-complete, merge (flush/seal/discovery), bootstrap-live close,
+	// and mid-compaction-rewrite seams. Mirrors the crashpoint set the nil-
+	// coordinator tier (TestOracle_RestartCrashPointsDoNotLoseRecords) uses,
+	// plus the compaction-rewrite seam, now with the chain wired in.
+	crashPoints := []crashpoint.Point{
+		crashpoint.AfterRepoComplete,
+		crashpoint.AfterMergeDstFlushBeforeSourceCommit,
+		crashpoint.AfterMergeDstSealBeforeDiscovery,
+		crashpoint.AfterBootstrapLiveCloseBeforeSeal,
+		crashpoint.AfterCompactionRewriteBeforeWatermark,
+	}
 
-	// Final state converges after crash + recovery.
-	assertOracleMatches(t, run.dataDir, run.w, run.cfg, "crash-consistency")
+	for i, point := range crashPoints {
+		t.Run(point.String(), func(t *testing.T) {
+			label := "crash-consistency-" + point.String()
+			run := runChainThroughCrash(t, label, i, point)
 
-	// The chain's durable intermediates survived the crash: every expected
-	// durable row is present at least once, the compaction contract holds at
-	// the recovered watermark, and the delete->recreate record is visible.
-	assertChainDurable(t, run.dataDir, run.coord, "crash-consistency")
+			// Final state converges after crash + recovery (replay-aware: a
+			// crash at a merge boundary may re-emit already-merged survivors
+			// at fresh seqs in non-rev order — benign per the at-least-once
+			// contract; Compare still converges).
+			assertOracleMatchesAfterReplay(t, run.dataDir, run.w, run.cfg, label)
 
-	// Red-first power check: losing the shape-B live delete tombstone across
-	// the crash boundary must break coverage. Ties the crash test's power to
-	// the actual recovered fixture (mirrors the no-crash shape-B power test).
-	rc := recordChainForShape(t, run.spec, shapeBfCreateDelete)
-	cov := chainCoverage(t, run.dataDir, run.coord)
-	assertCoverageFailsWithoutRow(t, cov, "delete", rc.collection, rc.rkey)
+			// The chain's durable intermediates survived the crash: every
+			// expected durable row is present at least once, the compaction
+			// contract holds at the recovered watermark, and the
+			// delete->recreate record is visible.
+			assertChainDurable(t, run.dataDir, run.coord, label)
+
+			// Red-first power check: losing the shape-B live delete tombstone
+			// across the crash boundary must break coverage. Ties the crash
+			// test's power to the actual recovered fixture at THIS crashpoint
+			// (mirrors the no-crash shape-B power test).
+			rc := recordChainForShape(t, run.spec, shapeBfCreateDelete)
+			cov := chainCoverage(t, run.dataDir, run.coord)
+			assertCoverageFailsWithoutRow(t, cov, "delete", rc.collection, rc.rkey)
+		})
+	}
 }


### PR DESCRIPTION
## Why

#113's remaining DoD item — *"cover all crash points … so an intermediate can be lost across a crash/restart boundary"* — was only partly met after #161: the durable-chain crash test crashed at a single crashpoint. This covers them all, and doing so surfaced (then fixed) a real oracle limitation.

## What

- **`TestOracle_RestartChainCrashConsistency` is now a table test** over every enumerated crashpoint: `after-repo-complete`, `after-merge-dst-flush-before-source-commit`, `after-merge-dst-seal-before-discovery`, `after-bootstrap-live-close-before-seal`, `after-compaction-rewrite-before-watermark`. Each crashes the chain, recovers via re-merge, and runs the full `assertChainDurable` bundle (at-least-once coverage `≥`, `CheckCompacted`, no-permanent-tombstone) + a red-first power check. A durable update/delete/tombstone is now crash-exposed at every merge/backfill/compaction seam.

## The oracle earned its keep — a real finding

Adding `after-merge-dst-flush-before-source-commit` failed **deterministically across 5 seeds** with `oracle: rev regression for DID …`. Contributing-factors analysis:

- **Not corruption.** Final-state `Compare` converges exactly to ground truth — no survivors lost.
- **Benign replay artifact.** That crashpoint's contract is *"recovery may replay duplicates, but must not lose survivors."* Recovery re-emits already-merged survivors at fresh higher seqs carrying their **original lower revs** (repro: 8 duplicates + 2 re-emitted uniques), so a later seq legitimately carries an earlier rev.
- **Root limitation.** `CheckInvariants`' per-DID rev-monotonicity-**by-seq** assumes seq order tracks rev order — true for the clean forward stream, false for a crash-recovered one. The nil-coordinator crash tier never hit it (single-rev backfill creates only); durable multi-rev chains crossing a replay boundary expose it. At-least-once + idempotent clients is an explicit product non-goal (no exactly-once promise).

## Fix — scoped, not a blanket weakening

- Split `CheckInvariants` into `CheckStructuralInvariants` (unique/increasing seq + commit-has-rev — holds for **any** stream) and the per-DID rev-monotonic check. **`CheckInvariants` still runs both**, so every clean-stream caller is unchanged and the rev-regression kill signal is fully preserved.
- The crash-replay tier asserts via a new `assertOracleMatchesAfterReplay` (structural invariants + final-state `Compare`); per-record rev correctness + at-least-once coverage remain owned by the event-log / chain tiers.

## Validation

- New unit tests lock the split's contract: full check rejects a rev regression; structural check tolerates replay order but still catches non-increasing seq + empty commit rev.
- **m005 re-verified KILLED@restart** on a clean tree (kill message still `oracle: rev regression for DID …` — signal survived the split). **m018 KILLED@default** (kills via the event-log tier, unaffected).
- Full `internal/oracle` suite green; restart tier `-race` clean; table test stable across seeds {7,42,1009,2026}.
- The table test was **red before** the invariant split (the flush-before-commit seam) and green after.

## Stale-clause note

#113 named itself the home for the "deferred #100 convergence-hiding over-drop mutant." That mutant is infeasible in merge-tail (resolved under #114/#161) and lives in the steady tier (m025). That clause no longer applies.

Closes #113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)