### PR TITLE
oracle: seeded predicate-driven restart kill points; re-disposition m003 (#29)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,9 @@ go.work.sum
 # Unanchored: the restart child subprocess runs with CWD=internal/oracle, so
 # the default ORACLE_ARTIFACT_DIR can also resolve there.
 oracle-artifacts/
+
+# Local `just mutation-gate` / `mutation-campaign` output (the JSON scorecard).
+# CI writes it under a workspace path (MUTATION_RESULT_JSON); locally it
+# defaults to the repo root. The committed source of truth is
+# testing/mutation/baseline.json, not this run artifact.
+/mutation-result.json

--- a/internal/oracle/restart_crash_chain_test.go
+++ b/internal/oracle/restart_crash_chain_test.go
@@ -29,6 +29,19 @@ import (
 // nolint:paralleltest
 func runChainThroughCrash(t *testing.T, label string, seedIdx int, point crashpoint.Point) recoveredChainRun {
 	t.Helper()
+	return runChainThroughCrashAt(t, label, seedIdx, point, 1)
+}
+
+// runChainThroughCrashAt is runChainThroughCrash with an explicit 1-based kill
+// ordinal: the first child is SIGKILLed on the ordinal-th hit of point rather
+// than the first. ordinal=1 is the original behavior. This is the mechanism
+// behind the predicate-driven kill tier (#29): a seeded predicate chooses
+// (point, ordinal) so a crash can land "between" named crashpoints by
+// occurrence count (e.g. after the 3rd repo completes).
+//
+// nolint:paralleltest
+func runChainThroughCrashAt(t *testing.T, label string, seedIdx int, point crashpoint.Point, ordinal int) recoveredChainRun {
+	t.Helper()
 	if testing.Short() {
 		t.Skip("skipping restart oracle under -short")
 	}
@@ -54,6 +67,7 @@ func runChainThroughCrash(t *testing.T, label string, seedIdx int, point crashpo
 		"accounts":      cfg.Accounts,
 		"case":          label,
 		"crash_point":   point.String(),
+		"crash_ordinal": ordinal,
 		"chain_did_idx": spec.chainAccountIdx(),
 		"chain_records": len(spec.records),
 	})
@@ -78,13 +92,14 @@ func runChainThroughCrash(t *testing.T, label string, seedIdx int, point crashpo
 		relayURL:        srv.URL,
 		markerPath:      markerPath,
 		crashPoint:      point,
+		crashOrdinal:    ordinal,
 		killAfterMarker: true,
 		timeout:         30 * time.Second,
 		trace:           trace,
 		runLabel:        "first-" + label,
 	})
 	recordTraceOrError(t, trace, "restart_child_result", traceRestartChildResult("first", first))
-	require.Truef(t, wasSIGKILL(first.err), "first child should be killed at %s: err=%v\n%s", point, first.err, first.output)
+	require.Truef(t, wasSIGKILL(first.err), "first child should be killed at %s ordinal=%d: err=%v\n%s", point, ordinal, first.err, first.output)
 
 	// Second child: re-run the merge idempotently to a clean after-merge
 	// exit. The coordinator does NOT regenerate (sync.Once already fired on

--- a/internal/oracle/restart_harness_test.go
+++ b/internal/oracle/restart_harness_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -33,6 +34,10 @@ const (
 	envRestartMarker     = "JETSTREAM_ORACLE_RESTART_MARKER"
 	envRestartMergeDone  = "JETSTREAM_ORACLE_RESTART_MERGE_DONE"
 	envRestartCrashPoint = "JETSTREAM_ORACLE_RESTART_CRASH_POINT"
+	// envRestartCrashOrdinal selects the 1-based occurrence of the crashpoint
+	// to kill on (default 1). Lets a predicate kill "between" named crashpoints
+	// by occurrence count, e.g. the 3rd AfterRepoComplete.
+	envRestartCrashOrdinal = "JETSTREAM_ORACLE_RESTART_CRASH_ORDINAL"
 )
 
 // nolint:paralleltest
@@ -335,27 +340,49 @@ func newOracleCrashInjectorFromEnv(t *testing.T, markerPath string) crashpoint.I
 	point, err := crashpoint.Parse(rawPoint)
 	require.NoError(t, err)
 
+	// Optional 1-based ordinal: kill on the Nth hit of the target crashpoint
+	// rather than the first. Absent/empty => 1 (the historical behavior). This
+	// is what lets a seeded predicate kill "between" named crashpoints — e.g.
+	// after the 3rd repo completes, not just the 1st — without adding new
+	// firing sites (Notes: prefer trace-event-count kill points).
+	ordinal := 1
+	if raw := os.Getenv(envRestartCrashOrdinal); raw != "" {
+		require.NoError(t, parseIntEnv(os.LookupEnv, envRestartCrashOrdinal, &ordinal))
+		require.Greaterf(t, ordinal, 0, "%s must be >= 1", envRestartCrashOrdinal)
+	}
+
 	return &oracleCrashInjector{
 		target:     point,
+		ordinal:    ordinal,
 		markerPath: markerPath,
 	}
 }
 
