### PR TITLE
oracle: store-fault injection tier; kill m006 (#30)

### DIFF
--- a/internal/ingest/live/storefault_test.go
+++ b/internal/ingest/live/storefault_test.go
@@ -1,0 +1,50 @@
+package live
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/bluesky-social/jetstream/internal/store"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConsumer_SaveCursorFailsLoudOnStoreFault pins the fail-loud contract for
+// the relay-cursor commit boundary (issue #30 fault point: "relay cursor
+// writes"). saveCursorAndSyncState is the production path that persists the
+// firehose resume cursor (batched with verifier sync state under one Sync
+// commit). A failed commit must surface as an error so the caller
+// (onAfterFlush -> the ingest flush hook -> the consumer Run loop) tears the
+// process down, rather than reporting a durable cursor advance that never
+// reached disk — which across a restart would resume the firehose from a seq
+// that was never persisted, silently skipping events.
+//
+// The fault targets the relay/cursor batch commit; the assertion is that
+// saveCursorAndSyncState propagates the injected error AND the cursor is not
+// durable (no silent advance).
+func TestConsumer_SaveCursorFailsLoudOnStoreFault(t *testing.T) {
+	t.Parallel()
+
+	const cursorKey = "relay/cursor"
+	injected := errors.New("injected: relay cursor commit failed")
+	fault := &store.KeyPrefixFault{
+		Prefix:  []byte(cursorKey),
+		Op:      store.WriteOpBatchCommit,
+		Ordinal: 1,
+		Err:     injected,
+	}
+	st, err := store.Open(t.TempDir(), nil, store.WithFaultInjector(fault))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	// Minimal consumer: saveCursorAndSyncState only needs Store + CursorKey
+	// (SyncStateStore nil → cursor-only batch, exactly the relay/cursor write).
+	c := &Consumer{cfg: Config{Store: st, CursorKey: cursorKey}}
+
+	require.ErrorIs(t, c.saveCursorAndSyncState(42), injected,
+		"relay cursor commit failure must surface loud, not be swallowed")
+
+	// No silent advance: the cursor was never durably written.
+	got, err := LoadUpstreamCursor(st, cursorKey)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), got, "relay cursor must not advance when its commit failed")
+}

--- a/internal/ingest/orchestrator/compact_storefault_test.go
+++ b/internal/ingest/orchestrator/compact_storefault_test.go
@@ -1,0 +1,89 @@
+package orchestrator
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/bluesky-social/jetstream/internal/store"
+	"github.com/bluesky-social/jetstream/segment"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCompaction_StoreFaultOnWatermarkSave_FailsLoudNoAdvance is the kill for
+// mutation m028 (compaction_watermark_save_error_swallowed), a new
+// swallowed-persistence-error mutant on the compaction watermark write — a
+// distinct high-risk fault point named in issue #30, and a different store op
+// from m006 (a plain Set on compaction/seq, not a batch commit), so it
+// exercises the fault seam's Set path.
+//
+// m028 inverts the error check on saveCompactionWatermark in
+// runDeleteCompaction so a FAILED watermark write is swallowed and the pass
+// proceeds: the in-memory watermark gauge and finalWatermark advance, tombstone
+// eviction runs, and the pass returns success — all while the DURABLE
+// compaction/seq is stale. On the next process the persisted watermark is below
+// what was already rewritten, so a resumed compaction can re-drop or mis-handle
+// rows relative to a watermark the rest of the system believed had advanced.
+//
+// We force the watermark Set to fail and assert the phase contract (#30): the
+// pass fails LOUD and the durable watermark does NOT advance, so a restart
+// re-runs the pass from the true persisted point. Under the mutant the error is
+// swallowed and runDeleteCompaction returns nil — the kill.
+func TestCompaction_StoreFaultOnWatermarkSave_FailsLoudNoAdvance(t *testing.T) {
+	t.Parallel()
+
+	dataDir := t.TempDir()
+	segmentsDir := filepath.Join(dataDir, "segments")
+	require.NoError(t, os.MkdirAll(segmentsDir, 0o755))
+
+	injected := errors.New("injected: compaction watermark save failed")
+	fault := &store.KeyPrefixFault{
+		Prefix:  []byte(compactionWatermarkKey),
+		Op:      store.WriteOpSet,
+		Ordinal: 1,
+		Err:     injected,
+	}
+	st, err := store.Open(dataDir, nil, store.WithFaultInjector(fault))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	// A create superseded by a delete: the merge-tail pass rewrites the segment
+	// (dropping the create) and then advances the watermark to seq 2 — the Set
+	// our fault aborts.
+	path := writeCompactionSegment(t, segmentsDir, 0, []segment.Event{
+		{Seq: 1, IndexedAt: 10, Kind: segment.KindCreate, DID: "did:plc:a", Collection: "app.bsky.feed.post", Rkey: "r", Rev: "1", Payload: []byte("old")},
+		{Seq: 2, IndexedAt: 20, Kind: segment.KindDelete, DID: "did:plc:a", Collection: "app.bsky.feed.post", Rkey: "r", Rev: "2"},
+	})
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	o := &Orchestrator{cfg: Config{
+		DataDir:            dataDir,
+		Store:              st,
+		Logger:             logger,
+		CompactionInterval: time.Hour,
+	}, logger: logger}
+
+	// Correct code propagates the watermark-save failure; the mutant swallows it
+	// and returns nil. This is the kill.
+	err = o.runDeleteCompaction(t.Context(), compactionMergeTail, nil)
+	require.Error(t, err, "compaction must fail loud when the watermark save fails")
+	require.ErrorIs(t, err, injected)
+
+	// No silent advance: the durable watermark must remain unset/zero, so a
+	// restart re-runs the pass from the true persisted point rather than
+	// trusting a watermark that was never durably written.
+	watermark, ok, lerr := loadCompactionWatermark(st)
+	require.NoError(t, lerr)
+	require.False(t, ok && watermark > 0,
+		"durable watermark must not advance when its save failed (got ok=%v watermark=%d)", ok, watermark)
+
+	// Anti-vacuity: the rewrite actually ran (the create was dropped), so the
+	// failed write was a real watermark advance, not a no-op pass.
+	events := readCompactionSegment(t, path)
+	require.Len(t, events, 1, "rewrite should have dropped the superseded create before the watermark save")
+	require.Equal(t, segment.KindDelete, events[0].Kind)
+}

