### PR TITLE
oracle: fix restart-chain durable-intermediate cutover delivery race (#166)

### DIFF
--- a/internal/oracle/cutover_gate_test.go
+++ b/internal/oracle/cutover_gate_test.go
@@ -1,0 +1,148 @@
+package oracle
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/bluesky-social/jetstream/segment"
+	"github.com/stretchr/testify/require"
+)
+
+// tipServer is a minimal stand-in for the simulator's /_oracle/firehose-tip
+// endpoint, serving a settable seq so the gate's fetchTip path is exercised
+// for real (not stubbed).
+func tipServer(t *testing.T, tip *atomic.Int64) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		rw.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(rw).Encode(struct {
+			Seq int64 `json:"seq"`
+		}{Seq: tip.Load()})
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func liveEvent(seq int64) *segment.Event {
+	return &segment.Event{Kind: segment.KindCreate, UpstreamRelayCursor: seq}
+}
+
+// TestCutoverGateBlocksUntilTipDelivered is the core regression guard for
+// #114: the gate must NOT release the cutover barrier until every frame up
+// to the relay tip has been durably archived. This is exactly the property
+// whose absence let an undrained chain tail vanish at cutover. We drive the
+// archive observations on a goroutine and assert the gate stays blocked
+// until the last seq lands.
+func TestCutoverGateBlocksUntilTipDelivered(t *testing.T) {
+	t.Parallel()
+
+	var tip atomic.Int64
+	tip.Store(5)
+	gate := newCutoverDeliveryGate(tipServer(t, &tip), 5*time.Second)
+
+	// Observe 1..4 but withhold 5: the gate must stay blocked on the gap.
+	for s := int64(1); s <= 4; s++ {
+		gate.observe(liveEvent(s))
+	}
+
+	released := make(chan error, 1)
+	go func() { released <- gate.waitDelivered(context.Background()) }()
+
+	select {
+	case err := <-released:
+		t.Fatalf("gate released before tip seq 5 was delivered (err=%v)", err)
+	case <-time.After(100 * time.Millisecond):
+		// Correct: still blocked on the missing seq 5.
+	}
+
+	// Deliver the final frame; the gate must now release cleanly.
+	gate.observe(liveEvent(5))
+	select {
+	case err := <-released:
+		require.NoError(t, err, "gate must release once the tip is contiguously delivered")
+	case <-time.After(2 * time.Second):
+		t.Fatal("gate did not release after the tip frame was delivered")
+	}
+}
+
+// TestCutoverGateFloorsAtLowestObserved proves the recovering-child case: a
+// child that resumes bootstrap at a persisted cursor C only re-observes
+// C+1..tip (frames 1..C are already durable from the prior child). The gate
+// must floor contiguity at the lowest observed seq, not at 1, or it would
+// hang forever waiting for frames that will never be redelivered.
+func TestCutoverGateFloorsAtLowestObserved(t *testing.T) {
+	t.Parallel()
+
+	var tip atomic.Int64
+	tip.Store(10)
+	gate := newCutoverDeliveryGate(tipServer(t, &tip), 2*time.Second)
+
+	// Resume at cursor 6: observe only 7..10 (1..6 durable from before).
+	for s := int64(7); s <= 10; s++ {
+		gate.observe(liveEvent(s))
+	}
+
+	require.NoError(t, gate.waitDelivered(context.Background()),
+		"gate must release when the resumed window 7..tip is contiguous (floor at lowest observed)")
+}
+
+// TestCutoverGateNoLiveOps covers the nil-coordinator / no-traffic case: a
+// run that generated no live ops has tip=0, so the gate is a no-op and must
+// not block (there is nothing to deliver).
+func TestCutoverGateNoLiveOps(t *testing.T) {
+	t.Parallel()
+
+	var tip atomic.Int64 // stays 0
+	gate := newCutoverDeliveryGate(tipServer(t, &tip), time.Second)
+
+	require.NoError(t, gate.waitDelivered(context.Background()),
+		"gate must release immediately when no live ops were generated (tip=0)")
+}
+
+// TestCutoverGateTimesOutLoud proves the gate fails LOUD rather than
+// silently proceeding when the chain never lands: if the tip is never
+// contiguously delivered, waitDelivered must return an error (which the
+// child surfaces) rather than releasing the barrier on an undrained tail.
+func TestCutoverGateTimesOutLoud(t *testing.T) {
+	t.Parallel()
+
+	var tip atomic.Int64
+	tip.Store(3)
+	gate := newCutoverDeliveryGate(tipServer(t, &tip), 50*time.Millisecond)
+
+	// Deliver a gappy set (missing seq 2) so contiguity to tip=3 is never met.
+	gate.observe(liveEvent(1))
+	gate.observe(liveEvent(3))
+
+	err := gate.waitDelivered(context.Background())
+	require.Error(t, err, "gate must fail loud when the tip is never contiguously delivered")
+	require.Contains(t, err.Error(), "timeout")
+}
+
+// TestCutoverGateRespectsContextCancel ensures a cancelled run unblocks the
+// gate promptly with the context error (clean shutdown), not a timeout hang.
+func TestCutoverGateRespectsContextCancel(t *testing.T) {
+	t.Parallel()
+
+	var tip atomic.Int64
+	tip.Store(2)
+	gate := newCutoverDeliveryGate(tipServer(t, &tip), time.Minute)
+	gate.observe(liveEvent(1)) // seq 2 never arrives
+
+	ctx, cancel := context.WithCancel(context.Background())
+	released := make(chan error, 1)
+	go func() { released <- gate.waitDelivered(ctx) }()
+
+	cancel()
+	select {
+	case err := <-released:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(2 * time.Second):
+		t.Fatal("gate did not observe context cancellation")
+	}
+}