-// oracleCrashInjector fires on the FIRST time the target crashpoint is
-// reached: it writes the marker file (the parent polls for it, then
-// SIGKILLs this child) and blocks until the process is killed. The
-// sync.Once makes the marker write exactly-once even though backfill
-// invokes SimulateCrash from multiple per-DID worker goroutines
-// concurrently.
+// oracleCrashInjector fires the kill-marker when the target crashpoint is
+// reached for the ordinal-th time: it writes the marker file (the parent polls
+// for it, then SIGKILLs this child) and blocks until the process is killed.
+// The atomic hit counter + sync.Once makes the marker write exactly-once even
+// though backfill invokes SimulateCrash from multiple per-DID worker goroutines
+// concurrently; only the goroutine that observes the ordinal-th hit writes the
+// marker, and every hit at/after the ordinal blocks so the process is reliably
+// killed at the chosen point.
 type oracleCrashInjector struct {
 	target     crashpoint.Point
+	ordinal    int
 	markerPath string
+	hits       atomic.Int64
 	once       sync.Once
 	writeErr   error
 }
 
 func (i *oracleCrashInjector) SimulateCrash(ctx context.Context, point crashpoint.Point) error {
 	if point != i.target {
+		return nil
+	}
+
+	// Hits before the target ordinal pass through (the lifecycle proceeds);
+	// the ordinal-th and any later hit arm the kill and block until SIGKILL.
+	if i.hits.Add(1) < int64(i.ordinal) {
 		return nil
 	}
 
@@ -414,6 +441,7 @@ type restartChildArgs struct {
 	markerPath      string
 	mergeDonePath   string
 	crashPoint      crashpoint.Point
+	crashOrdinal    int // 1-based kill ordinal; 0 == default (1st hit)
 	killAfterMarker bool
 	timeout         time.Duration
 	trace           *Trace
@@ -431,10 +459,13 @@ func runRestartChild(t *testing.T, args restartChildArgs) restartChildResult {
 
 	logPath, logFile, closeLog := newOracleArtifactFile(t, args.runLabel+"-restart-child.log")
 	defer closeLog()
+	// 0 means "unset"; the child treats a missing ordinal as 1.
+	ordinal := args.crashOrdinal
 	recordTraceOrError(t, args.trace, "restart_child_start", map[string]any{
 		"label":             args.runLabel,
 		"log_path":          logPath,
 		"crash_point":       args.crashPoint.String(),
+		"crash_ordinal":     ordinal,
 		"kill_after_marker": args.killAfterMarker,
 		"marker_path":       args.markerPath,
 		"merge_done_path":   args.mergeDonePath,
@@ -451,6 +482,9 @@ func runRestartChild(t *testing.T, args restartChildArgs) restartChildResult {
 		envRestartMergeDone+"="+args.mergeDonePath,
 		envRestartCrashPoint+"="+args.crashPoint.String(),
 	)
+	if ordinal > 0 {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%d", envRestartCrashOrdinal, ordinal))
+	}
 	require.NoError(t, cmd.Start())
 	recordTraceOrError(t, args.trace, "restart_child_process", map[string]any{
 		"label": args.runLabel,

--- a/internal/oracle/restart_predicate_kill_test.go
+++ b/internal/oracle/restart_predicate_kill_test.go
@@ -1,0 +1,185 @@
+package oracle
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"os"
+	"testing"
+
+	"github.com/bluesky-social/jetstream/internal/crashpoint"
+)
+
+// #29: seeded, predicate-driven restart kill points.
+//
+// The fixed crash tiers (TestOracle_RestartCrashPointsDoNotLoseRecords,
+// TestOracle_RestartChainCrashConsistency) always kill at the FIRST hit of a
+// hardcoded crashpoint. This tier instead chooses the kill point by a seeded
+// predicate over a *trace-event-count* coordinate — the (crashpoint, 1-based
+// occurrence ordinal) pair — so a crash can land "between" named crashpoints
+// (e.g. after the 3rd repo completes), exploring interleavings the fixed set
+// never reaches. Per the issue Notes, occurrence-count kill points are
+// preferred over wall-clock timing: they are deterministic given the seed and
+// reproduce exactly.
+//
+// Each selected kill still drives the full durable chain through crash +
+// recovery and asserts the same invariants as the fixed tier (final-state
+// convergence + chain durability), so a predicate-selected interleaving that
+// loses or corrupts a durable intermediate fails loudly.
+
+// killOption is one entry in the predicate's selection space: a crashpoint and
+// the maximum occurrence ordinal that is reliably reachable for it in the
+// restart-chain scenario (Accounts=4, single source segment). maxOrdinal is
+// kept conservative so a seeded pick is always reachable — an unreachable
+// ordinal would hang the child until timeout, which the harness surfaces, but
+// we do not want a flaky kill selection.
+type killOption struct {
+	point      crashpoint.Point
+	maxOrdinal int
+}
+
+// killSpace is the reachable (crashpoint, ordinal) selection space.
+//   - AfterRepoComplete fires once per backfilled repo (Accounts=4 → ordinals
+//     1..4), the canonical trace-event-count predicate.
+//   - The merge/bootstrap/compaction seams fire once per run in this scenario
+//     (single source segment), so ordinal is pinned to 1; they still vary the
+//     PHASE the kill lands in, which is the other predicate dimension the issue
+//     asks for.
+var killSpace = []killOption{
+	{point: crashpoint.AfterRepoComplete, maxOrdinal: 4},
+	{point: crashpoint.AfterBootstrapLiveCloseBeforeSeal, maxOrdinal: 1},
+	{point: crashpoint.AfterMergeDstFlushBeforeSourceCommit, maxOrdinal: 1},
+	{point: crashpoint.AfterMergeDstSealBeforeDiscovery, maxOrdinal: 1},
+	{point: crashpoint.AfterCompactionRewriteBeforeWatermark, maxOrdinal: 1},
+}
+
+// killDecision is a fully-resolved predicate selection: which crashpoint and
+// which occurrence. It is a pure function of the seed (selectKill), so a CI
+// failure replays the exact same kill.
+type killDecision struct {
+	point   crashpoint.Point
+	ordinal int
+}
+
+func (d killDecision) String() string {
+	return fmt.Sprintf("%s#%d", d.point, d.ordinal)
+}
+
+// selectKill is the seeded predicate: it deterministically maps a seed to a
+// (crashpoint, ordinal) kill decision over killSpace. Same seed → identical
+// decision; different seeds explore different points and occurrences.
+func selectKill(seed uint64) killDecision {
+	rng := rand.New(rand.NewPCG(seed^0x6b696c6c70, seed^0x7072656431))
+	opt := killSpace[rng.IntN(len(killSpace))]
+	ordinal := 1 + rng.IntN(opt.maxOrdinal)
+	return killDecision{point: opt.point, ordinal: ordinal}
+}
+
+// TestOracle_RestartPredicateKill drives a seeded predicate-selected kill
+// through the durable chain crash + recovery, then asserts the full chain
+// durability bundle. It runs ONE deterministic decision for push CI (fixed
+// seed, so the selection and the failing repro are stable), and a multi-kill
+// sweep when JETSTREAM_ORACLE_SEED is set (nightly/manual), each iteration
+// drawing a fresh decision so the sweep explores the kill space.
+//
+// nolint:paralleltest
+func TestOracle_RestartPredicateKill(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping restart oracle under -short")
+	}
+
+	for i, seed := range predicateKillSeeds() {
+		decision := selectKill(seed)
+		t.Run(decision.String(), func(t *testing.T) {
+			label := fmt.Sprintf("predicate-kill-%s-seed%d", decision, seed)
+			t.Logf("predicate kill decision: seed=%d point=%s ordinal=%d", seed, decision.point, decision.ordinal)
+
+			run := runChainThroughCrashAt(t, label, predicateSeedIdx(i, seed), decision.point, decision.ordinal)
+
+			// The predicate-selected interleaving must still converge and keep
+			// every durable intermediate (replay-aware: a merge-boundary crash
+			// may re-emit survivors out of per-DID rev order — benign).
+			assertOracleMatchesAfterReplay(t, run.dataDir, run.w, run.cfg, label)
+			assertChainDurable(t, run.dataDir, run.coord, label)
+
+			// Red-first power: the shape-B delete tombstone must be present and
+			// load-bearing for coverage at this kill point too.
+			rc := recordChainForShape(t, run.spec, shapeBfCreateDelete)
+			cov := chainCoverage(t, run.dataDir, run.coord)
+			assertCoverageFailsWithoutRow(t, cov, "delete", rc.collection, rc.rkey)
+		})
+	}
+}
+
+// predicateKillSeeds returns the seeds the predicate-kill tier sweeps. Without
+// JETSTREAM_ORACLE_SEED it returns a single fixed seed so push CI runs one
+// deterministic kill; with it set, it returns that seed plus a small
+// deterministic fan (seed, seed+1, ...) so a nightly/manual run does multiple
+// random kills (DoD: "nightly/manual mode can run multiple random kills").
+func predicateKillSeeds() []uint64 {
+	const fixed = 0x29ce11 // stable push-CI seed (issue #29)
+	raw, ok := os.LookupEnv(envOracleSeed)
+	if !ok || raw == "" {
+		return []uint64{fixed}
+	}
+	var base uint64
+	if err := parseUint64Env(func(string) (string, bool) { return raw, true }, envOracleSeed, &base); err != nil {
+		return []uint64{fixed}
+	}
+	const sweep = 5
+	seeds := make([]uint64, sweep)
+	for i := range seeds {
+		seeds[i] = base + uint64(i)
+	}
+	return seeds
+}
+
+// predicateSeedIdx derives the world/chain seed index for iteration i. It must
+// vary per iteration (so each kill runs a different world) while staying a pure
+// function of (i, seed) for replay. restartSeed honors JETSTREAM_ORACLE_SEED;
+// offsetting by i keeps successive sweep iterations on distinct worlds.
+func predicateSeedIdx(i int, _ uint64) int {
+	return i
+}
+
+// TestSelectKillIsDeterministicAndInBounds locks the predicate contract without
+// the subprocess cost: same seed → identical decision, the chosen ordinal is
+// always within the crashpoint's reachable [1, maxOrdinal], and over many seeds
+// the predicate actually exercises more than one crashpoint and more than one
+// ordinal (anti-vacuity — a constant selector would defeat the tier's purpose).
+func TestSelectKillIsDeterministicAndInBounds(t *testing.T) {
+	t.Parallel()
+
+	maxByPoint := make(map[crashpoint.Point]int, len(killSpace))
+	for _, opt := range killSpace {
+		maxByPoint[opt.point] = opt.maxOrdinal
+	}
+
+	seenPoints := make(map[crashpoint.Point]struct{})
+	seenOrdinalsAbove1 := false
+	for s := range 500 {
+		seed := uint64(s)
+		d := selectKill(seed)
+		// Deterministic.
+		if again := selectKill(seed); again != d {
+			t.Fatalf("selectKill(%d) not deterministic: %v vs %v", seed, d, again)
+		}
+		// In a known crashpoint with a reachable ordinal.
+		maxOrd, ok := maxByPoint[d.point]
+		if !ok {
+			t.Fatalf("selectKill(%d) chose unknown crashpoint %q", seed, d.point)
+		}
+		if d.ordinal < 1 || d.ordinal > maxOrd {
+			t.Fatalf("selectKill(%d) ordinal %d out of [1,%d] for %q", seed, d.ordinal, maxOrd, d.point)
+		}
+		seenPoints[d.point] = struct{}{}
+		if d.ordinal > 1 {
+			seenOrdinalsAbove1 = true
+		}
+	}
+	if len(seenPoints) < 2 {
+		t.Fatalf("predicate exercises only %d crashpoint(s); expected variety across the kill space", len(seenPoints))
+	}
+	if !seenOrdinalsAbove1 {
+		t.Fatal("predicate never selected an ordinal > 1; the trace-event-count dimension is unexercised")
+	}
+}

--- a/testing/mutation/RESULTS.md
+++ b/testing/mutation/RESULTS.md
@@ -102,6 +102,55 @@ Full gate verification passed:
 gate: PASS — 25 mutants match baseline (commit b6d3f09000c578400264db8b3c0b56b553427c7e)
 ```
 
+## m003 re-disposition 2026-06-26 (#29 — accepted-benign, mechanism nailed down)
+
+Re-examined m003 while building the #29 predicate-driven kill tier (the issue
+named this tier the home for killing m003). m003 remains **SURVIVED** on current
+`main` after #113/#114, and a direct spike confirms it is **architecturally
+benign in every scenario the restart tier can construct** — not a coverage gap.
+This reaffirms the 2026-06-20 "benign, not a gap" disposition below, now with the
+full mechanism nailed down, and three independent guards each of which alone
+neutralizes the mutant:
+
+1. **Source segments are deleted on clean completion, and the cursor is then
+   ignored.** After a full merge, `merge.go` `os.RemoveAll(.../backfill)` removes
+   the source tree; on the next start the restart-after-cleanup guard sees
+   `live_segments` gone, deletes the cursor keys, and returns. So m003's
+   `commitSourceComplete(sf.Idx)` vs `sf.Idx+1` off-by-one is **never read** on a
+   clean restart — there is no source tree left to re-process. Idempotency holds
+   independently of the cursor value.
+
+2. **The restart-chain scenario produces a single source segment** (verified:
+   `live_segments` empties to one merged `segments/seg_0000000000.jss`). With one
+   source, the only mid-merge crashpoint (`AfterMergeDstFlushBeforeSourceCommit`)
+   fires *before* `commitSourceComplete`, so the cursor is uncommitted under both
+   correct and mutant code and the re-run reprocesses identically. There is no
+   "earlier-committed source + later-pending source" gap where `Idx` vs `Idx+1`
+   diverges.
+
+3. **The destination re-stamps seqs** (`ingest.Writer` sets `ev.Seq = nextSeq`),
+   so even a hypothetical re-append is a contract-permitted at-least-once
+   duplicate, which #113's replay-aware `CheckStructuralInvariants` + the `≥`
+   coverage comparator now *correctly* tolerate. The mutant author's predicted
+   kill signal (CheckInvariants duplicate-seq / Compare extra-record) assumed a
+   seq-preserving re-append; the re-stamp defeats it.
+
+Empirical confirmation (#29 work): applying m003 and running the durable-chain
+crash tier at `AfterMergeDstFlushBeforeSourceCommit` (rows kept, unlike the old
+nil-coordinator tier) still **passes** — no duplicate, no loss, final-state
+`Compare` converges. Killing m003 would require a multi-retained-source-segment
+scenario with a crash between per-source commits, which the architecture
+deliberately does not produce and whose cursor mechanics are already covered by
+orchestrator unit tests.
+
+**Disposition: accepted-benign, owned by #29.** Kept in the catalog as a SURVIVED
+documented blind spot (its mutation point is real; it simply has no observable
+effect here), consistent with the enforced baseline. The #29 DoD clause "this
+tier kills m003" is withdrawn; #29 delivers the seeded/predicate-driven
+kill-point selection instead. Note: this is the same class of finding as #114's
+withdrawn convergence-hiding over-drop — a "kill the mutant" goal written before
+the idempotency guarantees were fully traced.
+
 ## Active catalog check 2026-06-15 — retired mutants removed
 
 - commit under test: `767792e`


### PR DESCRIPTION
## Why

The restart crash tiers always killed at the **first** hit of a hardcoded crashpoint. #29 adds seeded, **predicate-driven** kill-point selection over a *trace-event-count* coordinate — the `(crashpoint, 1-based occurrence ordinal)` pair — so a crash can land **between** named crashpoints (e.g. after the 3rd repo completes), exploring interleavings the fixed set never reaches. Per the issue Notes, occurrence-count kill points are preferred over wall-clock timing: deterministic given the seed, reproduce exactly.

## What

- **Ordinal-aware crash injector.** `oracleCrashInjector` gains a 1-based ordinal (atomic hit counter + `sync.Once`): it arms the kill on the ordinal-th hit of the target crashpoint, not the first. Threaded via `JETSTREAM_ORACLE_RESTART_CRASH_ORDINAL`; absent ⇒ 1, so every existing crash tier is byte-for-byte unchanged.
- **`runChainThroughCrashAt(label, seedIdx, point, ordinal)`** generalizes `runChainThroughCrash` (now delegates with ordinal=1). Kill ordinal recorded in the parent trace alongside the existing kill-decision fields (seed, PID, phase, crashpoint).
- **`selectKill(seed)`** — pure seed → `(crashpoint, ordinal)` predicate over a reachable kill space (`AfterRepoComplete` ordinals 1..Accounts; the single-fire merge/bootstrap/compaction seams at ordinal 1, varying the phase the kill lands in).
- **`TestOracle_RestartPredicateKill`** runs ONE deterministic kill for push CI (fixed seed, stable repro) and a 5-kill sweep when `JETSTREAM_ORACLE_SEED` is set (nightly/manual "multiple random kills"). Every selected kill drives the full durable chain through crash + recovery and asserts `assertChainDurable` + the red-first shape-B coverage power check.

## Test-power discipline

- `TestSelectKillIsDeterministicAndInBounds` locks the predicate contract without subprocess cost: same seed → identical decision; ordinal always within the crashpoint's reachable bound; over 500 seeds the predicate exercises >1 crashpoint and selects ordinals > 1 (anti-vacuity — a constant selector would defeat the tier).
- Verified ordinals 1..4 at `AfterRepoComplete` each kill mid-backfill and recover cleanly; nightly sweep observed `after-repo-complete#3/#4`.

## m003 re-disposition (the DoD's named kill target — withdrawn as benign)

The DoD said *"this tier kills m003"* (merge-cursor off-by-one). A spike proves m003 is **architecturally benign** in every scenario the restart tier can construct — three independent guards each neutralize it:

1. Source segments are deleted on clean completion; the restart-after-cleanup guard then makes the cursor **unread** on restart — m003's `Idx` vs `Idx+1` is never consulted.
2. The restart-chain scenario has a **single source segment**, so the only mid-merge crashpoint fires *before* `commitSourceComplete` — cursor uncommitted under both correct and mutant code.
3. The dst **re-stamps seqs**, so any re-append is a contract-permitted at-least-once duplicate that #113's replay-aware `CheckStructuralInvariants` + `≥` coverage now correctly tolerate.

Confirmed empirically: m003 still **SURVIVED**, and the durable-chain crash tier passes under it. Recorded as accepted-benign in `testing/mutation/RESULTS.md` (kept in catalog as a documented SURVIVED blind spot); the "kill m003" DoD clause is withdrawn. Same class of finding as #114's withdrawn convergence-hiding over-drop — a "kill the mutant" goal written before the idempotency guarantees were traced.

## Validation

- Full `internal/oracle` suite green (default); predicate tier + adjacent crash tiers `-race` clean.
- **Mutation gate PASS — 25 mutants match baseline** (no disposition drift; changes are test-additive + prose).
- `selectKill` determinism verified across repeated runs.

Also: `.gitignore` now ignores the root `mutation-result.json` gate artifact (`just mutation-gate` writes it locally).

Closes #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)