--- a/internal/ingest/orchestrator/merge_storefault_test.go
+++ b/internal/ingest/orchestrator/merge_storefault_test.go
@@ -1,0 +1,118 @@
+package orchestrator
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/bluesky-social/jetstream/internal/lifecycle"
+	"github.com/bluesky-social/jetstream/internal/store"
+	"github.com/bluesky-social/jetstream/segment"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMerge_StoreFaultOnCursorCommit_FailsLoudNoSilentAdvance is the
+// store-fault tier's primary kill for mutation m006
+// (merge_commit_error_swallowed). The mutant inverts the error check on
+// the source-cursor commit in merge_runner.go so a FAILED commit is
+// silently swallowed and the merge proceeds — the classic swallowed-
+// persistence-error that can advance past unarchived data.
+//
+// We force commitSourceComplete's batch commit to fail by injecting a
+// fault on the merge/next_source_idx batch (the only batch that key rides)
+// and assert the phase-specific contract: runMerge fails LOUD, and the
+// durable state is left untouched for a clean restart — the cursor is not
+// advanced and the backfill source tree is NOT cleaned up. Under the
+// mutant the commit error is swallowed, so runMerge runs to completion:
+// it returns nil and removes data/backfill. Either divergence fails this
+// test, killing the mutant.
+//
+// Contract reference: issue #30 — "fail loud where continuing risks
+// corruption ... never silently advance cursors past unarchived data."
+func TestMerge_StoreFaultOnCursorCommit_FailsLoudNoSilentAdvance(t *testing.T) {
+	t.Parallel()
+	injected := errors.New("injected: merge cursor commit failed")
+	fault := &store.KeyPrefixFault{
+		Prefix:  []byte(mergeNextSourceIdxKey),
+		Op:      store.WriteOpBatchCommit,
+		Ordinal: 1,
+		Err:     injected,
+	}
+
+	srcEvs := []segment.Event{ev("did:plc:a", "3l6", segment.KindCreate, 1000)}
+	fix := newMergeFixture(t, [][]segment.Event{srcEvs},
+		map[string]string{"did:plc:a": "3l5"}, store.WithFaultInjector(fault))
+
+	require.NoError(t, lifecycle.WritePhase(fix.store, lifecycle.PhaseMerging, time.Now().UTC()))
+	o, err := New(fix.cfg)
+	require.NoError(t, err)
+
+	// Correct code propagates the commit failure; the mutant swallows it
+	// and returns nil. This assertion is the kill.
+	err = o.runMerge(t.Context())
+	require.Error(t, err, "merge must fail loud when the source-cursor commit fails")
+	require.ErrorIs(t, err, injected)
+
+	// No silent advance: the cursor key must remain absent (the failed
+	// commit never applied), so a restart re-drains the source.
+	cur, err := loadMergeCursor(fix.store)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), cur, "failed cursor commit must not advance the merge cursor")
+
+	// Durable source preserved: the backfill tree must NOT be cleaned up,
+	// because cleanup past an un-archived source is the data-loss class
+	// m006 models. Under the mutant runMerge reaches terminal cleanup and
+	// removes this directory.
+	_, statErr := os.Stat(filepath.Join(fix.dataDir, "backfill", "live_segments"))
+	require.NoError(t, statErr, "backfill source tree must survive a failed merge for restart")
+}
+
+// TestMergeNextSourceIdxKeyMatchesOracleStoreFault pins the oracle
+// store-fault tier's duplicated key constant to the orchestrator's source of
+// truth. The oracle test (internal/oracle) cannot import this package-private
+// const, so it hardcodes the string; if mergeNextSourceIdxKey ever changes,
+// this guard fails and forces both to move together — otherwise the oracle
+// fault would stop matching the merge cursor commit and the m006 kill would
+// silently go vacuous.
+func TestMergeNextSourceIdxKeyMatchesOracleStoreFault(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "merge/next_source_idx", mergeNextSourceIdxKey,
+		"oracle store-fault tier hardcodes this key (internal/oracle/restart_storefault_test.go "+
+			"mergeNextSourceIdxStoreKey); keep them in sync")
+}
+
+// TestMerge_MultiSourceDrainsAllSources is the complementary kill for
+// m006's other inverted branch. With err==nil the mutant returns early
+// after the FIRST source commit, so sources 2..N are never drained and
+// their survivors never reach the destination. The existing
+// TestMerge_MultiSourceContiguousCommit only checks post-cleanup state
+// (cursor absent, backfill removed), which holds under the early return
+// too, so it does not catch this. Here we assert every source's survivor
+// lands in the destination.
+func TestMerge_MultiSourceDrainsAllSources(t *testing.T) {
+	t.Parallel()
+	// Three distinct DIDs across three source segments. Each is a fresh
+	// DID with no backfill row, so every event is a keep (no rev-filter
+	// drop), making the survivor count unambiguous.
+	src1 := []segment.Event{ev("did:plc:a", "3l6", segment.KindCreate, 1000)}
+	src2 := []segment.Event{ev("did:plc:b", "3l7", segment.KindCreate, 1001)}
+	src3 := []segment.Event{ev("did:plc:c", "3l8", segment.KindCreate, 1002)}
+	fix := newMergeFixture(t, [][]segment.Event{src1, src2, src3}, nil)
+
+	require.NoError(t, lifecycle.WritePhase(fix.store, lifecycle.PhaseMerging, time.Now().UTC()))
+	o, err := New(fix.cfg)
+	require.NoError(t, err)
+	require.NoError(t, o.runMerge(t.Context()))
+
+	got := readDestEvents(t, fix.dataDir)
+	revs := map[string]bool{}
+	for _, e := range got {
+		revs[e.Rev] = true
+	}
+	require.True(t, revs["3l6"], "source 1 survivor must reach destination")
+	require.True(t, revs["3l7"], "source 2 survivor must reach destination")
+	require.True(t, revs["3l8"], "source 3 survivor must reach destination (mutant early-returns after source 1)")
+	require.Len(t, got, 3, "exactly one survivor per source segment")
+}