--- a/internal/oracle/restart_harness_test.go
+++ b/internal/oracle/restart_harness_test.go
@@ -2,11 +2,13 @@ package oracle
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"math/rand/v2"
 	"net"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"os/exec"
@@ -25,6 +27,7 @@ import (
 	"github.com/bluesky-social/jetstream/internal/simulator/world"
 	"github.com/bluesky-social/jetstream/internal/store"
 	"github.com/bluesky-social/jetstream/internal/xrpcapi"
+	"github.com/bluesky-social/jetstream/segment"
 	"github.com/stretchr/testify/require"
 )
 
@@ -311,6 +314,24 @@ func TestOracleRestartChild(t *testing.T) {
 		}
 	}
 
+	// Cross-process cutover gate (#114 flake fix). The parent injects the
+	// durable-intermediate chain on the live firehose during this child's
+	// backfill (chainCoordinator.onGetRepoServed). Those frames must be
+	// durably archived into live_segments BEFORE cutover cancels the
+	// bootstrap-live consumer — otherwise an undrained tail is lost and a
+	// chain record vanishes from disk while staying in ground truth
+	// ("oracle: missing ..."). Production re-fetches such in-flight events
+	// from the persisted cursor in steady-state, but the restart child
+	// exits at the after-merge barrier and never runs steady-state, so the
+	// in-process BarrierBeforeCutover the main harness uses
+	// (bootstrapTraffic.WaitDelivered) has no cross-process analogue here
+	// today. This gate is that analogue: at cutover it samples the relay's
+	// firehose tip and blocks until the bootstrap-live consumer has
+	// contiguously archived every frame up to it. The plan authorized this
+	// escalation once the no-crash baseline proved flaky (specs/notes/
+	// 2026-06-20-restart-tier-intermediates-plan.md §3.1 Q2(b)).
+	cutoverGate := newCutoverDeliveryGate(relayURL, 30*time.Second)
+
 	rt, err := jetstreamd.Build(ctx, jetstreamd.Options{
 		PublicAddr:                "127.0.0.1:0",
 		DebugAddr:                 "127.0.0.1:0",
@@ -336,9 +357,11 @@ func TestOracleRestartChild(t *testing.T) {
 		SubscribeSlowMinRate:      1,
 		CursorBlockIndexCacheSize: 32,
 		CompactionInterval:        time.Hour,
+		BarrierBeforeCutover:      cutoverGate.waitDelivered,
 		BarrierAfterMerge:         afterMerge,
 		CrashInjector:             crashInjector,
 		StoreFaultInjector:        storeFault,
+		OnBootstrapLiveEvent:      cutoverGate.observe,
 	})
 	require.NoError(t, err)
 
@@ -465,6 +488,167 @@ func (i *oracleCrashInjector) SimulateCrash(ctx context.Context, point crashpoin
 	return ctx.Err()
 }
 
+// cutoverDeliveryGate is the cross-process analogue of the main harness's
+// bootstrapTraffic.WaitDelivered (#114 flake fix). The parent injects the
+// durable-intermediate chain on the live firehose during the child's
+// backfill; those frames must be durably archived into live_segments
+// before cutover cancels the bootstrap-live consumer, or an undrained tail
+// is lost (production re-fetches such in-flight events from the persisted
+// cursor in steady-state, but the restart child exits at the after-merge
+// barrier and never runs steady-state).
+//
+// waitDelivered (wired to BarrierBeforeCutover) samples the relay's
+// firehose tip once at cutover and blocks until the bootstrap-live consumer
+// has contiguously archived every frame up to it. observe (wired to
+// OnBootstrapLiveEvent) records each archived frame's upstream seq.
+//
+// Why contiguity-from-lowest-observed is sound: every world seq.Add stages
+// exactly one firehose frame (shape G's silent mutation bumps no seq, so
+// there are no gaps), and every generated frame yields at least one archived
+// event carrying UpstreamRelayCursor == seq. bootstrap-live runs BatchSize=1
+// and fires OnEvent after each durable Append, so observed seqs arrive in
+// archive order. A fresh child resumes at cursor 0 and observes 1..tip; a
+// child recovering in PhaseBootstrap (e.g. an AfterRepoComplete crash before
+// the merging-phase write) resumes at its persisted cursor C and observes
+// C+1..tip — frames 1..C are already durable from the first child, so
+// flooring contiguity at the lowest observed seq is correct in both cases.
+type cutoverDeliveryGate struct {
+	relayURL string
+	timeout  time.Duration
+
+	mu   sync.Mutex
+	seen map[int64]struct{}
+}
+
+func newCutoverDeliveryGate(relayURL string, timeout time.Duration) *cutoverDeliveryGate {
+	return &cutoverDeliveryGate{
+		relayURL: relayURL,
+		timeout:  timeout,
+		seen:     make(map[int64]struct{}),
+	}
+}
+
+// observe records one durably-archived bootstrap-live frame's upstream seq.
+func (g *cutoverDeliveryGate) observe(ev *segment.Event) {
+	if ev == nil || ev.UpstreamRelayCursor <= 0 {
+		return
+	}
+	g.mu.Lock()
+	g.seen[ev.UpstreamRelayCursor] = struct{}{}
+	g.mu.Unlock()
+}
+
+// waitDelivered samples the relay firehose tip and blocks until every frame
+// up to it has been contiguously archived by the bootstrap-live consumer, or
+// ctx is cancelled, or the timeout elapses. A timeout is a genuine delivery
+// failure (the chain never landed durably before cutover) and fails loud
+// rather than silently dropping the unmet tail.
+func (g *cutoverDeliveryGate) waitDelivered(ctx context.Context) error {
+	tip, err := g.fetchTip(ctx)
+	if err != nil {
+		return fmt.Errorf("cutover gate: fetch firehose tip: %w", err)
+	}
+	if tip <= 0 {
+		// No live ops were generated this run (e.g. the nil-coordinator
+		// after-repo-complete case): nothing to wait for.
+		return nil
+	}
+
+	deadline := time.NewTimer(g.timeout)
+	defer deadline.Stop()
+	tick := time.NewTicker(5 * time.Millisecond)
+	defer tick.Stop()
+
+	for {
+		if g.contiguousToTip(tip) {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline.C:
+			lo, hi := g.contiguousSpan()
+			return fmt.Errorf("cutover gate: timeout after %s waiting for bootstrap-live to archive firehose tip=%d "+
+				"(lowest_observed=%d highest_contiguous=%d observed=%d): the injected chain did not land durably before cutover",
+				g.timeout, tip, lo, hi, g.observedCount())
+		case <-tick.C:
+		}
+	}
+}
+
+func (g *cutoverDeliveryGate) fetchTip(ctx context.Context) (int64, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, g.relayURL+"/_oracle/firehose-tip", nil)
+	if err != nil {
+		return 0, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+	var out struct {
+		Seq int64 `json:"seq"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return 0, err
+	}
+	return out.Seq, nil
+}
+
+// contiguousToTip reports whether every seq from the lowest observed up to
+// tip has been archived. With zero observations it is false (keep waiting):
+// a fresh consumer always replays from seq 1, so an empty set means the
+// consumer simply hasn't delivered yet, not that delivery is complete.
+func (g *cutoverDeliveryGate) contiguousToTip(tip int64) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if len(g.seen) == 0 {
+		return false
+	}
+	lo := g.lowestLocked()
+	for s := lo; s <= tip; s++ {
+		if _, ok := g.seen[s]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func (g *cutoverDeliveryGate) contiguousSpan() (lo, hi int64) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if len(g.seen) == 0 {
+		return 0, 0
+	}
+	lo = g.lowestLocked()
+	hi = lo - 1
+	for {
+		if _, ok := g.seen[hi+1]; !ok {
+			return lo, hi
+		}
+		hi++
+	}
+}
+
+func (g *cutoverDeliveryGate) lowestLocked() int64 {
+	lo := int64(-1)
+	for s := range g.seen {
+		if lo == -1 || s < lo {
+			lo = s
+		}
+	}
+	return lo
+}
+
+func (g *cutoverDeliveryGate) observedCount() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return len(g.seen)
+}
+
 func newRestartWorld(t *testing.T, cfg Config) *world.World {
 	t.Helper()
 
@@ -499,6 +683,10 @@ func newRestartServer(t *testing.T, w *world.World, onGetRepoServed func(did str
 	srv.Listener = ln
 	srv.Config.Handler = simhttp.NewHandlerWithOptions(w, "http://"+ln.Addr().String(), simhttp.HandlerOptions{
 		OnGetRepoServed: onGetRepoServed,
+		// The cutover gate (TestOracleRestartChild's BarrierBeforeCutover)
+		// queries the firehose tip so a child can hold cutover until its
+		// bootstrap-live consumer has durably archived every generated frame.
+		EnableFirehoseTip: true,
 	})
 	srv.Start()
 	return srv

--- a/internal/simulator/http/firehose_tip.go
+++ b/internal/simulator/http/firehose_tip.go
@@ -1,0 +1,34 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/bluesky-social/jetstream/internal/simulator/world"
+)
+
+// oracleFirehoseTipURLPath is the request path of the read-only endpoint
+// that reports the world's current firehose tip seq. It is namespaced off
+// the atproto xrpc surface ("/_oracle/…") so it can never collide with a
+// real lexicon method, and is mounted only when HandlerOptions.
+// EnableFirehoseTip is set (the restart oracle harness; never production).
+const oracleFirehoseTipURLPath = "/_oracle/firehose-tip"
+
+type firehoseTipOutput struct {
+	Seq int64 `json:"seq"`
+}
+
+// newFirehoseTipHandler serves the current firehose tip seq as JSON.
+// CurrentSeq reflects every live op the world has broadcast (it advances
+// on the same atomic the commit/account/sync publishers bump), so a tip
+// sampled after backfill drains spans the full generated chain. The
+// restart oracle's pre-cutover gate queries this so a child can hold the
+// cutover barrier until its bootstrap-live consumer has durably archived
+// every frame up to the tip (see TestOracleRestartChild's
+// BarrierBeforeCutover).
+func newFirehoseTipHandler(w *world.World) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		rw.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(rw).Encode(firehoseTipOutput{Seq: w.CurrentSeq()})
+	})
+}

--- a/internal/simulator/http/handler.go
+++ b/internal/simulator/http/handler.go
@@ -36,6 +36,15 @@ type HandlerOptions struct {
 	// fire on the fault/truncation paths, which do not serve a clean
 	// snapshot.
 	OnGetRepoServed func(did string)
+
+	// EnableFirehoseTip mounts the read-only GET /_oracle/firehose-tip
+	// endpoint, which reports the world's current firehose tip seq. It is
+	// off by default (production never sets it) and exists for the restart
+	// oracle's cutover gate: a child queries the tip so it can hold the
+	// pre-cutover barrier until its bootstrap-live consumer has durably
+	// archived every frame up to it. The path is namespaced off the
+	// atproto xrpc surface so it cannot collide with a real lexicon method.
+	EnableFirehoseTip bool
 }
 
 // NewHandlerWithOptions builds the simulator's HTTP handler, optionally
@@ -48,6 +57,9 @@ func NewHandlerWithOptions(w *world.World, publicURL string, opts HandlerOptions
 	mux.Handle("GET /xrpc/com.atproto.sync.getRepo", newPDSGetRepoHandler(w, opts.Faults, opts.OnGetRepoServed))
 	mux.Handle("GET /xrpc/com.atproto.sync.listRepos", newRelayListReposHandler(w))
 	mux.Handle("GET /xrpc/com.atproto.sync.subscribeRepos", newRelaySubscribeReposHandler(w, opts.Faults))
+	if opts.EnableFirehoseTip {
+		mux.Handle("GET "+oracleFirehoseTipURLPath, newFirehoseTipHandler(w))
+	}
 
 	// PLC's `/<did>` doesn't fit Go ServeMux's path syntax cleanly
 	// because `did:` contains a colon. Pre-route any request whose

--- a/specs/notes/2026-06-20-restart-tier-intermediates-plan.md
+++ b/specs/notes/2026-06-20-restart-tier-intermediates-plan.md
@@ -356,6 +356,35 @@ consumed by bootstrap-live, racing cutover. **Q2 RESOLVED → (a), baseline-gate
   present on a no-crash baseline run (§7 step 0e) before any crash case relies on
   it.
 
+**Q2 ESCALATED → (b), 2026-06-27.** The passive-timing assumption (a) proved
+flaky. Under `JETSTREAM_ORACLE_SEED=11212589348287832646 GOMAXPROCS=2` the
+no-crash baseline `TestOracle_RestartChainDurableIntermediates_Baseline` failed
+~1 in 40 single runs with `oracle: missing <did> <coll>/<rkey> rev=` — a chain
+record present in ground truth but absent on disk. The crash tier
+(`TestOracle_RestartChainCrashConsistency`) inherited the same flake. Cause: the
+chain's tail frames were not always drained into `live_segments` before cutover
+cancelled the bootstrap-live consumer (the §3.1 risk). The seed-chosen chain DID
+was `chainAccountIdx=3` (the *last* of 4), so mitigation (a)'s "early DID" never
+held — the spec picks the host by RNG, not by sort order. Production tolerates
+this via steady-state re-fetch from the persisted cursor, but the restart child
+exits at the after-merge barrier and never runs steady-state.
+
+Implemented (b) as a cross-process cutover gate (the test-process analogue of the
+main harness's in-process `bootstrapTraffic.WaitDelivered`):
+`TestOracleRestartChild` wires a `cutoverDeliveryGate` to `BarrierBeforeCutover`.
+At cutover it samples the relay's firehose tip (a new read-only test endpoint
+`GET /_oracle/firehose-tip`, mounted only under `HandlerOptions.EnableFirehoseTip`)
+and blocks until the bootstrap-live consumer has contiguously archived every
+frame up to it (observed via `OnBootstrapLiveEvent`). Seqs are dense `1..tip`
+(every `world.seq.Add` stages exactly one frame; shape G's silent mutation bumps
+no seq), so the gate is deterministic and non-vacuous; it floors contiguity at the
+lowest observed seq so a child resuming bootstrap at a persisted cursor `C` (e.g.
+an `AfterRepoComplete` crash before the merging-phase write) correctly waits on
+`C+1..tip`. A never-delivered tail fails LOUD (timeout error surfaced by the
+child) rather than silently proceeding. Post-fix: 0 failures in 80× baseline,
+60× crash-consistency, and a 5-seed × full-restart-tier sweep at the flaky seed.
+Unit guards live in `cutover_gate_test.go` (red-first verified).
+
 ### 3.2 Determinism
 
 Seq-assignment order across DIDs is nondeterministic (backfill concurrency,

--- a/specs/oracle/2026-06-27-restart-chain-cutover-delivery-race.md
+++ b/specs/oracle/2026-06-27-restart-chain-cutover-delivery-race.md
@@ -1,0 +1,159 @@
+# Oracle failure diary — restart-chain cutover delivery race
+
+- **Date:** 2026-06-27
+- **Commit (failure observed on):** `cd4207b9d3e903e0e73e32e85367b4387d624137`
+- **Test:** `TestOracle_RestartChainCrashConsistency/after-bootstrap-live-close-before-seal` (and other subtests; see below)
+- **Symptom:** `oracle: missing did:plc:… app.bsky.feed.post/… rev=` — a chain record present in ground truth (world repo state) is absent from the recovered on-disk segments. Sometimes surfaces instead as `oracle: payload mismatch …` on a different DID/subtest.
+- **Classification:** flaky, wall-clock/scheduling dependent (not seed-deterministic).
+- **Status:** FIXED
+- **Tracking issue:** [#166](https://github.com/bluesky-social/jetstream/issues/166) (related: #114, epic #35).
+
+## Repro
+
+```
+JETSTREAM_ORACLE_SEED=11212589348287832646 \
+  GOMAXPROCS=2 go test ./internal/oracle -run 'TestOracle_Restart' \
+    -count=50 -failfast -timeout 60m -v
+```
+
+The failure is timing-dependent: which subtest trips, and whether it trips as
+`missing` vs `payload mismatch`, varies run to run. It does **not** require the
+full suite. The cleanest minimal repro is the **no-crash baseline** (see
+analysis) — it removes the crash variable entirely and still fails:
+
+```
+JETSTREAM_ORACLE_SEED=11212589348287832646 \
+  GOMAXPROCS=2 go test ./internal/oracle \
+    -run 'TestOracle_RestartChainDurableIntermediates_Baseline$' \
+    -count=60 -failfast -timeout 30m
+```
+
+Measured pre-fix flake rate: ~1 failure per 40 single runs of the baseline at
+this seed.
+
+## Analysis
+
+The decisive observation: the **no-crash baseline**
+`TestOracle_RestartChainDurableIntermediates_Baseline` reproduces the identical
+`oracle: missing … rev=` error at the same seed. Since that test never crashes,
+the bug is **not** in crash recovery — the crash tier merely inherits it.
+
+Data-flow that must hold for a durable intermediate to land:
+
+1. The parent's `chainCoordinator` (installed as the simulator's
+   `OnGetRepoServed` hook) injects the seed-derived chain
+   (create/update/delete/recreate, plus shapes F/G) onto the relay's live
+   firehose **during the child's backfill**, at a rev above the now-pinned
+   backfill head (`restart_chain_coordinator_test.go`,
+   `internal/simulator/http/pds.go:79` — generation fires synchronously before
+   the getRepo body's EOF).
+2. The child's bootstrap-live consumer must read those frames off the fanout and
+   durably append them to `backfill/live_segments/` **before** cutover cancels
+   the consumer.
+3. At cutover, `runBootstrap` writes `phase=merging`, then calls `cancelLive()`
+   to tear down the bootstrap-live consumer
+   (`internal/ingest/orchestrator/bootstrap.go:128-156`). The merge then drains
+   `live_segments`, the rev-filter keeps the chain (`rev > BackfillRev`), and
+   compaction runs.
+
+The race: backfill of the *other* repos can finish — triggering cutover — before
+the bootstrap-live consumer has drained the chain's tail frames. Any undrained
+frame at `cancelLive()` is lost. In production this is benign: steady-state
+re-subscribes from the persisted cursor and re-fetches the in-flight events. But
+the restart child **exits at the after-merge barrier and never runs
+steady-state**, so the lost tail is never recovered → the record is missing on
+disk while still present in ground truth → `Compare` fails.
+
+Why it looked seed-stable but wasn't: the seed fixes the *inputs* (world, chain
+shape, which DID hosts the chain), but backfill concurrency + bootstrap-live
+delivery timing are real wall-clock nondeterminism. At this seed
+`deriveChainSpec` picked `chainAccountIdx=3` — the **last** of 4 accounts — so
+the plan's mitigation of "target an early-sorting DID" never actually held (the
+host is chosen by RNG, not by sort order).
+
+Contributing factors:
+
+- No cross-process cutover gate in the restart child (the main harness has an
+  in-process one — `bootstrapTraffic.WaitDelivered` wired to
+  `BarrierBeforeCutover` in `harness_test.go`).
+- Chain host DID chosen by RNG, defeating the "early DID" passive-timing
+  assumption documented in the plan (§3.1, Q2 option a).
+- The restart child's exit-at-after-merge lifecycle removes the steady-state
+  re-fetch that masks this race in production.
+
+This was anticipated: the plan
+`specs/notes/2026-06-20-restart-tier-intermediates-plan.md` §3.1 Q2 says to
+escalate to the active cutover gate (option b) "**ONLY if the baseline proves
+flaky** (record the flake evidence in this doc if so)."
+
+## Root cause
+
+A generation-vs-cutover **delivery race**: chain frames injected on the live
+firehose during backfill are not guaranteed to be durably archived into
+`live_segments` before `cancelLive()` tears down the bootstrap-live consumer at
+cutover. The restart child, lacking both the early-DID timing slack and the
+steady-state re-fetch that protect the no-gate path elsewhere, can lose the
+undrained tail.
+
+## Fix (test-only; no production behavior change)
+
+Implemented the plan's Q2 option (b) — a cross-process cutover gate, the
+test-process analogue of the main harness's in-process
+`bootstrapTraffic.WaitDelivered`:
+
+- **New read-only sim endpoint** `GET /_oracle/firehose-tip`
+  (`internal/simulator/http/firehose_tip.go`), mounted only under
+  `HandlerOptions.EnableFirehoseTip` (off by default; production `NewHandler`
+  never sets it). Reports `world.CurrentSeq()`.
+- **`cutoverDeliveryGate`** in `internal/oracle/restart_harness_test.go`, wired
+  in `TestOracleRestartChild` to `BarrierBeforeCutover` (the wait) and
+  `OnBootstrapLiveEvent` (the observations). At cutover it samples the relay
+  firehose tip once and blocks until the bootstrap-live consumer has
+  *contiguously* archived every frame up to it.
+  - Soundness: every `world.seq.Add` stages exactly one firehose frame (shape
+    G's silent mutation bumps no seq → no gaps), and every generated frame
+    yields ≥1 archived event with `UpstreamRelayCursor == seq`. bootstrap-live
+    runs `BatchSize=1` and fires `OnEvent` after each durable Append.
+  - Floors contiguity at the **lowest observed seq**, so a child resuming
+    bootstrap at a persisted cursor `C` (e.g. an `AfterRepoComplete` crash before
+    the merging-phase write) correctly waits on `C+1..tip` rather than hanging on
+    `1..C` (already durable from the prior child).
+  - Fails **loud** (timeout error surfaced by the child) if the tip is never
+    delivered — never silently proceeds on an undrained tail
+    (AGENTS.md: crashing > silent data loss).
+- **Doc update:** recorded the escalation + flake evidence in the plan's §3.1
+  Q2.
+
+### Regression tests
+
+`internal/oracle/cutover_gate_test.go` (fast, deterministic, can't flake):
+
+- `TestCutoverGateBlocksUntilTipDelivered` — the core guard: gate stays blocked
+  while a tip frame is withheld, releases once delivered.
+- `TestCutoverGateFloorsAtLowestObserved` — recovering-child case (resume at
+  cursor C, observe only C+1..tip).
+- `TestCutoverGateNoLiveOps` — nil-coordinator / tip=0 is a no-op.
+- `TestCutoverGateTimesOutLoud` — fails loud on a never-delivered (gappy) tail.
+- `TestCutoverGateRespectsContextCancel` — clean unblock on ctx cancel.
+
+**Red-first verified:** stubbing `contiguousToTip` to always return `true` (the
+"no gate" behavior) makes `TestCutoverGateBlocksUntilTipDelivered` and
+`TestCutoverGateTimesOutLoud` fail; restoring the gate makes them pass.
+
+## Verification
+
+- Original repro (`TestOracle_Restart`, count=50, failfast) at the flaky seed:
+  PASS.
+- No-crash baseline: 0/80 failures (was ~1/40).
+- `TestOracle_RestartChainCrashConsistency`: 0/60 failures.
+- 5-seed × full-restart-tier sweep (count=2 each) at the flaky seed: 0 failures.
+- Full `internal/oracle`, `internal/simulator/...`, `internal/ingest/...`: green.
+- `go build ./...`, `go vet`, `gofmt`: clean.
+
+## Files touched
+
+- `internal/simulator/http/firehose_tip.go` (new)
+- `internal/simulator/http/handler.go` (`EnableFirehoseTip` option + mount)
+- `internal/oracle/restart_harness_test.go` (`cutoverDeliveryGate` + wiring)
+- `internal/oracle/cutover_gate_test.go` (new; regression guards)
+- `specs/notes/2026-06-20-restart-tier-intermediates-plan.md` (Q2 escalation note)

--- a/specs/oracle/README.md
+++ b/specs/oracle/README.md
@@ -1,0 +1,26 @@
+# Oracle test failure diary
+
+A running log of oracle simulator test failures, one markdown file per
+incident. Each entry records, for a single failure:
+
+- the commit hash the failure was observed on,
+- the exact repro command,
+- the analysis (how the diagnosis was reached),
+- the root cause (contributing factors), and
+- the fix and its verification.
+
+The goal is institutional memory: a future flake at a similar seam should be
+diagnosable by reading past entries, and each fix's red-first evidence is on
+record.
+
+## Naming
+
+`YYYY-MM-DD-short-slug.md` — date the failure was investigated, plus a slug
+naming the failure mode (not the test).
+
+## Entries
+
+- [2026-06-27 — restart-chain cutover delivery race](2026-06-27-restart-chain-cutover-delivery-race.md):
+  durable-intermediate chain frames lost when cutover cancelled the
+  bootstrap-live consumer before the tail was archived; fixed with a
+  cross-process cutover delivery gate.


### PR DESCRIPTION
Closes #166.

## Problem

`TestOracle_RestartChainCrashConsistency` (and the no-crash baseline `TestOracle_RestartChainDurableIntermediates_Baseline`) flaked with `oracle: missing <did> <coll>/<rkey> rev=` — a seed-derived chain record present in ground truth but absent from the recovered on-disk segments. Observed on `cd4207b`.

## Root cause

A **generation-vs-cutover delivery race**, not crash recovery — the no-crash baseline reproduces it identically (~1/40 at the flaky seed).

The `chainCoordinator` injects durable intermediates on the live firehose during the child's backfill. Those frames must be archived into `backfill/live_segments/` before cutover cancels the bootstrap-live consumer (`orchestrator/bootstrap.go` `cancelLive()`). When the other repos' backfill finishes first, the undrained chain tail is lost. Production tolerates this via steady-state re-fetch from the persisted cursor, but the restart child exits at the after-merge barrier and never runs steady-state. The chain host DID is RNG-chosen and landed last of 4 at this seed, so the plan's "early DID" passive-timing mitigation never held.

This was anticipated: `specs/notes/2026-06-20-restart-tier-intermediates-plan.md` §3.1 Q2 said to escalate to the active cutover gate (option b) "ONLY if the baseline proves flaky."

## Fix (test-only; no production behavior change)

Implements the plan's Q2 option (b) — a cross-process cutover gate, the test-process analogue of the main harness's in-process `bootstrapTraffic.WaitDelivered`:

- New read-only sim endpoint `GET /_oracle/firehose-tip`, mounted only under `HandlerOptions.EnableFirehoseTip` (production `NewHandler` never sets it).
- `cutoverDeliveryGate` in `restart_harness_test.go`, wired to the child's `BarrierBeforeCutover` + `OnBootstrapLiveEvent`: at cutover it samples the relay tip and blocks until bootstrap-live has contiguously archived every frame up to it. Floors contiguity at the lowest observed seq (recovering-child resume case); fails loud on timeout.
- Regression guards in `cutover_gate_test.go` (red-first verified).
- Plan doc updated with the escalation + flake evidence.
- New `specs/oracle/` failure diary with the full incident writeup.

## Verification

- Original repro (`TestOracle_Restart`, count=50, failfast) at the flaky seed: PASS.
- No-crash baseline 0/80, crash-consistency 0/60, 5-seed full-restart-tier sweep: 0 failures (was ~1/40).
- Full `internal/oracle`, `internal/simulator/...`, `internal/ingest/...`: green; `go build ./...`, `go vet`, `gofmt`: clean.

Related: #114 (introduced the durable-intermediates tier), #35 (epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)