--- a/internal/ingest/orchestrator/testfixtures_test.go
+++ b/internal/ingest/orchestrator/testfixtures_test.go
@@ -171,10 +171,10 @@ type mergeFixture struct {
 // the pre-merge per-DID Backfill.Rev (also pre-populates the top-level
 // Rev to that same value, mirroring what the real OnComplete callback
 // does). Both arguments may be nil/empty.
-func newMergeFixture(t *testing.T, sources [][]segment.Event, repoRevs map[string]string) *mergeFixture {
+func newMergeFixture(t *testing.T, sources [][]segment.Event, repoRevs map[string]string, storeOpts ...store.Option) *mergeFixture {
 	t.Helper()
 	dataDir := t.TempDir()
-	st, err := store.Open(dataDir, nil)
+	st, err := store.Open(dataDir, nil, storeOpts...)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = st.Close() })
 

--- a/internal/ingest/storefault_test.go
+++ b/internal/ingest/storefault_test.go
@@ -1,0 +1,74 @@
+package ingest
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"testing"
+
+	"github.com/bluesky-social/jetstream/internal/store"
+	"github.com/bluesky-social/jetstream/segment"
+	"github.com/cockroachdb/pebble"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWriter_DurableBatchFailsLoudOnStoreFault pins the fail-loud contract for
+// the seq/next durable-commit boundary (issue #30 fault point: "seq/next
+// writes"). commitDurableBatchLocked stages seq/next (plus any OnDurableBatch
+// metadata) and commits it with Sync after the block's segment bytes are
+// fsynced. A failed commit must surface as an error so the flush — and the
+// owning consumer/backfill loop — tears down, rather than reporting an
+// advanced in-memory durableNextSeq that never reached disk. A swallowed
+// failure here would leave seq/next behind the durable segment data: across a
+// restart the writer would re-allocate already-used seqs, duplicating or
+// colliding archived events.
+//
+// A full block flush drives commitDurableBatchLocked; the fault aborts the
+// seq/next batch commit. We assert Append surfaces the injected error and that
+// seq/next is not durable (no silent advance).
+func TestWriter_DurableBatchFailsLoudOnStoreFault(t *testing.T) {
+	t.Parallel()
+
+	injected := errors.New("injected: seq/next durable commit failed")
+	fault := &store.KeyPrefixFault{
+		Prefix:  []byte(seqNextKey),
+		Op:      store.WriteOpBatchCommit,
+		Ordinal: 1,
+		Err:     injected,
+	}
+	st, err := store.Open(t.TempDir(), nil, store.WithFaultInjector(fault))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	const blockSize = 4
+	w, err := Open(Config{
+		SegmentsDir:       filepath.Join(t.TempDir(), "segments"),
+		Store:             st,
+		SeqKey:            seqNextKey,
+		MaxEventsPerBlock: blockSize,
+		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Metrics:           NewMetrics(prometheus.NewRegistry()),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	// The first blockSize-1 appends buffer; the blockSize-th fills the block,
+	// flushes the segment bytes, and commits the seq/next batch — which the
+	// fault aborts. The failure must surface out of Append.
+	var appendErr error
+	for range blockSize {
+		ev := segment.Event{Kind: segment.KindCreate, DID: "did:plc:a"}
+		if appendErr = w.Append(t.Context(), &ev); appendErr != nil {
+			break
+		}
+	}
+	require.Error(t, appendErr, "block flush must fail loud when the seq/next commit fails")
+	require.ErrorIs(t, appendErr, injected)
+
+	// No silent advance: seq/next never became durable.
+	_, _, getErr := st.Get([]byte(seqNextKey))
+	require.ErrorIs(t, getErr, pebble.ErrNotFound,
+		"seq/next must not be durable when its commit failed")
+}

--- a/internal/ingest/syncstate/storefault_test.go
+++ b/internal/ingest/syncstate/storefault_test.go
@@ -1,0 +1,51 @@
+package syncstate
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/bluesky-social/jetstream/internal/store"
+	atmossync "github.com/jcalabro/atmos/sync"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStateStore_FlushFailsLoudOnStoreFault pins the fail-loud contract for
+// the syncstate commit boundary (issue #30 fault point: "syncstate commits").
+// A failed verifier-state commit must surface as an error, not be swallowed —
+// otherwise the in-memory promoted state would be cleared (CommitStaged) while
+// nothing reached disk, silently losing sync state across a restart and
+// letting the verifier run ahead of the durable archive.
+//
+// The fault targets the sync/ prefix batch commit; the assertion is that
+// Flush propagates the injected error AND, because the commit failed, the
+// promoted entry is NOT durable on a fresh reader (no silent advance).
+func TestStateStore_FlushFailsLoudOnStoreFault(t *testing.T) {
+	t.Parallel()
+
+	injected := errors.New("injected: syncstate flush commit failed")
+	fault := &store.KeyPrefixFault{
+		Prefix:  []byte("sync/"),
+		Op:      store.WriteOpBatchCommit,
+		Ordinal: 1,
+		Err:     injected,
+	}
+	raw, err := store.Open(t.TempDir(), nil, store.WithFaultInjector(fault))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = raw.Close() })
+
+	s := New(raw)
+	did := parseDID(t, "did:plc:aaaaaaaaaaaaaaaaaaaaaaaa")
+	want := atmossync.ChainState{Rev: "3l3qo2vutsw2b", Data: fixedCID(t)}
+	require.NoError(t, s.SaveChain(t.Context(), did, want))
+	s.PromoteChain(did, want.Rev)
+
+	// The flush commit fails: Flush must surface it loud.
+	require.ErrorIs(t, s.Flush(), injected)
+
+	// No silent advance: a fresh reader sees nothing durable, because the
+	// failed commit applied nothing.
+	fresh := New(raw)
+	durable, err := fresh.LoadChain(t.Context(), did)
+	require.NoError(t, err)
+	require.Nil(t, durable, "syncstate must not be durable when its commit failed")
+}

--- a/internal/jetstreamd/options.go
+++ b/internal/jetstreamd/options.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/bluesky-social/jetstream/internal/crashpoint"
 	"github.com/bluesky-social/jetstream/internal/ingest/backfill"
+	"github.com/bluesky-social/jetstream/internal/store"
 	"github.com/bluesky-social/jetstream/segment"
 	"github.com/jcalabro/atmos"
 	"github.com/jcalabro/atmos/streaming"
@@ -123,8 +124,15 @@ type Options struct {
 	OnBeforeCompactionPass    func(targetWatermark uint64)
 	AfterRepoComplete         func(context.Context, atmos.DID) error
 	CrashInjector             crashpoint.Injector
-	OnBootstrapLiveEvent      func(*segment.Event)
-	OnSteadyStateEvent        func(*segment.Event)
+	// StoreFaultInjector is a test-only deterministic metadata-store write
+	// fault seam (store.FaultInjector). nil in production, where it is never
+	// installed on the store, so the fault path is unreachable. Used by the
+	// oracle store-fault tier to fail selected persistence ops by name and
+	// ordinal and assert the system fails loud rather than swallowing the
+	// error. Mirrors CrashInjector's nil-in-prod contract.
+	StoreFaultInjector   store.FaultInjector
+	OnBootstrapLiveEvent func(*segment.Event)
+	OnSteadyStateEvent   func(*segment.Event)
 }
 
 func (o Options) effectiveBackfillWorkers() int {

--- a/internal/jetstreamd/runtime.go
+++ b/internal/jetstreamd/runtime.go
@@ -177,7 +177,7 @@ func Build(ctx context.Context, opts Options) (*Runtime, error) {
 		return fail(fmt.Errorf("serve: create segments dir %s: %w", segmentsDir, err))
 	}
 
-	metaStore, err := store.Open(opts.DataDir, storeMetrics)
+	metaStore, err := store.Open(opts.DataDir, storeMetrics, store.WithFaultInjector(opts.StoreFaultInjector))
 	if err != nil {
 		return fail(err)
 	}

--- a/internal/oracle/restart_harness_test.go
+++ b/internal/oracle/restart_harness_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/bluesky-social/jetstream/internal/simulator/fanout"
 	simhttp "github.com/bluesky-social/jetstream/internal/simulator/http"
 	"github.com/bluesky-social/jetstream/internal/simulator/world"
+	"github.com/bluesky-social/jetstream/internal/store"
 	"github.com/bluesky-social/jetstream/internal/xrpcapi"
 	"github.com/stretchr/testify/require"
 )
@@ -38,7 +39,27 @@ const (
 	// to kill on (default 1). Lets a predicate kill "between" named crashpoints
 	// by occurrence count, e.g. the 3rd AfterRepoComplete.
 	envRestartCrashOrdinal = "JETSTREAM_ORACLE_RESTART_CRASH_ORDINAL"
+
+	// Store-fault tier (#30): the child installs a deterministic metadata-store
+	// write fault that fails the Ordinal-th batch_commit touching a key under
+	// Prefix. This models a Pebble persistence failure (e.g. the merge
+	// source-cursor commit) that the orchestrator must surface rather than
+	// swallow. When the prefix is set the child runs to natural completion (no
+	// SIGKILL): a correct runtime fails the merge LOUD, which the child
+	// recognizes via the injected sentinel and records in the observed-marker
+	// file; a runtime that swallows the error instead completes the merge and
+	// reaches the after-merge barrier, leaving the observed-marker absent.
+	envRestartStoreFaultPrefix   = "JETSTREAM_ORACLE_RESTART_STORE_FAULT_PREFIX"
+	envRestartStoreFaultOrdinal  = "JETSTREAM_ORACLE_RESTART_STORE_FAULT_ORDINAL"
+	envRestartStoreFaultObserved = "JETSTREAM_ORACLE_RESTART_STORE_FAULT_OBSERVED"
 )
+
+// errStoreFaultInjected is the sentinel the store-fault tier injects into the
+// metadata store. The child matches it with errors.Is to distinguish the
+// expected fail-loud merge error (which propagates wrapped up through
+// commitSourceComplete -> mergeRunner.run -> Orchestrator.Run) from any other
+// runtime error, so the kill signal is unambiguous.
+var errStoreFaultInjected = errors.New("oracle: injected store fault (merge cursor commit)")
 
 // nolint:paralleltest
 func TestOracle_RestartCrashPointsDoNotLoseRecords(t *testing.T) {
@@ -278,6 +299,7 @@ func TestOracleRestartChild(t *testing.T) {
 	defer cancel()
 
 	crashInjector := newOracleCrashInjectorFromEnv(t, markerPath)
+	storeFault := newOracleStoreFaultFromEnv(t)
 	var afterMerge jetstreamd.PhaseBarrier
 	if mergeDonePath := os.Getenv(envRestartMergeDone); mergeDonePath != "" {
 		afterMerge = func(context.Context) error {
@@ -316,6 +338,7 @@ func TestOracleRestartChild(t *testing.T) {
 		CompactionInterval:        time.Hour,
 		BarrierAfterMerge:         afterMerge,
 		CrashInjector:             crashInjector,
+		StoreFaultInjector:        storeFault,
 	})
 	require.NoError(t, err)
 
@@ -323,9 +346,55 @@ func TestOracleRestartChild(t *testing.T) {
 	closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	require.NoError(t, rt.Close(closeCtx))
+
+	// Store-fault tier: when a fault is armed, the contract is that the runtime
+	// surfaces it LOUD. The merge error propagates wrapped up through
+	// Orchestrator.Run, so errors.Is finds the sentinel. The child does NOT
+	// assert here — it RECORDS the outcome and lets the parent judge: it writes
+	// the observed-marker IFF it saw the sentinel. Under the m006 mutant the
+	// error is swallowed, the merge completes, the after-merge barrier cancels
+	// the run, and rt.Run returns context.Canceled (not the sentinel) — so the
+	// marker is never written and the parent's require.FileExists fails. Either
+	// way the child exits 0, so the kill signal is the marker's absence, not a
+	// child crash or a timeout.
+	if observedPath := os.Getenv(envRestartStoreFaultObserved); observedPath != "" {
+		if errors.Is(runErr, errStoreFaultInjected) {
+			require.NoError(t, os.WriteFile(observedPath, []byte(runErr.Error()), 0o644))
+		} else {
+			t.Logf("store fault armed but runtime did not surface the sentinel (got %v); "+
+				"observed-marker withheld — parent will treat this as a swallowed-error kill", runErr)
+		}
+		return
+	}
+
 	require.True(t,
 		runErr == nil || errors.Is(runErr, context.Canceled) || errors.Is(runErr, context.DeadlineExceeded),
 		"runtime error: %v", runErr)
+}
+
+// newOracleStoreFaultFromEnv builds the store-fault injector for the child
+// from env, or returns nil when no fault is armed (the common case for the
+// crash/predicate tiers). The fault fails the Ordinal-th batch_commit that
+// touches a key under the configured prefix — the merge source-cursor commit
+// rides merge/next_source_idx, the boundary m006 swallows.
+func newOracleStoreFaultFromEnv(t *testing.T) store.FaultInjector {
+	t.Helper()
+
+	prefix := os.Getenv(envRestartStoreFaultPrefix)
+	if prefix == "" {
+		return nil
+	}
+	ordinal := 1
+	if raw := os.Getenv(envRestartStoreFaultOrdinal); raw != "" {
+		require.NoError(t, parseIntEnv(os.LookupEnv, envRestartStoreFaultOrdinal, &ordinal))
+		require.Greaterf(t, ordinal, 0, "%s must be >= 1", envRestartStoreFaultOrdinal)
+	}
+	return &store.KeyPrefixFault{
+		Prefix:  []byte(prefix),
+		Op:      store.WriteOpBatchCommit,
+		Ordinal: ordinal,
+		Err:     errStoreFaultInjected,
+	}
 }
 
 func newOracleCrashInjectorFromEnv(t *testing.T, markerPath string) crashpoint.Injector {
@@ -443,9 +512,16 @@ type restartChildArgs struct {
 	crashPoint      crashpoint.Point
 	crashOrdinal    int // 1-based kill ordinal; 0 == default (1st hit)
 	killAfterMarker bool
-	timeout         time.Duration
-	trace           *Trace
-	runLabel        string
+	// Store-fault tier (#30): when storeFaultPrefix is set the child arms a
+	// metadata-store write fault on the Ordinal-th batch_commit touching the
+	// prefix, and writes storeFaultObservedPath if (and only if) the runtime
+	// failed loud with the injected sentinel.
+	storeFaultPrefix       string
+	storeFaultOrdinal      int
+	storeFaultObservedPath string
+	timeout                time.Duration
+	trace                  *Trace
+	runLabel               string
 }
 
 type restartChildResult struct {
@@ -484,6 +560,15 @@ func runRestartChild(t *testing.T, args restartChildArgs) restartChildResult {
 	)
 	if ordinal > 0 {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%d", envRestartCrashOrdinal, ordinal))
+	}
+	if args.storeFaultPrefix != "" {
+		cmd.Env = append(cmd.Env,
+			envRestartStoreFaultPrefix+"="+args.storeFaultPrefix,
+			envRestartStoreFaultObserved+"="+args.storeFaultObservedPath,
+		)
+		if args.storeFaultOrdinal > 0 {
+			cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%d", envRestartStoreFaultOrdinal, args.storeFaultOrdinal))
+		}
 	}
 	require.NoError(t, cmd.Start())
 	recordTraceOrError(t, args.trace, "restart_child_process", map[string]any{

--- a/internal/oracle/restart_storefault_test.go
+++ b/internal/oracle/restart_storefault_test.go
@@ -1,0 +1,143 @@
+package oracle
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// mergeNextSourceIdxStoreKey mirrors the orchestrator's unexported
+// mergeNextSourceIdxKey ("merge/next_source_idx", merge_cursor.go). It is the
+// pebble key the source-cursor batch commit rides — the boundary m006
+// swallows. Duplicated here (not imported) because it is package-private to
+// orchestrator; if that key ever changes, this test's fault stops matching and
+// the kill goes vacuous, so the two must stay in sync. A guard test in the
+// orchestrator package (TestMergeNextSourceIdxKeyMatchesOracleStoreFault)
+// pins them together.
+const mergeNextSourceIdxStoreKey = "merge/next_source_idx"
+
+// TestOracle_RestartStoreFaultOnMergeCursor_FailsLoudThenRecovers is the
+// oracle-level store-fault tier for issue #30, and the gate-recognized kill
+// for mutation m006 (merge_commit_error_swallowed).
+//
+// The first child runs a real jetstreamd through backfill into the merge with
+// a deterministic metadata-store fault armed on the merge/next_source_idx
+// batch commit — the exact persistence op the m006 mutant swallows. The
+// contract under test (issue #30): the runtime must FAIL LOUD when that commit
+// fails, never silently advance past unarchived data. The child asserts the
+// runtime surfaced the injected sentinel (errors.Is up through
+// commitSourceComplete -> mergeRunner.run -> Orchestrator.Run) and writes the
+// observed-marker; the parent requires that marker.
+//
+//   - Correct code: commit error propagates, runMerge fails, rt.Run returns the
+//     sentinel, observed-marker written. PASS.
+//   - m006 mutant: inverted check swallows the error, merge completes, the
+//     after-merge barrier fires, rt.Run returns context.Canceled — the sentinel
+//     is NEVER observed, so the observed-marker is absent. The parent's
+//     require.FileExists fails. KILL.
+//
+// A second, fault-free child then re-runs the merge idempotently to a clean
+// after-merge exit, and the full chain-durability bundle asserts the data the
+// faulted merge could not commit is not lost — it converges on recovery. This
+// is the "transient persistence failure must be survivable, not silently
+// dropped" half of the contract.
+//
+// nolint:paralleltest
+func TestOracle_RestartStoreFaultOnMergeCursor_FailsLoudThenRecovers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping restart oracle under -short")
+	}
+
+	cfg := Config{
+		Mode:                "restart",
+		Seed:                restartSeed(0),
+		Accounts:            4,
+		MinInitialRecords:   1,
+		MaxInitialRecords:   4,
+		LiveEventsBootstrap: 4,
+		LiveEventsSteady:    4,
+	}
+	trace, _, closeTrace := newOracleTrace(t, "restart-storefault-merge-cursor.jsonl")
+	t.Cleanup(closeTrace)
+
+	spec := deriveChainSpec(cfg.Seed, cfg.Accounts)
+	recordTraceOrError(t, trace, "run_start", map[string]any{
+		"mode":          cfg.Mode,
+		"seed":          cfg.Seed,
+		"go_version":    runtime.Version(),
+		"gomaxprocs":    runtime.GOMAXPROCS(0),
+		"accounts":      cfg.Accounts,
+		"case":          "storefault-merge-cursor",
+		"store_fault":   mergeNextSourceIdxStoreKey,
+		"chain_did_idx": spec.chainAccountIdx(),
+		"chain_records": len(spec.records),
+	})
+
+	w := newRestartWorld(t, cfg)
+	t.Cleanup(func() { require.NoError(t, w.Close()) })
+
+	coord := newChainCoordinator(t, w, spec)
+	srv := newRestartServer(t, w, coord.onGetRepoServed)
+	t.Cleanup(srv.Close)
+
+	dataDir := t.TempDir()
+	markersDir := t.TempDir()
+	observedPath := filepath.Join(markersDir, "store-fault-observed")
+	firstMergeDonePath := filepath.Join(markersDir, "first-after-merge")
+	mergeDonePath := filepath.Join(markersDir, "after-merge")
+
+	// First child: backfill serves the chain, the merge drains it, and the
+	// FIRST source-cursor batch commit fails. Correct code surfaces it loud
+	// (sentinel observed via errors.Is); the m006 mutant swallows it and
+	// reaches the after-merge barrier instead, leaving the observed-marker
+	// absent. The after-merge barrier is armed so the mutant path cancels and
+	// the child exits promptly (a clean fast kill) rather than running on in
+	// steady state until the timeout; correct code never reaches that barrier.
+	first := runRestartChild(t, restartChildArgs{
+		dataDir:                dataDir,
+		relayURL:               srv.URL,
+		mergeDonePath:          firstMergeDonePath,
+		storeFaultPrefix:       mergeNextSourceIdxStoreKey,
+		storeFaultOrdinal:      1,
+		storeFaultObservedPath: observedPath,
+		timeout:                30 * time.Second,
+		trace:                  trace,
+		runLabel:               "first-storefault",
+	})
+	recordTraceOrError(t, trace, "restart_child_result", traceRestartChildResult("first", first))
+	require.NoErrorf(t, first.err, "first store-fault child should exit cleanly (fail-loud is in-process, not a crash)\n%s", first.output)
+	require.FileExistsf(t, observedPath,
+		"runtime must FAIL LOUD on the merge-cursor commit failure (m006 swallows it and reaches after-merge instead)\n%s",
+		first.output)
+	// Anti-vacuity: under correct code the merge must NOT have completed (the
+	// fault aborts it), so the first child's after-merge barrier never fired.
+	// If this marker exists, the merge completed despite the armed fault — the
+	// fault did not bite, and the kill would be vacuous.
+	require.NoFileExistsf(t, firstMergeDonePath,
+		"merge completed despite the armed cursor-commit fault — fault did not bite, kill is vacuous\n%s",
+		first.output)
+
+	// Second child: no fault armed. The merge re-runs idempotently from the
+	// un-advanced cursor (the failed commit never persisted), drains the same
+	// sources, and exits cleanly at the after-merge barrier.
+	second := runRestartChild(t, restartChildArgs{
+		dataDir:       dataDir,
+		relayURL:      srv.URL,
+		mergeDonePath: mergeDonePath,
+		timeout:       30 * time.Second,
+		trace:         trace,
+		runLabel:      "second-storefault",
+	})
+	recordTraceOrError(t, trace, "restart_child_result", traceRestartChildResult("second", second))
+	require.NoErrorf(t, second.err, "recovery child should exit cleanly\n%s", second.output)
+	require.FileExistsf(t, mergeDonePath, "recovery child must reach after-merge barrier before exiting")
+
+	// Convergence: the data the faulted merge could not commit is NOT lost.
+	// Final state matches the simulator (replay-aware: re-running the merge can
+	// re-emit survivors at fresh seqs), and the durable chain survived intact.
+	assertOracleMatchesAfterReplay(t, dataDir, w, cfg, "storefault-merge-cursor")
+	assertChainDurable(t, dataDir, coord, "storefault-merge-cursor")
+}

--- a/internal/store/fault.go
+++ b/internal/store/fault.go
@@ -1,0 +1,146 @@
+package store
+
+import (
+	"bytes"
+	"sync/atomic"
+
+	"github.com/cockroachdb/pebble"
+)
+
+// WriteOp names the metadata-store write being attempted. The values
+// mirror the metric op labels (set / delete / batch_commit) so a fault
+// target reads the same in a test as it does on the histogram.
+type WriteOp string
+
+const (
+	WriteOpSet         WriteOp = "set"
+	WriteOpDelete      WriteOp = "delete"
+	WriteOpBatchCommit WriteOp = "batch_commit"
+)
+
+// FaultInjector is the test-only seam that lets a scenario fail selected
+// metadata-store writes deterministically, modeling a Pebble persistence
+// failure that production code must surface rather than swallow.
+//
+// Production never installs one: Open takes zero options, so the field is
+// nil and BeforeWrite is never consulted (mirrors the nil *Metrics and the
+// nil crashpoint.Injector idioms — the fault path adds no production cost
+// and cannot be armed by accident).
+//
+// BeforeWrite is consulted BEFORE the underlying Pebble write. A non-nil
+// return aborts the write entirely (the bytes never reach Pebble) and the
+// store returns that error to the caller. This is the faithful model of a
+// failed persistence op: a failed batch commit leaves the keyspace
+// untouched, so a correct caller must not advance any cursor past it.
+//
+// keys is every key the op will touch: one for Set/Delete, all staged keys
+// for a batch Commit (decoded from the batch's own repr). Implementations
+// must be safe for concurrent use; *Store is.
+type FaultInjector interface {
+	BeforeWrite(op WriteOp, keys [][]byte) error
+}
+
+// Option configures a Store at Open time. Kept as a functional option so
+// production (store.Open(dir, metrics)) stays a clean two-argument call and
+// no post-construction setter can race a concurrent writer.
+type Option func(*Store)
+
+// WithFaultInjector installs a test-only write-fault seam. Passing nil is a
+// no-op, so a test can thread an optional injector unconditionally.
+func WithFaultInjector(f FaultInjector) Option {
+	return func(s *Store) {
+		if f != nil {
+			s.faults = f
+		}
+	}
+}
+
+// faultBeforeWrite consults the injector (if any) for a single-key op. It
+// returns the injected error when the write should fail, in which case the
+// caller must skip the underlying Pebble write.
+func (s *Store) faultBeforeWrite(op WriteOp, key []byte) error {
+	if s.faults == nil {
+		return nil
+	}
+	return s.faults.BeforeWrite(op, [][]byte{key})
+}
+
+// faultBeforeCommit consults the injector for a batch commit, passing every
+// key staged in the batch so a fault can target by key name. Reading the
+// batch repr is cheap (a header walk) and only happens when an injector is
+// installed, so production pays nothing.
+func (s *Store) faultBeforeCommit(b *pebble.Batch) error {
+	if s.faults == nil {
+		return nil
+	}
+	keys, err := batchKeys(b)
+	if err != nil {
+		return err
+	}
+	return s.faults.BeforeWrite(WriteOpBatchCommit, keys)
+}
+
+// batchKeys decodes the set of user keys staged in a pebble batch via its
+// public BatchReader. Used only on the fault path; values are ignored.
+func batchKeys(b *pebble.Batch) ([][]byte, error) {
+	r := b.Reader()
+	var keys [][]byte
+	for {
+		_, ukey, _, ok, err := r.Next()
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return keys, nil
+		}
+		// ukey aliases the batch's internal buffer; copy so a retained
+		// matcher can't observe later mutation.
+		k := make([]byte, len(ukey))
+		copy(k, ukey)
+		keys = append(keys, k)
+	}
+}
+
+// KeyPrefixFault is the canonical FaultInjector: it fails the Ordinal-th
+// (1-based) write op that touches a key under Prefix, with Err. Earlier and
+// later matching ops succeed, so a scenario fails exactly one targeted
+// persistence op and observes how the system behaves across the boundary.
+//
+// "By name" is a key-prefix match (e.g. "merge/next_source_idx", "repo/",
+// "seq/") and "by ordinal" is the 1-based occurrence count — both
+// deterministic, so a failing run reproduces exactly. A batch commit counts
+// as one occurrence when any staged key matches the prefix; Op, when set,
+// further restricts matching to that write op.
+type KeyPrefixFault struct {
+	Prefix []byte
+	// Op, when non-empty, restricts the fault to that write op (e.g. only
+	// batch_commit). Empty matches any write op.
+	Op      WriteOp
+	Ordinal int
+	Err     error
+
+	seen atomic.Int64
+}
+
+// BeforeWrite implements FaultInjector. It is safe for concurrent use: the
+// occurrence counter is atomic, so the Ordinal-th matching op fires exactly
+// once even under concurrent writers.
+func (f *KeyPrefixFault) BeforeWrite(op WriteOp, keys [][]byte) error {
+	if f.Op != "" && f.Op != op {
+		return nil
+	}
+	matched := false
+	for _, k := range keys {
+		if bytes.HasPrefix(k, f.Prefix) {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		return nil
+	}
+	if int(f.seen.Add(1)) == f.Ordinal {
+		return f.Err
+	}
+	return nil
+}

--- a/internal/store/fault_test.go
+++ b/internal/store/fault_test.go
@@ -1,0 +1,108 @@
+package store_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/bluesky-social/jetstream/internal/store"
+	"github.com/stretchr/testify/require"
+)
+
+var errInjected = errors.New("injected store fault")
+
+// TestKeyPrefixFault_FailsTargetedOrdinalOnly proves the canonical
+// injector fails exactly the Ordinal-th write under the prefix and that
+// the failed write never reaches pebble: a Set that the injector aborts
+// must leave no row behind.
+func TestKeyPrefixFault_FailsTargetedOrdinalOnly(t *testing.T) {
+	t.Parallel()
+	fault := &store.KeyPrefixFault{Prefix: []byte("merge/"), Ordinal: 2, Err: errInjected}
+	s, err := store.Open(t.TempDir(), nil, store.WithFaultInjector(fault))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+
+	// 1st matching write: succeeds.
+	require.NoError(t, s.Set([]byte("merge/a"), []byte("v1"), store.SyncWrites))
+	// 2nd matching write: the targeted ordinal fails.
+	err = s.Set([]byte("merge/b"), []byte("v2"), store.SyncWrites)
+	require.ErrorIs(t, err, errInjected)
+	// 3rd matching write: succeeds again (fault is one-shot).
+	require.NoError(t, s.Set([]byte("merge/c"), []byte("v3"), store.SyncWrites))
+
+	// The aborted write must not have persisted: continuing past a failed
+	// persistence op is exactly the corruption class this seam exists to
+	// catch, so the seam itself must not silently write.
+	_, _, getErr := s.Get([]byte("merge/b"))
+	require.ErrorIs(t, getErr, store.ErrNotFound)
+
+	// Non-matching keys are never faulted regardless of ordinal.
+	require.NoError(t, s.Set([]byte("repo/x"), []byte("v"), store.SyncWrites))
+}
+
+// TestKeyPrefixFault_BatchCommitMatchesStagedKey proves a batch commit is
+// faulted when any staged key matches the prefix — the path m006 rides
+// (commitSourceComplete stages merge/next_source_idx + repo/<did> rows in
+// one batch). A failed commit must leave the entire batch unapplied.
+func TestKeyPrefixFault_BatchCommitMatchesStagedKey(t *testing.T) {
+	t.Parallel()
+	fault := &store.KeyPrefixFault{
+		Prefix:  []byte("merge/next_source_idx"),
+		Op:      store.WriteOpBatchCommit,
+		Ordinal: 1,
+		Err:     errInjected,
+	}
+	s, err := store.Open(t.TempDir(), nil, store.WithFaultInjector(fault))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+
+	b := s.NewBatch()
+	t.Cleanup(func() { _ = b.Close() })
+	require.NoError(t, b.Set([]byte("merge/next_source_idx"), []byte{0x01}, nil))
+	require.NoError(t, b.Set([]byte("repo/did:plc:a"), []byte("status"), nil))
+
+	require.ErrorIs(t, s.Commit(b, store.SyncWrites), errInjected)
+
+	// Neither staged key applied: a failed commit is atomic.
+	_, _, getErr := s.Get([]byte("merge/next_source_idx"))
+	require.ErrorIs(t, getErr, store.ErrNotFound)
+	_, _, getErr = s.Get([]byte("repo/did:plc:a"))
+	require.ErrorIs(t, getErr, store.ErrNotFound)
+}
+
+// TestKeyPrefixFault_OpFilterIgnoresNonMatchingOp confirms the Op filter:
+// a batch-commit-scoped fault does not fire on a plain Set even when the
+// key matches, so a scenario can target the precise write boundary.
+func TestKeyPrefixFault_OpFilterIgnoresNonMatchingOp(t *testing.T) {
+	t.Parallel()
+	fault := &store.KeyPrefixFault{
+		Prefix:  []byte("merge/"),
+		Op:      store.WriteOpBatchCommit,
+		Ordinal: 1,
+		Err:     errInjected,
+	}
+	s, err := store.Open(t.TempDir(), nil, store.WithFaultInjector(fault))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+
+	// Set matches the prefix but not the op → not faulted.
+	require.NoError(t, s.Set([]byte("merge/x"), []byte("v"), store.SyncWrites))
+
+	// A matching batch commit is faulted (ordinal still 1 — the Set above
+	// did not consume it, proving op-scoped counting).
+	b := s.NewBatch()
+	t.Cleanup(func() { _ = b.Close() })
+	require.NoError(t, b.Set([]byte("merge/y"), []byte("v"), nil))
+	require.ErrorIs(t, s.Commit(b, store.SyncWrites), errInjected)
+}
+
+// TestStore_NoFaultInjectorIsClean is the production-shape guard: with no
+// option installed, every write succeeds. Protects the nil-gated contract
+// (production never arms the seam).
+func TestStore_NoFaultInjectorIsClean(t *testing.T) {
+	t.Parallel()
+	s, err := store.Open(t.TempDir(), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	require.NoError(t, s.Set([]byte("merge/a"), []byte("v"), store.SyncWrites))
+	require.NoError(t, s.Delete([]byte("merge/a"), store.SyncWrites))
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -56,6 +56,9 @@ const PebbleSubdir = "meta.pebble"
 type Store struct {
 	*pebble.DB
 	metrics *Metrics
+	// faults is a test-only write-fault seam. nil in production (Open
+	// installs nothing); see fault.go.
+	faults FaultInjector
 }
 
 // Open opens (creating if necessary) the metadata pebble database
@@ -68,7 +71,7 @@ type Store struct {
 // observability stay unwired.
 //
 // The returned Store must be Close()d to release file locks.
-func Open(dataDir string, m *Metrics) (*Store, error) {
+func Open(dataDir string, m *Metrics, opts ...Option) (*Store, error) {
 	if dataDir == "" {
 		return nil, fmt.Errorf("store: Open: data dir is required")
 	}
@@ -81,18 +84,22 @@ func Open(dataDir string, m *Metrics) (*Store, error) {
 	// comfortably. A bloom filter on point lookups keeps the hot
 	// per-DID Get path off disk for negative lookups, which the
 	// backfill seed step performs once per relay listRepos entry.
-	opts := &pebble.Options{}
-	opts.EnsureDefaults()
-	for i := range opts.Levels {
-		opts.Levels[i].FilterPolicy = bloom.FilterPolicy(10)
+	pebbleOpts := &pebble.Options{}
+	pebbleOpts.EnsureDefaults()
+	for i := range pebbleOpts.Levels {
+		pebbleOpts.Levels[i].FilterPolicy = bloom.FilterPolicy(10)
 	}
 
-	db, err := pebble.Open(path, opts)
+	db, err := pebble.Open(path, pebbleOpts)
 	if err != nil {
 		return nil, fmt.Errorf("store: open pebble at %s: %w", path, err)
 	}
 
-	return &Store{DB: db, metrics: m}, nil
+	s := &Store{DB: db, metrics: m}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s, nil
 }
 
 // Close releases the metadata db. Idempotent: subsequent calls are
@@ -122,6 +129,9 @@ func (s *Store) Get(key []byte) ([]byte, io.Closer, error) {
 
 // Set is the instrumented version of *pebble.DB.Set.
 func (s *Store) Set(key, value []byte, opts *pebble.WriteOptions) error {
+	if err := s.faultBeforeWrite(WriteOpSet, key); err != nil {
+		return err
+	}
 	start := time.Now()
 	err := s.DB.Set(key, value, opts)
 	s.metrics.ObserveSet(start, err)
@@ -130,6 +140,9 @@ func (s *Store) Set(key, value []byte, opts *pebble.WriteOptions) error {
 
 // Delete is the instrumented version of *pebble.DB.Delete.
 func (s *Store) Delete(key []byte, opts *pebble.WriteOptions) error {
+	if err := s.faultBeforeWrite(WriteOpDelete, key); err != nil {
+		return err
+	}
 	start := time.Now()
 	err := s.DB.Delete(key, opts)
 	s.metrics.ObserveDelete(start, err)
@@ -140,6 +153,9 @@ func (s *Store) Delete(key []byte, opts *pebble.WriteOptions) error {
 // it in place of b.Commit(opts) so the duration histogram captures
 // batch commits alongside single-key writes.
 func (s *Store) Commit(b *pebble.Batch, opts *pebble.WriteOptions) error {
+	if err := s.faultBeforeCommit(b); err != nil {
+		return err
+	}
 	start := time.Now()
 	err := b.Commit(opts)
 	s.metrics.ObserveBatchCommit(start, err)

--- a/testing/mutation/RESULTS.md
+++ b/testing/mutation/RESULTS.md
@@ -850,3 +850,29 @@ reverting each patch before wiring the gate.
 |---|---|---|
 | m006_merge_commit_error_swallowed | KILLED@storefault | store-fault tier: forced `merge/next_source_idx` commit failure must fail loud; multi-source test also catches the clean-commit early-return. Was SURVIVED (no store-fault tier). |
 | m028_compaction_watermark_save_error_swallowed | KILLED@storefault | store-fault tier: forced `compaction/seq` Set failure must fail loud; durable watermark must not advance. |
+
+**Remaining #30 fault points — fail-loud contract tests (no mutants).** The
+issue lists more high-risk write boundaries than the two with mutants. The
+`KeyPrefixFault` seam covers each; rather than mint a swallow-mutant per site,
+the fail-loud / no-silent-advance contract is pinned directly at each boundary
+(these are regression tests, not gated kills — a single store-fault seam bug is
+already caught by m006/m028):
+
+- **seq/next** — `TestWriter_DurableBatchFailsLoudOnStoreFault`
+  (internal/ingest): a forced `seq/next` durable-batch commit failure must
+  surface out of `Append`/flush; `seq/next` must not become durable.
+- **relay cursor** — `TestConsumer_SaveCursorFailsLoudOnStoreFault`
+  (internal/ingest/live): a forced `relay/cursor` commit failure must surface
+  out of `saveCursorAndSyncState`; the cursor must not advance.
+- **syncstate commits** — `TestStateStore_FlushFailsLoudOnStoreFault`
+  (internal/ingest/syncstate): a forced `sync/` commit failure must surface out
+  of `Flush`; promoted verifier state must not be durable.
+
+**manifest refresh after compaction — N/A (no pebble write).** The DoD names
+"manifest refresh/update after compaction" as a fault point, but the manifest
+reconcile (`manifest.OnSegmentCompacted` → `refreshSegment`) updates only the
+in-memory manifest and the on-disk segment headers; it performs NO
+`store.Store` (pebble) write. The store-fault seam therefore cannot target it,
+and faulting it would require a separate manifest/segment IO-fault seam — out
+of scope for this metadata-store tier. Recorded here so the gap is explicit
+rather than silently unaddressed.

--- a/testing/mutation/RESULTS.md
+++ b/testing/mutation/RESULTS.md
@@ -799,3 +799,54 @@ benign/equivalent; m006 #30; m009 #32; m013/m014 dead-path covered by
 m017/m018; m015 footer-index blind spot) — no true escapes. This run seeds
 `baseline.json`; subsequent scheduled runs are diffed against it and a
 KILLED→SURVIVED flip fails the job.
+
+## 2026-06-26 — store-fault tier; m006 killed, m028 added (#30)
+
+Closes the long-standing m006 gap by adding the store-fault injection tier
+the issue called for. Net scorecard change: **m006 SURVIVED→KILLED@storefault**
+and a new **m028 KILLED@storefault**; every other mutant keeps its prior
+disposition (gate: PASS, 26 mutants). `baseline.json` refreshed to bank both.
+
+**The seam.** `store.FaultInjector` is a nil-gated hook on
+`store.Store.Set/Delete/Commit`, installed via the new
+`store.Open(dir, metrics, opts...)` variadic option and threaded through
+`jetstreamd.Options.StoreFaultInjector`. Production never installs one (the
+Options field is nil, mirroring the nil-in-prod `CrashInjector`), so the fault
+path is unreachable off the test harness. `store.KeyPrefixFault` is the
+canonical injector: fail the Ordinal-th write op touching a key prefix,
+optionally scoped to one `WriteOp`; batch commits match against their staged
+keys via the public `BatchReader`.
+
+**The `storefault` campaign tier** runs the kill at two layers in one
+`go test`, so a regression in either fails CI:
+
+- *oracle level* — `TestOracle_RestartStoreFaultOnMergeCursor_FailsLoudThenRecovers`
+  drives a real `jetstreamd` through the merge with a fault on the
+  `merge/next_source_idx` batch commit, asserts the runtime fails LOUD (the
+  injected sentinel surfaces up through `Orchestrator.Run` — never swallowed),
+  then re-runs the merge fault-free and asserts convergence (the data the
+  faulted commit could not persist is not lost). Anti-vacuity: the first
+  child's after-merge barrier must NOT have fired (the fault really aborted the
+  merge).
+- *orchestrator unit level* — `TestMerge_StoreFaultOnCursorCommit_FailsLoudNoSilentAdvance`
+  pins the same contract directly on `runMerge` (fail loud, cursor not
+  advanced, backfill tree preserved); `TestMerge_MultiSourceDrainsAllSources`
+  catches m006's *other* inverted branch (the `err==nil` early-return drops
+  later sources — the pre-existing `TestMerge_MultiSourceContiguousCommit` only
+  checked post-cleanup state and missed this).
+
+**m028 (new, DoD "new swallowed-persistence-error mutants").** Inverts the
+error check on `saveCompactionWatermark` in `runDeleteCompaction` — a distinct
+high-risk fault point named in #30 and a different store op from m006 (a plain
+`Set` on `compaction/seq`, not a batch commit, so it exercises the seam's `Set`
+path). `TestCompaction_StoreFaultOnWatermarkSave_FailsLoudNoAdvance` forces the
+watermark `Set` to fail and asserts the pass fails loud and the durable
+watermark does not advance.
+
+Both kills were verified red-under-mutant / green-on-correct by applying and
+reverting each patch before wiring the gate.
+
+| mutant | result | note |
+|---|---|---|
+| m006_merge_commit_error_swallowed | KILLED@storefault | store-fault tier: forced `merge/next_source_idx` commit failure must fail loud; multi-source test also catches the clean-commit early-return. Was SURVIVED (no store-fault tier). |
+| m028_compaction_watermark_save_error_swallowed | KILLED@storefault | store-fault tier: forced `compaction/seq` Set failure must fail loud; durable watermark must not advance. |

--- a/testing/mutation/baseline.json
+++ b/testing/mutation/baseline.json
@@ -1,15 +1,15 @@
 {
-  "commit": "007abab5b56d2b32e01a04d71667e8077fd6fce1",
+  "commit": "5808d7c87f93969e4553593558ede8a4a16e65ca",
   "mutants": [
-    {"id":"m001_delete_mapped_to_update","disposition":"KILLED","result":"KILLED@default","note":"hang: test timed out, no oracle assertion (likely liveness break — e.g. barrier never releases; inspect log for the blocked goroutine)"},
+    {"id":"m001_delete_mapped_to_update","disposition":"KILLED","result":"KILLED@default","note":"see log"},
     {"id":"m002_watermark_floor_off_by_one","disposition":"SURVIVED","result":"SURVIVED","note":"escape — analyze and disposition"},
     {"id":"m003_merge_cursor_no_advance","disposition":"SURVIVED","result":"SURVIVED","note":"escape — analyze and disposition"},
     {"id":"m004_rev_filter_inverted","disposition":"KILLED","result":"KILLED@default","note":"oracle: missing did:plc:iv2erqbe5k4ltaawmik4tfeo app.bsky.actor.profile/22auixj3zqj3g rev="},
-    {"id":"m005_backfill_status_check_inverted","disposition":"KILLED","result":"KILLED@restart","note":"oracle: rev regression for DID did:plc:xe6kimero4ysp4mpzse6npbs at event 13: seq=19 app.bsky.feed.post/22avhp53lzac4 rev="},
-    {"id":"m006_merge_commit_error_swallowed","disposition":"SURVIVED","result":"SURVIVED","note":"escape — analyze and disposition"},
+    {"id":"m005_backfill_status_check_inverted","disposition":"KILLED","result":"KILLED@restart","note":"oracle: rev regression for DID did:plc:xe6kimero4ysp4mpzse6npbs at event 16: seq=22 app.bsky.feed.post/22avhp53lzac4 rev="},
+    {"id":"m006_merge_commit_error_swallowed","disposition":"KILLED","result":"KILLED@storefault","note":"see log"},
     {"id":"m008_header_offset_byteslice","disposition":"KILLED","result":"KILLED@default","note":"see log"},
     {"id":"m009_checksum_range_off_by_one","disposition":"SURVIVED","result":"SURVIVED","note":"escape — analyze and disposition"},
-    {"id":"m011_wire_frame_length","disposition":"KILLED","result":"KILLED@default","note":"oracle: walk active segment /tmp/TestOracle_DefaultLifecycle1233169754/003/segments/seg_0000000000.jss: segment: walk active frames: segment"},
+    {"id":"m011_wire_frame_length","disposition":"KILLED","result":"KILLED@default","note":"oracle: walk active segment /tmp/TestOracle_DefaultLifecycle2245685970/003/segments/seg_0000000000.jss: segment: walk active frames: segment"},
     {"id":"m012_block_event_count_off_by_one","disposition":"KILLED","result":"KILLED@default","note":"see log"},
     {"id":"m013_collection_rkey_swap","disposition":"SURVIVED","result":"SURVIVED","note":"escape — analyze and disposition"},
     {"id":"m014_rev_dropped","disposition":"SURVIVED","result":"SURVIVED","note":"escape — analyze and disposition"},
@@ -17,14 +17,15 @@
     {"id":"m016_bloom_size_off_by_one","disposition":"KILLED","result":"KILLED@default","note":"see log"},
     {"id":"m017_commit_collection_rkey_swap","disposition":"KILLED","result":"KILLED@default","note":"oracle: event mismatch at index 1: want seq=2 kind=create did=did:plc:osv2tmz2rla3ku63phjjgzdh key=app.bsky.feed.like/22bbxbcjghpur rev=3ke6"},
     {"id":"m018_commit_rev_dropped","disposition":"KILLED","result":"KILLED@default","note":"oracle: event mismatch at index 1: want seq=2 kind=create did=did:plc:osv2tmz2rla3ku63phjjgzdh key=app.bsky.feed.like/22bbxbcjghpur rev=3ke6"},
-    {"id":"m019_sync_tombstone_dropped","disposition":"KILLED","result":"KILLED@default","note":"hang: test timed out, no oracle assertion (likely liveness break — e.g. barrier never releases; inspect log for the blocked goroutine)"},
+    {"id":"m019_sync_tombstone_dropped","disposition":"KILLED","result":"KILLED@default","note":"see log"},
     {"id":"m020_overlay_drop_did_tombstones","disposition":"KILLED","result":"KILLED@default","note":"see log"},
     {"id":"m021_overlay_record_seq_base_zero","disposition":"KILLED","result":"KILLED@default","note":"see log"},
-    {"id":"m022_shoulddrop_did_seq_inverted","disposition":"KILLED","result":"KILLED@default","note":"hang: test timed out, no oracle assertion (likely liveness break — e.g. barrier never releases; inspect log for the blocked goroutine)"},
+    {"id":"m022_shoulddrop_did_seq_inverted","disposition":"KILLED","result":"KILLED@default","note":"oracle: missing did:plc:iv2erqbe5k4ltaawmik4tfeo app.bsky.actor.profile/22auixj3zqj3g rev="},
     {"id":"m023_overlay_drop_record_tombstones","disposition":"KILLED","result":"KILLED@default","note":"see log"},
     {"id":"m024_compaction_over_drop_survivors","disposition":"KILLED","result":"KILLED@default","note":"oracle: missing did:plc:iv2erqbe5k4ltaawmik4tfeo app.bsky.actor.profile/22auixj3zqj3g rev="},
     {"id":"m025_compaction_overdrop_above_watermark","disposition":"KILLED","result":"KILLED@stress","note":"oracle: missing expected event at index 27528: seq=29284 kind=create did=did:plc:iv2erqbe5k4ltaawmik4tfeo key=app.bsky.feed.repost/22bab3wsv"},
     {"id":"m026_commit_rev_altered","disposition":"KILLED","result":"KILLED@default","note":"oracle: event mismatch at index 1: want seq=2 kind=create did=did:plc:osv2tmz2rla3ku63phjjgzdh key=app.bsky.feed.like/22bbxbcjghpur rev=3ke6"},
-    {"id":"m027_getrepo_http_fault_disabled","disposition":"KILLED","result":"KILLED@default","note":"see log"}
+    {"id":"m027_getrepo_http_fault_disabled","disposition":"KILLED","result":"KILLED@default","note":"see log"},
+    {"id":"m028_compaction_watermark_save_error_swallowed","disposition":"KILLED","result":"KILLED@storefault","note":"see log"}
   ]
 }

--- a/testing/mutation/mutants/m006_merge_commit_error_swallowed.patch
+++ b/testing/mutation/mutants/m006_merge_commit_error_swallowed.patch
@@ -5,12 +5,15 @@ failure-mode: |
   failed commit is silently ignored and merge proceeds. Models the classic
   inverted err check that swallows a persistence failure.
 expected-detection: |
-  Hard to surface without injecting a store failure; under normal runs the
-  commit succeeds and the early-return-on-nil changes control flow. This is
-  a candidate ESCAPE that argues for a store-fault oracle tier. Predicted to
-  survive unless restart timing exposes a lost cursor.
-expected-tier: stress
-tiers: default,stress,restart
+  Requires forcing the source-cursor batch commit to fail: the store-fault
+  tier (#30) injects a deterministic fault on the merge/next_source_idx commit
+  and asserts the runtime fails LOUD (sentinel surfaced up through
+  Orchestrator.Run) rather than swallowing the error and advancing past
+  unarchived data. The inverted check also early-returns on a CLEAN commit, so
+  the orchestrator multi-source test (every source's survivors must reach dst)
+  catches it too. Both run in the storefault tier.
+expected-tier: storefault
+tiers: storefault
 
 diff --git a/internal/ingest/orchestrator/merge_runner.go b/internal/ingest/orchestrator/merge_runner.go
 index 6118c4c..82424fd 100644

--- a/testing/mutation/mutants/m028_compaction_watermark_save_error_swallowed.patch
+++ b/testing/mutation/mutants/m028_compaction_watermark_save_error_swallowed.patch
@@ -1,0 +1,30 @@
+mutant: m028_compaction_watermark_save_error_swallowed
+target: internal/ingest/orchestrator/compact_deletes.go
+failure-mode: |
+  The error check on the compaction watermark save is inverted (== nil), so a
+  failed persistent watermark write is silently swallowed and the pass
+  proceeds: the in-memory gauge and finalWatermark advance and tombstones are
+  evicted while the durable compaction/seq stays stale. A swallowed-
+  persistence-error in the same family as m006, on the compaction-watermark
+  fault point named in issue #30.
+expected-detection: |
+  Killed by the store-fault tier: TestCompaction_StoreFaultOnWatermarkSave_*
+  forces the watermark Set to fail and asserts the pass fails LOUD and the
+  durable watermark does not advance. Without a forced store fault the Set
+  always succeeds, so the inverted check is dormant (would otherwise survive).
+expected-tier: storefault
+tiers: storefault
+
+diff --git a/internal/ingest/orchestrator/compact_deletes.go b/internal/ingest/orchestrator/compact_deletes.go
+index 9ef6801..26330f1 100644
+--- a/internal/ingest/orchestrator/compact_deletes.go
++++ b/internal/ingest/orchestrator/compact_deletes.go
+@@ -179,7 +179,7 @@ func (o *Orchestrator) runDeleteCompaction(ctx context.Context, mode compactionM
+ 				return err
+ 			}
+ 
+-			if err := saveCompactionWatermark(o.cfg.Store, chunkEnd); err != nil {
++			if err := saveCompactionWatermark(o.cfg.Store, chunkEnd); err == nil {
+ 				return err
+ 			}
+ 			o.cfg.Metrics.setCompactionWatermark(chunkEnd)

--- a/testing/mutation/run.sh
+++ b/testing/mutation/run.sh
@@ -242,13 +242,15 @@ for patch in "$MUTANTS_DIR"/*.patch; do
                     #     real runtime through the merge with a metadata-store
                     #     fault on the source-cursor commit and asserts fail-loud
                     #     + recovery convergence;
-                    #   - orchestrator unit level: TestMerge_StoreFault* and
-                    #     TestMerge_MultiSourceDrainsAllSources pin the same
-                    #     contract fast and directly on runMerge.
+                    #   - orchestrator unit level: TestMerge_StoreFault*,
+                    #     TestMerge_MultiSourceDrainsAllSources, and
+                    #     TestCompaction_StoreFault* pin the same fail-loud /
+                    #     no-silent-advance contract fast and directly on
+                    #     runMerge / runDeleteCompaction.
                     # Both packages run so a regression in either layer is a kill.
                     cmd=(go test "${RACE_FLAG[@]}"
                          ./internal/oracle ./internal/ingest/orchestrator
-                         -run 'TestOracle_RestartStoreFault|TestMerge_StoreFault|TestMerge_MultiSourceDrainsAllSources'
+                         -run 'TestOracle_RestartStoreFault|TestMerge_StoreFault|TestMerge_MultiSourceDrainsAllSources|TestCompaction_StoreFault'
                          -count=1 -timeout "$storefault_timeout") ;;
                 *)
                     echo "error: unknown tier '$tier' in $id" >&2

--- a/testing/mutation/run.sh
+++ b/testing/mutation/run.sh
@@ -55,12 +55,16 @@ RACE_FLAG=()
 default_timeout="5m"
 stress_timeout="30m"
 restart_timeout="10m"
+# The storefault tier runs the same subprocess-restart machinery as the restart
+# tier (two child runtimes), so it shares the restart timeout budget.
+storefault_timeout="10m"
 if [[ "$RACE" -eq 1 ]]; then
     RACE_FLAG=(-race)
     default_timeout="15m"
     stress_timeout="90m"
     restart_timeout="30m"
-    echo "mutation campaign: race detector ENABLED (timeouts default=$default_timeout stress=$stress_timeout restart=$restart_timeout)"
+    storefault_timeout="30m"
+    echo "mutation campaign: race detector ENABLED (timeouts default=$default_timeout stress=$stress_timeout restart=$restart_timeout storefault=$storefault_timeout)"
 fi
 
 if ! git diff --quiet || ! git diff --cached --quiet; then
@@ -231,6 +235,21 @@ for patch in "$MUTANTS_DIR"/*.patch; do
                 restart)
                     cmd=(go test "${RACE_FLAG[@]}" ./internal/oracle -run 'TestOracle_RestartCrashPointsDoNotLoseRecords$'
                          -count=1 -timeout "$restart_timeout") ;;
+                storefault)
+                    # Store-fault tier (#30): kills swallowed-persistence-error
+                    # mutants (m006 and kin) at two layers in one `go test`:
+                    #   - oracle level: TestOracle_RestartStoreFault* drives a
+                    #     real runtime through the merge with a metadata-store
+                    #     fault on the source-cursor commit and asserts fail-loud
+                    #     + recovery convergence;
+                    #   - orchestrator unit level: TestMerge_StoreFault* and
+                    #     TestMerge_MultiSourceDrainsAllSources pin the same
+                    #     contract fast and directly on runMerge.
+                    # Both packages run so a regression in either layer is a kill.
+                    cmd=(go test "${RACE_FLAG[@]}"
+                         ./internal/oracle ./internal/ingest/orchestrator
+                         -run 'TestOracle_RestartStoreFault|TestMerge_StoreFault|TestMerge_MultiSourceDrainsAllSources'
+                         -count=1 -timeout "$storefault_timeout") ;;
                 *)
                     echo "error: unknown tier '$tier' in $id" >&2
                     exit 1 ;;


### PR DESCRIPTION
## What

Adds the store-fault injection tier issue #30 calls for, and uses it to kill mutation **m006** (`merge_commit_error_swallowed`) — a swallowed-persistence-error on the merge source-cursor commit that had survived because no tier could force a Pebble write to fail.

Closes #30.

## The seam

`store.FaultInjector` is a nil-gated hook on `store.Store.Set/Delete/Commit`, installed via the new `store.Open(dir, metrics, opts...)` variadic option and threaded through `jetstreamd.Options.StoreFaultInjector`. **Production never installs one** (the Options field is nil, mirroring the existing nil-in-prod `CrashInjector`), so the fault path is unreachable off the test harness — production store APIs stay clean per the issue's Notes.

`store.KeyPrefixFault{Prefix, Op, Ordinal, Err}` is the canonical injector: fail the Ordinal-th write op touching a key prefix ("by name"), optionally scoped to one `WriteOp`. Batch commits are matched against their staged keys via pebble's public `BatchReader`.

## Kills (verified red-under-mutant / green-on-correct)

A new **`storefault`** campaign tier runs the kill at two layers in one `go test`, so a regression in either fails CI:

- **Oracle level** — `TestOracle_RestartStoreFaultOnMergeCursor_FailsLoudThenRecovers` drives a real `jetstreamd` through the merge with a fault on the `merge/next_source_idx` batch commit, asserts the runtime **fails loud** (the injected sentinel surfaces up through `Orchestrator.Run`, never swallowed), then re-runs the merge fault-free and asserts **convergence** (the data the faulted commit couldn't persist is not lost).
- **Orchestrator level** — `TestMerge_StoreFaultOnCursorCommit_FailsLoudNoSilentAdvance` pins the same contract directly on `runMerge`; `TestMerge_MultiSourceDrainsAllSources` catches m006's *other* inverted branch (the `err==nil` early-return drops later sources — the pre-existing test only checked post-cleanup state and missed this).

**New mutant m028** (`compaction_watermark_save_error_swallowed`, DoD "new swallowed-persistence-error mutants"): inverts the error check on `saveCompactionWatermark` — a distinct fault point and a different store op (plain `Set` on `compaction/seq`, not a batch commit). Killed by `TestCompaction_StoreFaultOnWatermarkSave_FailsLoudNoAdvance`.

Mutation gate: **m006 SURVIVED→KILLED@storefault**, **m028 NEW KILLED@storefault**, no regressions. `baseline.json` refreshed → gate **PASS, 26 mutants**.

## Remaining DoD fault points

Fail-loud / no-silent-advance contract tests at the other named boundaries (regression tests, not gated kills — a seam regression is already caught by the gated m006/m028):

- **seq/next** — `TestWriter_DurableBatchFailsLoudOnStoreFault`
- **relay cursor** — `TestConsumer_SaveCursorFailsLoudOnStoreFault`
- **syncstate commits** — `TestStateStore_FlushFailsLoudOnStoreFault`

**manifest refresh after compaction = N/A:** the reconcile path (`manifest.OnSegmentCompacted`) writes no Pebble keys (in-memory manifest + segment headers only), so the metadata-store seam cannot target it. Documented in RESULTS.md rather than left silently unaddressed.

## Testing

- All kills proven by applying+reverting each mutant patch.
- Full mutation gate PASS (26 mutants).
- All touched suites pass under `-race`; repo-wide `build` + `vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)