### PR TITLE
live: enqueue net-new DIDs for repo backfill (#188)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -424,8 +424,13 @@ type Status string
 
 const (
     StatusNotStarted Status = "not_started"
+    // discovered live in steady state, awaiting initial getRepo (issue #188)
+    StatusPending Status = "pending"
     StatusComplete   Status = "complete"
     StatusFailed     Status = "failed"
+    // account exists but its repo is unfetchable (deactivated/suspended/
+    // taken down); terminal and never retried
+    StatusUnavailable Status = "unavailable"
 )
 
 type RepoStatus struct {
@@ -510,6 +515,8 @@ The steady-state phase simply consumes from the upstream firehose and writes eve
 Every block seal commits a single pebble batch that advances `relay/cursor` and refreshes `repo/<did>.LatestRev` for every DID in the block. We always fsync the segment block first and then commit the pebble batch with `sync=true`, so the persisted cursor can never get ahead of the durable event data. A crash between the two steps is handled by the active-segment recovery path described in Section 3.1, and the upstream resumes from whatever cursor pebble last saw.
 
 If there were any accounts that failed to download during the initial backfill phase (i.e. `repo/<did>.Status == StatusFailed`), we periodically retry downloading them with exponential backoff in the background until they succeed. Retry eligibility and backoff are stored on `repo/<did>` via `RetryCount` and `NextAttemptAt` so process restarts do not create retry storms. When we do successfully download a repo that previously failed, we treat it similar to a whole-repo `#sync` event: mark all previous events for that DID as deleted, and recreate from the downloaded CAR file.
+
+The same loop also backfills **net-new DIDs** ([#188](https://github.com/bluesky-social/jetstream/issues/188)). A repo can show up live that we never backfilled — say its PDS was firewalled during the `listRepos` sweep and only later starts replaying, so the first event we see is #101 and we missed #1–100. When the live consumer archives an event for a DID with no `repo/<did>` row, it writes one at `StatusPending`. The retry loop treats pending and failed the same way, so the next pass downloads it over the usual `getRepo` path. This only matters in steady state; during bootstrap a DID that appears mid-sweep still turns up later in the same `listRepos` pagination.
 
 ### 4.4 Identity, Account, and Sync Events
 

--- a/internal/ingest/backfill/counts.go
+++ b/internal/ingest/backfill/counts.go
@@ -13,6 +13,7 @@ import (
 type Counts struct {
 	Total       uint64 `json:"total"`
 	Discovered  uint64 `json:"discovered"`
+	Pending     uint64 `json:"pending"`
 	Complete    uint64 `json:"complete"`
 	Failed      uint64 `json:"failed"`
 	Unavailable uint64 `json:"unavailable"`
@@ -110,6 +111,8 @@ func CountStatuses(s *store.Store) (Counts, error) {
 		switch rs.Backfill.Status {
 		case StatusNotStarted:
 			c.Discovered++
+		case StatusPending:
+			c.Pending++
 		case StatusComplete:
 			c.Complete++
 		case StatusFailed:

--- a/internal/ingest/backfill/diagnostics.go
+++ b/internal/ingest/backfill/diagnostics.go
@@ -342,6 +342,8 @@ func hostStatusBucket(h *HostStatus, st Status) *uint64 {
 	switch st {
 	case StatusNotStarted:
 		return &h.NotStarted
+	case StatusPending:
+		return &h.Pending
 	case StatusComplete:
 		return &h.Complete
 	case StatusFailed:

--- a/internal/ingest/backfill/enqueue.go
+++ b/internal/ingest/backfill/enqueue.go
@@ -29,6 +29,19 @@
 // The seen cache is an optimization, never the source of truth: the worker's
 // EnqueueNetNewRepo re-checks pebble and is a no-op when a row already exists,
 // so an eviction (or a cold start) costs at most one redundant point read.
+//
+// Durability window (accepted limitation). Observe is deliberately async and
+// pebble-free, so the durable StatusPending write lags the live consumer. The
+// relay cursor can advance past a DID's archived event (a block flush inside
+// writer.Append persists relay/cursor) before the worker drains that DID and
+// writes its row. A process crash — or a transient EnqueueNetNewRepo failure
+// racing the DID's last event — in that window loses the in-memory candidate,
+// and the relay does not redeliver. This is only unrecoverable for a DID that
+// emits exactly ONE event in that window: any DID that emits another event
+// re-observes and re-enqueues (the fast-path last and seen cache are cleared on
+// failure precisely so a later event retries). We accept this rather than make
+// the per-event hot path take a synchronous pebble write at firehose rate; a
+// genuinely active repo that we missed will almost always emit again.
 package backfill
 
 import (
@@ -145,6 +158,22 @@ func (e *LiveEnqueuer) Observe(did string) {
 		return
 	}
 
+	// Drop malformed DIDs here, on the hot path, before they consume a queue
+	// slot or a durable write. #identity events (and #account verification
+	// failures) are not DID-syntax-verified upstream, so a malformed DID can
+	// reach Observe. A bad DID is non-retryable — re-validating it forever would
+	// be pure churn — so cache it (and set last) exactly like a handled DID: the
+	// fast path and seen cache then absorb every later event for it instead of
+	// re-running validation. EnqueueNetNewRepo re-checks at the durable boundary
+	// as defense in depth, so a malformed key can never become a repo/ row that
+	// wedges the retry scan.
+	if err := atmos.DID(did).Validate(); err != nil {
+		e.cache.store(did)
+		e.setLast(did)
+		e.metrics.incEnqueueInvalidDID()
+		return
+	}
+
 	// Unknown DID: hand it to the worker without blocking the firehose.
 	select {
 	case e.queue <- did:
@@ -196,7 +225,19 @@ func (e *LiveEnqueuer) process(ctx context.Context, did string) {
 		if ctx.Err() != nil {
 			return
 		}
+		// Evict the seen cache FIRST, then clear the burst-absorber, so a later
+		// event re-enqueues this DID. Order matters and is concurrency-critical:
+		// Observe (firehose goroutine) checks last before the cache. If we
+		// cleared last first, a same-DID Observe racing between the clear and the
+		// cache eviction would find last==nil, hit the still-present cache entry,
+		// and call setLast(did) — repopulating last with the failed DID and
+		// re-suppressing the retry forever. Removing the cache entry first means
+		// that once last is cleared, Observe can no longer repopulate it from the
+		// cache, so the next same-DID event genuinely re-enqueues.
 		e.cache.remove(did)
+		if last := e.last.Load(); last != nil && *last == did {
+			e.last.CompareAndSwap(last, nil)
+		}
 		e.logger.WarnContext(ctx, "failed to enqueue net-new repo for backfill",
 			"did", did,
 			"err", err,

--- a/internal/ingest/backfill/enqueue.go
+++ b/internal/ingest/backfill/enqueue.go
@@ -1,0 +1,354 @@
+// Package backfill: enqueue.go implements LiveEnqueuer, the steady-state
+// firehose hook that detects net-new DIDs and schedules a full repo backfill
+// for them (issue #188).
+//
+// During steady state a DID can appear on the firehose that we never
+// backfilled — e.g. a PDS that was unreachable or firewalled during the
+// bootstrap listRepos sweep becomes reachable and replays its backlog. We
+// archive that DID's live events but are missing all of its historical
+// records. LiveEnqueuer notices the first event from an unknown DID and
+// durably creates a StatusPending repo row; the steady-state failed-repo retry
+// loop then performs a full getRepo on its next pass, reusing the exact same
+// download → verify → complete machinery as a failed-repo retry.
+//
+// Hot-path budget. Observe runs synchronously on the live consumer's single
+// processBatch goroutine, once per archived event — 500+ events/sec steady,
+// and during a #sync-driven repo replay potentially millions of events/sec for
+// one DID in a short burst. It must never touch pebble or block on that path:
+//
+//  1. A lock-free last-DID fast path absorbs same-DID bursts (the #sync replay
+//     case) with a single atomic load and a string compare — no lock, no map.
+//  2. A bounded sharded-LRU "seen" cache absorbs recently-observed distinct
+//     DIDs with one sharded-mutex map lookup and no pebble read.
+//  3. A genuinely unknown DID is handed to a bounded channel drained by a
+//     single background worker that performs the idempotent durable
+//     EnqueueNetNewRepo off the firehose goroutine. If the channel is full the
+//     candidate is dropped (and intentionally NOT cached) so a later event for
+//     the same still-active DID retries — self-healing under backpressure.
+//
+// The seen cache is an optimization, never the source of truth: the worker's
+// EnqueueNetNewRepo re-checks pebble and is a no-op when a row already exists,
+// so an eviction (or a cold start) costs at most one redundant point read.
+package backfill
+
+import (
+	"context"
+	"hash/maphash"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+
+	"github.com/jcalabro/atmos"
+)
+
+const (
+	// DefaultLiveEnqueueQueueSize bounds the in-memory candidate channel
+	// between Observe and the background worker. Sized so a transient worker
+	// stall (a slow pebble write) does not immediately start dropping
+	// candidates, while still capping memory and keeping the drop path bounded.
+	DefaultLiveEnqueueQueueSize = 4096
+
+	// DefaultLiveEnqueueCacheSize is the total number of recently-seen DIDs
+	// held across all seen-cache shards. This is a working-set cache, not a
+	// full-network index: at ~50 bytes/DID this defaults to a few tens of MB.
+	// An evicted-but-still-active DID simply triggers one redundant
+	// already-known pebble read on its next event.
+	DefaultLiveEnqueueCacheSize = 500_000
+
+	// DefaultLiveEnqueueCacheShards is the seen-cache shard count. Rounded up
+	// to a power of two so shard selection is a mask. Observe is called from a
+	// single goroutine today; sharding bounds per-shard map/eviction cost and
+	// keeps the cache correct if the hook is ever driven concurrently.
+	DefaultLiveEnqueueCacheShards = 64
+)
+
+// LiveEnqueuerConfig configures a LiveEnqueuer. Store is required.
+type LiveEnqueuerConfig struct {
+	Store   *Store
+	Metrics *Metrics
+	Logger  *slog.Logger
+
+	// QueueSize, CacheSize, CacheShards override the package defaults when > 0.
+	QueueSize   int
+	CacheSize   int
+	CacheShards int
+}
+
+// LiveEnqueuer detects net-new DIDs on the steady-state firehose and schedules
+// them for a full repo backfill. Construct with NewLiveEnqueuer; call Observe
+// on the hot path and Run from a background goroutine.
+type LiveEnqueuer struct {
+	store   *Store
+	metrics *Metrics
+	logger  *slog.Logger
+
+	// last is the lock-free burst absorber: the most recently observed DID.
+	// A #sync replay emits a long run of events for one DID, so checking this
+	// first collapses that run to a single cache/queue interaction.
+	last atomic.Pointer[string]
+
+	cache *seenCache
+	queue chan string
+}
+
+// NewLiveEnqueuer builds a LiveEnqueuer. It panics if Store is nil — that is a
+// construction-time wiring bug, not a runtime condition.
+func NewLiveEnqueuer(cfg LiveEnqueuerConfig) *LiveEnqueuer {
+	if cfg.Store == nil {
+		panic("backfill: NewLiveEnqueuer: Store is required")
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	queueSize := cfg.QueueSize
+	if queueSize <= 0 {
+		queueSize = DefaultLiveEnqueueQueueSize
+	}
+	cacheSize := cfg.CacheSize
+	if cacheSize <= 0 {
+		cacheSize = DefaultLiveEnqueueCacheSize
+	}
+	shards := cfg.CacheShards
+	if shards <= 0 {
+		shards = DefaultLiveEnqueueCacheShards
+	}
+	return &LiveEnqueuer{
+		store:   cfg.Store,
+		metrics: cfg.Metrics,
+		logger:  logger.With(slog.String("component", "backfill/live-enqueuer")),
+		cache:   newSeenCache(cacheSize, shards),
+		queue:   make(chan string, queueSize),
+	}
+}
+
+// Observe records that an event for did was archived. It is safe to call with
+// an empty DID (ignored). It never blocks and never touches pebble; an unknown
+// DID is handed to the background worker via a non-blocking send.
+func (e *LiveEnqueuer) Observe(did string) {
+	if did == "" {
+		return
+	}
+
+	// Lock-free fast path: collapse a run of events for the same DID (the
+	// #sync replay burst) to nothing after the first. last only ever holds a
+	// DID we have fully handled (cached or successfully enqueued), so a dropped
+	// DID never poisons this path — it is retried on its next event.
+	if p := e.last.Load(); p != nil && *p == did {
+		e.metrics.incEnqueueSeenCacheHit()
+		return
+	}
+
+	if e.cache.seen(did) {
+		e.setLast(did)
+		e.metrics.incEnqueueSeenCacheHit()
+		return
+	}
+
+	// Unknown DID: hand it to the worker without blocking the firehose.
+	select {
+	case e.queue <- did:
+		// Mark seen only after a successful enqueue so a still-active DID is
+		// not enqueued repeatedly while its candidate sits in the channel or
+		// is being written. If the durable write later fails, the worker
+		// evicts it so a future event retries.
+		e.cache.store(did)
+		e.setLast(did)
+		e.metrics.setEnqueueQueueDepth(len(e.queue))
+	default:
+		// Channel full: drop, do NOT cache, and do NOT set last. The DID is
+		// still emitting events, so its next event retries once the worker
+		// drains — and the unset last means that retry is not short-circuited.
+		e.metrics.incEnqueueDropped()
+	}
+}
+
+func (e *LiveEnqueuer) setLast(did string) {
+	d := did
+	e.last.Store(&d)
+}
+
+// Run drains the candidate queue and performs the idempotent durable enqueue
+// for each net-new DID until ctx is cancelled. Returns ctx.Err() on shutdown.
+//
+// A per-DID durable write failure is logged and the DID is evicted from the
+// seen cache (so a later event retries) rather than tearing down ingest: a
+// missed pending row is recoverable on the next observation, and a genuinely
+// broken pebble would fail the main archive writer's own append path.
+func (e *LiveEnqueuer) Run(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case did := <-e.queue:
+			e.metrics.setEnqueueQueueDepth(len(e.queue))
+			e.process(ctx, did)
+		}
+	}
+}
+
+func (e *LiveEnqueuer) process(ctx context.Context, did string) {
+	// A net-new DID that is actively emitting events is, by definition, active;
+	// mark the row Active so the retry loop's scanDue picks it up. If the repo
+	// turns out to be deactivated/taken-down, the getRepo attempt records it as
+	// StatusUnavailable (terminal, non-retryable) — the self-correcting path.
+	if _, err := e.store.EnqueueNetNewRepo(ctx, atmos.DID(did), true); err != nil {
+		if ctx.Err() != nil {
+			return
+		}
+		e.cache.remove(did)
+		e.logger.WarnContext(ctx, "failed to enqueue net-new repo for backfill",
+			"did", did,
+			"err", err,
+		)
+	}
+}
+
+// QueueLen reports the current depth of the candidate channel. Test-only
+// visibility into backpressure.
+func (e *LiveEnqueuer) QueueLen() int {
+	return len(e.queue)
+}
+
+// seenCache is a bounded, sharded LRU set of recently-observed DIDs. Each shard
+// is an independent LRU guarded by its own mutex; shard selection hashes the
+// DID so a given DID always maps to the same shard.
+type seenCache struct {
+	shards []*seenShard
+	mask   uint64
+	seed   maphash.Seed
+}
+
+func newSeenCache(totalCap, shardCount int) *seenCache {
+	if shardCount < 1 {
+		shardCount = 1
+	}
+	// Round shard count up to a power of two for mask-based selection.
+	n := 1
+	for n < shardCount {
+		n <<= 1
+	}
+	perShard := max(totalCap/n, 1)
+	shards := make([]*seenShard, n)
+	for i := range shards {
+		shards[i] = newSeenShard(perShard)
+	}
+	return &seenCache{
+		shards: shards,
+		mask:   uint64(n - 1),
+		seed:   maphash.MakeSeed(),
+	}
+}
+
+func (c *seenCache) shardFor(did string) *seenShard {
+	h := maphash.String(c.seed, did)
+	return c.shards[h&c.mask]
+}
+
+// seen reports whether did is present, bumping it to most-recently-used when it
+// is. A miss does not insert — callers insert via store only after a successful
+// enqueue.
+func (c *seenCache) seen(did string) bool {
+	return c.shardFor(did).seen(did)
+}
+
+func (c *seenCache) store(did string) {
+	c.shardFor(did).store(did)
+}
+
+func (c *seenCache) remove(did string) {
+	c.shardFor(did).remove(did)
+}
+
+// seenNode is an intrusive doubly-linked-list node in a shard's LRU order.
+type seenNode struct {
+	did        string
+	prev, next *seenNode
+}
+
+// seenShard is one LRU shard. head.next is the most-recently-used node;
+// tail.prev is the least-recently-used (next to evict). head and tail are
+// sentinels so insert/remove need no nil checks on the boundaries.
+type seenShard struct {
+	mu    sync.Mutex
+	cap   int
+	items map[string]*seenNode
+	head  *seenNode
+	tail  *seenNode
+}
+
+func newSeenShard(capacity int) *seenShard {
+	head := &seenNode{}
+	tail := &seenNode{}
+	head.next = tail
+	tail.prev = head
+	return &seenShard{
+		cap:   capacity,
+		items: make(map[string]*seenNode),
+		head:  head,
+		tail:  tail,
+	}
+}
+
+func (s *seenShard) seen(did string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n, ok := s.items[did]
+	if !ok {
+		return false
+	}
+	s.moveToFront(n)
+	return true
+}
+
+func (s *seenShard) store(did string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if n, ok := s.items[did]; ok {
+		s.moveToFront(n)
+		return
+	}
+	n := &seenNode{did: did}
+	s.items[did] = n
+	s.insertFront(n)
+	if len(s.items) > s.cap {
+		s.evictLRU()
+	}
+}
+
+func (s *seenShard) remove(did string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if n, ok := s.items[did]; ok {
+		s.unlink(n)
+		delete(s.items, did)
+	}
+}
+
+func (s *seenShard) moveToFront(n *seenNode) {
+	s.unlink(n)
+	s.insertFront(n)
+}
+
+func (s *seenShard) insertFront(n *seenNode) {
+	n.prev = s.head
+	n.next = s.head.next
+	s.head.next.prev = n
+	s.head.next = n
+}
+
+func (s *seenShard) unlink(n *seenNode) {
+	n.prev.next = n.next
+	n.next.prev = n.prev
+	n.prev = nil
+	n.next = nil
+}
+
+func (s *seenShard) evictLRU() {
+	lru := s.tail.prev
+	if lru == s.head {
+		return
+	}
+	s.unlink(lru)
+	delete(s.items, lru.did)
+}

--- a/internal/ingest/backfill/enqueue_test.go
+++ b/internal/ingest/backfill/enqueue_test.go
@@ -2,11 +2,13 @@ package backfill
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/bluesky-social/jetstream/internal/store"
 	"github.com/jcalabro/atmos"
 	"github.com/stretchr/testify/require"
 )
@@ -192,6 +194,107 @@ func TestEnqueueNetNewRepo_CreatesPendingAndCounts(t *testing.T) {
 	scanned, err := CountStatuses(s.db)
 	require.NoError(t, err)
 	require.Equal(t, counts, scanned)
+}
+
+func TestLiveEnqueuer_MalformedDIDDroppedOnHotPathNotQueued(t *testing.T) {
+	t.Parallel()
+	s := newEnqueueTestStore(t)
+	e := NewLiveEnqueuer(LiveEnqueuerConfig{Store: s})
+	bad := "not-a-did"
+
+	// A malformed DID must be absorbed on the hot path: never queued, never a
+	// durable write. It is non-retryable, so a repeat must be absorbed by the
+	// seen cache / fast path rather than re-validated and re-dropped each event.
+	e.Observe(bad)
+	require.Equal(t, 0, e.QueueLen(), "malformed DID must not be queued")
+	require.True(t, e.cache.seen(bad), "malformed DID must be cached so repeats are absorbed")
+
+	// A burst of the same malformed DID stays absorbed (no queue growth).
+	for range 1000 {
+		e.Observe(bad)
+	}
+	require.Equal(t, 0, e.QueueLen())
+
+	// A valid DID interleaved still enqueues normally.
+	e.Observe("did:plc:valid")
+	require.Equal(t, 1, e.QueueLen())
+}
+
+func TestEnqueueNetNewRepo_RejectsInvalidDID(t *testing.T) {
+	t.Parallel()
+	s := newEnqueueTestStore(t)
+	ctx := context.Background()
+
+	// #identity events (and #account verification failures) reach the enqueuer
+	// without DID-syntax verification, so a malformed upstream DID can arrive
+	// here. It must be rejected at the durable boundary, never persisted: a
+	// persisted unparseable repo/ key wedges scanDue (which ParseDIDs every key
+	// on each retry pass) and survives restarts.
+	for _, bad := range []string{"not-a-did", "did:", "did:plc:", "plc:abc", "did:PLC:abc"} {
+		created, err := s.EnqueueNetNewRepo(ctx, atmos.DID(bad), true)
+		require.Error(t, err, "malformed DID %q must be rejected", bad)
+		require.False(t, created)
+
+		rs, rerr := s.readRepoStatus(atmos.DID(bad))
+		require.NoError(t, rerr)
+		require.Nil(t, rs, "malformed DID %q must not be persisted", bad)
+	}
+
+	// No bad row means no poisoned key, and the counts row stays empty.
+	counts, ok, err := LoadCounts(s.db)
+	if ok {
+		require.NoError(t, err)
+		require.Equal(t, uint64(0), counts.Total)
+	}
+}
+
+func TestLiveEnqueuer_FailedEnqueueClearsLastSoRetryWorks(t *testing.T) {
+	t.Parallel()
+	// Fail the first batch_commit touching repo/ (the EnqueueNetNewRepo write),
+	// then let later writes succeed. This models a transient pebble write
+	// failure for a net-new DID's first enqueue.
+	fault := &store.KeyPrefixFault{
+		Prefix:  []byte("repo/"),
+		Op:      store.WriteOpBatchCommit,
+		Ordinal: 1,
+		Err:     errors.New("injected enqueue write failure"),
+	}
+	db, err := store.Open(t.TempDir(), nil, store.WithFaultInjector(fault))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	s := NewStore(db, nil)
+
+	e := NewLiveEnqueuer(LiveEnqueuerConfig{Store: s})
+	did := "did:plc:failsfirst"
+
+	// First observation enqueues the candidate and marks last+cache.
+	e.Observe(did)
+	require.Equal(t, 1, e.QueueLen())
+
+	// Drain it: the durable write fails, so process must clear last and evict
+	// the cache rather than leaving the DID permanently short-circuited.
+	runEnqueuerOnce(t, e)
+
+	rs, err := s.readRepoStatus(atmos.DID(did))
+	require.NoError(t, err)
+	require.Nil(t, rs, "first enqueue must have failed (no row)")
+
+	// The fast-path burst absorber must no longer hold the failed DID; if it
+	// did, this same-DID event would be silently dropped and never retried.
+	if p := e.last.Load(); p != nil {
+		require.NotEqual(t, did, *p, "failed DID must be cleared from the last pointer")
+	}
+	require.False(t, e.cache.seen(did), "failed DID must be evicted from the seen cache")
+
+	// A later event for the still-active DID must re-enqueue (write now succeeds).
+	e.Observe(did)
+	require.Equal(t, 1, e.QueueLen(), "failed DID must re-enqueue on its next event")
+	runEnqueuerOnce(t, e)
+
+	rs, err = s.readRepoStatus(atmos.DID(did))
+	require.NoError(t, err)
+	require.NotNil(t, rs, "retry must durably create the pending row")
+	require.Equal(t, StatusPending, rs.Backfill.Status)
 }
 
 func TestEnqueueNetNewRepo_ConcurrentSameDIDCreatesOnce(t *testing.T) {

--- a/internal/ingest/backfill/enqueue_test.go
+++ b/internal/ingest/backfill/enqueue_test.go
@@ -1,0 +1,273 @@
+package backfill
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jcalabro/atmos"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSeenCache_LRUEviction(t *testing.T) {
+	t.Parallel()
+	// One shard, capacity 2, so eviction order is deterministic.
+	c := newSeenCache(2, 1)
+
+	c.store("a")
+	c.store("b")
+	require.True(t, c.seen("a"))
+	require.True(t, c.seen("b"))
+
+	// Touch "a" so "b" becomes least-recently-used, then insert "c": "b" evicts.
+	require.True(t, c.seen("a"))
+	c.store("c")
+	require.True(t, c.seen("a"))
+	require.True(t, c.seen("c"))
+	require.False(t, c.seen("b"))
+}
+
+func TestSeenCache_StoreIsIdempotent(t *testing.T) {
+	t.Parallel()
+	c := newSeenCache(4, 1)
+	c.store("a")
+	c.store("a")
+	c.store("a")
+	require.True(t, c.seen("a"))
+	// Re-storing must not have created duplicate nodes that distort the LRU.
+	shard := c.shardFor("a")
+	shard.mu.Lock()
+	require.Len(t, shard.items, 1)
+	shard.mu.Unlock()
+}
+
+func TestSeenCache_RemoveAllowsReinsert(t *testing.T) {
+	t.Parallel()
+	c := newSeenCache(4, 1)
+	c.store("a")
+	require.True(t, c.seen("a"))
+	c.remove("a")
+	require.False(t, c.seen("a"))
+	c.store("a")
+	require.True(t, c.seen("a"))
+}
+
+func TestSeenCache_ShardCountRoundsUpToPowerOfTwo(t *testing.T) {
+	t.Parallel()
+	c := newSeenCache(1000, 60)
+	require.Len(t, c.shards, 64)
+	require.Equal(t, uint64(63), c.mask)
+}
+
+// newEnqueueTestStore builds a Store over a fresh pebble with metrics so the
+// enqueue counters can be asserted.
+func newEnqueueTestStore(t *testing.T) *Store {
+	t.Helper()
+	return newTestStore(t)
+}
+
+func TestLiveEnqueuer_EnqueuesNetNewDID(t *testing.T) {
+	t.Parallel()
+	s := newEnqueueTestStore(t)
+	e := NewLiveEnqueuer(LiveEnqueuerConfig{Store: s})
+	did := "did:plc:netnew"
+
+	e.Observe(did)
+	require.Equal(t, 1, e.QueueLen(), "unknown DID should be queued")
+
+	// Drain one item synchronously via the worker loop with a short deadline.
+	runEnqueuerOnce(t, e)
+
+	rs, err := s.readRepoStatus(atmos.DID(did))
+	require.NoError(t, err)
+	require.NotNil(t, rs)
+	require.Equal(t, StatusPending, rs.Backfill.Status)
+	require.True(t, rs.Active)
+	require.True(t, rs.Backfill.NextAttemptAt.IsZero(), "pending row must be immediately due")
+}
+
+func TestLiveEnqueuer_BurstSameDIDCollapses(t *testing.T) {
+	t.Parallel()
+	s := newEnqueueTestStore(t)
+	e := NewLiveEnqueuer(LiveEnqueuerConfig{Store: s})
+	did := "did:plc:burst"
+
+	// Simulate a #sync replay: a long run of events for one DID.
+	for range 1_000_000 {
+		e.Observe(did)
+	}
+	require.Equal(t, 1, e.QueueLen(), "a same-DID burst must enqueue exactly once")
+}
+
+func TestLiveEnqueuer_KnownDIDNotReQueued(t *testing.T) {
+	t.Parallel()
+	s := newEnqueueTestStore(t)
+	e := NewLiveEnqueuer(LiveEnqueuerConfig{Store: s})
+	a, b := "did:plc:a", "did:plc:b"
+
+	// Interleave two DIDs so the lock-free last-DID path does not absorb them.
+	e.Observe(a)
+	e.Observe(b)
+	e.Observe(a)
+	e.Observe(b)
+	require.Equal(t, 2, e.QueueLen(), "each distinct DID should be queued once")
+}
+
+func TestLiveEnqueuer_EmptyDIDIgnored(t *testing.T) {
+	t.Parallel()
+	s := newEnqueueTestStore(t)
+	e := NewLiveEnqueuer(LiveEnqueuerConfig{Store: s})
+	e.Observe("")
+	require.Equal(t, 0, e.QueueLen())
+}
+
+func TestLiveEnqueuer_ChannelFullDropsAndDoesNotCache(t *testing.T) {
+	t.Parallel()
+	s := newEnqueueTestStore(t)
+	// Tiny queue, no worker draining: the 1st DID fills it, the 2nd drops.
+	e := NewLiveEnqueuer(LiveEnqueuerConfig{Store: s, QueueSize: 1})
+
+	e.Observe("did:plc:first")
+	require.Equal(t, 1, e.QueueLen())
+
+	e.Observe("did:plc:dropped")
+	require.Equal(t, 1, e.QueueLen(), "second DID must be dropped, not queued")
+
+	// A dropped DID must NOT be cached, so a later event for it retries.
+	require.False(t, e.cache.seen("did:plc:dropped"))
+
+	// Drain the first so there's room, then re-observe the dropped DID.
+	<-e.queue
+	e.Observe("did:plc:dropped")
+	require.Equal(t, 1, e.QueueLen(), "dropped DID should enqueue on retry once space frees")
+}
+
+func TestLiveEnqueuer_Idempotent_ExistingRowIsNoOp(t *testing.T) {
+	t.Parallel()
+	s := newEnqueueTestStore(t)
+	ctx := context.Background()
+	did := atmos.DID("did:plc:exists")
+
+	// Pre-existing complete row: enqueue must not overwrite it.
+	require.NoError(t, s.putRepoStatus(did, &RepoStatus{
+		Backfill: RepoBackfillStatus{Status: StatusComplete, Rev: "rev-1"},
+		Active:   true,
+	}))
+
+	created, err := s.EnqueueNetNewRepo(ctx, did, true)
+	require.NoError(t, err)
+	require.False(t, created, "existing row must not be re-created")
+
+	rs, err := s.readRepoStatus(did)
+	require.NoError(t, err)
+	require.Equal(t, StatusComplete, rs.Backfill.Status, "existing status must be preserved")
+	require.Equal(t, "rev-1", rs.Backfill.Rev)
+}
+
+func TestEnqueueNetNewRepo_CreatesPendingAndCounts(t *testing.T) {
+	t.Parallel()
+	s := newEnqueueTestStore(t)
+	ctx := context.Background()
+	did := atmos.DID("did:plc:pending")
+
+	created, err := s.EnqueueNetNewRepo(ctx, did, true)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	// Second call is a durable no-op.
+	created, err = s.EnqueueNetNewRepo(ctx, did, true)
+	require.NoError(t, err)
+	require.False(t, created)
+
+	counts, ok, err := LoadCounts(s.db)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint64(1), counts.Total)
+	require.Equal(t, uint64(1), counts.Pending)
+	require.Equal(t, uint64(0), counts.Failed)
+
+	// Scanned counts must agree with the maintained aggregate.
+	scanned, err := CountStatuses(s.db)
+	require.NoError(t, err)
+	require.Equal(t, counts, scanned)
+}
+
+func TestEnqueueNetNewRepo_ConcurrentSameDIDCreatesOnce(t *testing.T) {
+	t.Parallel()
+	s := newEnqueueTestStore(t)
+	ctx := context.Background()
+	did := atmos.DID("did:plc:race")
+
+	const goroutines = 32
+	var wg sync.WaitGroup
+	var createdCount int
+	var mu sync.Mutex
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			created, err := s.EnqueueNetNewRepo(ctx, did, true)
+			require.NoError(t, err)
+			if created {
+				mu.Lock()
+				createdCount++
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, 1, createdCount, "exactly one goroutine must create the row")
+	counts, ok, err := LoadCounts(s.db)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint64(1), counts.Total)
+	require.Equal(t, uint64(1), counts.Pending)
+}
+
+// runEnqueuerOnce runs the worker until it has drained the queue, then cancels.
+func runEnqueuerOnce(t *testing.T, e *LiveEnqueuer) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		_ = e.Run(ctx)
+		close(done)
+	}()
+	deadline := time.After(2 * time.Second)
+	for e.QueueLen() > 0 {
+		select {
+		case <-deadline:
+			t.Fatal("enqueuer worker did not drain queue")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+	// Give the worker a moment to finish the in-flight item's durable write.
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	<-done
+}
+
+// fmtDID is a tiny helper so table tests can generate distinct DIDs.
+func fmtDID(i int) string { return fmt.Sprintf("did:plc:gen-%d", i) }
+
+func TestSeenCache_DistinctDIDsAcrossShards(t *testing.T) {
+	t.Parallel()
+	c := newSeenCache(4096, 64)
+	const n = 2000
+	for i := range n {
+		c.store(fmtDID(i))
+	}
+	// All fit under capacity, so all should still be present.
+	present := 0
+	for i := range n {
+		if c.seen(fmtDID(i)) {
+			present++
+		}
+	}
+	require.Equal(t, n, present)
+}

--- a/internal/ingest/backfill/metrics.go
+++ b/internal/ingest/backfill/metrics.go
@@ -35,6 +35,13 @@ type Metrics struct {
 	RetrySucceeded           prometheus.Counter
 	RetryFailed              prometheus.Counter
 	RetrySkippedHostParked   prometheus.Counter
+
+	// Net-new steady-state DID enqueue (issue #188).
+	EnqueuedNetNew      prometheus.Counter
+	EnqueueAlreadyKnown prometheus.Counter
+	EnqueueSeenCacheHit prometheus.Counter
+	EnqueueDropped      prometheus.Counter
+	EnqueueQueueDepth   prometheus.Gauge
 }
 
 // NewMetrics registers the backfill counters against reg. Pass the
@@ -154,6 +161,31 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 			Name: "failed_repo_retry_skipped_host_parked_total",
 			Help: "Number of eligible failed repo retries skipped because their host was parked by a rate-limit response.",
 		}),
+		EnqueuedNetNew: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: metricsNamespace, Subsystem: metricsSubsystem,
+			Name: "net_new_enqueued_total",
+			Help: "Number of net-new DIDs first seen on the steady-state firehose for which a pending backfill row was created.",
+		}),
+		EnqueueAlreadyKnown: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: metricsNamespace, Subsystem: metricsSubsystem,
+			Name: "net_new_already_known_total",
+			Help: "Number of net-new enqueue attempts that found an existing repo row (seen-cache miss but row present); no-op.",
+		}),
+		EnqueueSeenCacheHit: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: metricsNamespace, Subsystem: metricsSubsystem,
+			Name: "net_new_seen_cache_hit_total",
+			Help: "Number of firehose events whose DID was served from the in-memory seen cache without touching pebble.",
+		}),
+		EnqueueDropped: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: metricsNamespace, Subsystem: metricsSubsystem,
+			Name: "net_new_dropped_total",
+			Help: "Number of net-new DID enqueue requests dropped because the background enqueue queue was full. Self-healing: an active DID re-emits and is retried on the next event.",
+		}),
+		EnqueueQueueDepth: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: metricsNamespace, Subsystem: metricsSubsystem,
+			Name: "net_new_queue_depth",
+			Help: "Current number of candidate net-new DIDs waiting for the background enqueue worker.",
+		}),
 	}
 	reg.MustRegister(
 		m.Discovered, m.Completed, m.Failed, m.ActiveFlips, m.OnFailErrors,
@@ -163,6 +195,8 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 		m.CompletionQueueWait, m.ForcedCheckpointFlushes,
 		m.RetryPasses, m.RetryCandidates, m.RetryAttempts,
 		m.RetrySucceeded, m.RetryFailed, m.RetrySkippedHostParked,
+		m.EnqueuedNetNew, m.EnqueueAlreadyKnown, m.EnqueueSeenCacheHit,
+		m.EnqueueDropped, m.EnqueueQueueDepth,
 	)
 	return m
 }
@@ -296,5 +330,35 @@ func (m *Metrics) incRetryFailed() {
 func (m *Metrics) incRetrySkippedHostParked() {
 	if m != nil {
 		m.RetrySkippedHostParked.Inc()
+	}
+}
+
+func (m *Metrics) incEnqueuedNetNew() {
+	if m != nil {
+		m.EnqueuedNetNew.Inc()
+	}
+}
+
+func (m *Metrics) incEnqueueAlreadyKnown() {
+	if m != nil {
+		m.EnqueueAlreadyKnown.Inc()
+	}
+}
+
+func (m *Metrics) incEnqueueSeenCacheHit() {
+	if m != nil {
+		m.EnqueueSeenCacheHit.Inc()
+	}
+}
+
+func (m *Metrics) incEnqueueDropped() {
+	if m != nil {
+		m.EnqueueDropped.Inc()
+	}
+}
+
+func (m *Metrics) setEnqueueQueueDepth(v int) {
+	if m != nil {
+		m.EnqueueQueueDepth.Set(float64(v))
 	}
 }

--- a/internal/ingest/backfill/metrics.go
+++ b/internal/ingest/backfill/metrics.go
@@ -41,6 +41,7 @@ type Metrics struct {
 	EnqueueAlreadyKnown prometheus.Counter
 	EnqueueSeenCacheHit prometheus.Counter
 	EnqueueDropped      prometheus.Counter
+	EnqueueInvalidDID   prometheus.Counter
 	EnqueueQueueDepth   prometheus.Gauge
 }
 
@@ -181,6 +182,11 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 			Name: "net_new_dropped_total",
 			Help: "Number of net-new DID enqueue requests dropped because the background enqueue queue was full. Self-healing: an active DID re-emits and is retried on the next event.",
 		}),
+		EnqueueInvalidDID: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: metricsNamespace, Subsystem: metricsSubsystem,
+			Name: "net_new_invalid_did_total",
+			Help: "Number of firehose events whose DID failed syntactic validation and were dropped from net-new enqueue (e.g. malformed #identity DIDs that are not signature-verified upstream). A rising value indicates upstream relay data quality issues.",
+		}),
 		EnqueueQueueDepth: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: metricsNamespace, Subsystem: metricsSubsystem,
 			Name: "net_new_queue_depth",
@@ -196,7 +202,7 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 		m.RetryPasses, m.RetryCandidates, m.RetryAttempts,
 		m.RetrySucceeded, m.RetryFailed, m.RetrySkippedHostParked,
 		m.EnqueuedNetNew, m.EnqueueAlreadyKnown, m.EnqueueSeenCacheHit,
-		m.EnqueueDropped, m.EnqueueQueueDepth,
+		m.EnqueueDropped, m.EnqueueInvalidDID, m.EnqueueQueueDepth,
 	)
 	return m
 }
@@ -354,6 +360,12 @@ func (m *Metrics) incEnqueueSeenCacheHit() {
 func (m *Metrics) incEnqueueDropped() {
 	if m != nil {
 		m.EnqueueDropped.Inc()
+	}
+}
+
+func (m *Metrics) incEnqueueInvalidDID() {
+	if m != nil {
+		m.EnqueueInvalidDID.Inc()
 	}
 }
 

--- a/internal/ingest/backfill/metrics_test.go
+++ b/internal/ingest/backfill/metrics_test.go
@@ -36,6 +36,11 @@ func TestNewMetrics_RegistersStableMetrics(t *testing.T) {
 	m.incRetrySucceeded()
 	m.incRetryFailed()
 	m.incRetrySkippedHostParked()
+	m.incEnqueuedNetNew()
+	m.incEnqueueAlreadyKnown()
+	m.incEnqueueSeenCacheHit()
+	m.incEnqueueDropped()
+	m.setEnqueueQueueDepth(7)
 
 	require.InDelta(t, 1.0, testutil.ToFloat64(m.Discovered), 0)
 	require.InDelta(t, 1.0, testutil.ToFloat64(m.Completed), 0)
@@ -58,6 +63,11 @@ func TestNewMetrics_RegistersStableMetrics(t *testing.T) {
 	require.InDelta(t, 1.0, testutil.ToFloat64(m.RetrySucceeded), 0)
 	require.InDelta(t, 1.0, testutil.ToFloat64(m.RetryFailed), 0)
 	require.InDelta(t, 1.0, testutil.ToFloat64(m.RetrySkippedHostParked), 0)
+	require.InDelta(t, 1.0, testutil.ToFloat64(m.EnqueuedNetNew), 0)
+	require.InDelta(t, 1.0, testutil.ToFloat64(m.EnqueueAlreadyKnown), 0)
+	require.InDelta(t, 1.0, testutil.ToFloat64(m.EnqueueSeenCacheHit), 0)
+	require.InDelta(t, 1.0, testutil.ToFloat64(m.EnqueueDropped), 0)
+	require.InDelta(t, 7.0, testutil.ToFloat64(m.EnqueueQueueDepth), 0)
 	requireNoDebugMetricFields(t, m)
 	requireNoDebugMetrics(t, reg)
 }
@@ -87,6 +97,11 @@ func TestNewMetrics_NilSafe(t *testing.T) {
 		m.incRetrySucceeded()
 		m.incRetryFailed()
 		m.incRetrySkippedHostParked()
+		m.incEnqueuedNetNew()
+		m.incEnqueueAlreadyKnown()
+		m.incEnqueueSeenCacheHit()
+		m.incEnqueueDropped()
+		m.setEnqueueQueueDepth(1)
 	})
 }
 

--- a/internal/ingest/backfill/metrics_test.go
+++ b/internal/ingest/backfill/metrics_test.go
@@ -40,6 +40,7 @@ func TestNewMetrics_RegistersStableMetrics(t *testing.T) {
 	m.incEnqueueAlreadyKnown()
 	m.incEnqueueSeenCacheHit()
 	m.incEnqueueDropped()
+	m.incEnqueueInvalidDID()
 	m.setEnqueueQueueDepth(7)
 
 	require.InDelta(t, 1.0, testutil.ToFloat64(m.Discovered), 0)
@@ -67,6 +68,7 @@ func TestNewMetrics_RegistersStableMetrics(t *testing.T) {
 	require.InDelta(t, 1.0, testutil.ToFloat64(m.EnqueueAlreadyKnown), 0)
 	require.InDelta(t, 1.0, testutil.ToFloat64(m.EnqueueSeenCacheHit), 0)
 	require.InDelta(t, 1.0, testutil.ToFloat64(m.EnqueueDropped), 0)
+	require.InDelta(t, 1.0, testutil.ToFloat64(m.EnqueueInvalidDID), 0)
 	require.InDelta(t, 7.0, testutil.ToFloat64(m.EnqueueQueueDepth), 0)
 	requireNoDebugMetricFields(t, m)
 	requireNoDebugMetrics(t, reg)
@@ -101,6 +103,7 @@ func TestNewMetrics_NilSafe(t *testing.T) {
 		m.incEnqueueAlreadyKnown()
 		m.incEnqueueSeenCacheHit()
 		m.incEnqueueDropped()
+		m.incEnqueueInvalidDID()
 		m.setEnqueueQueueDepth(1)
 	})
 }

--- a/internal/ingest/backfill/retry.go
+++ b/internal/ingest/backfill/retry.go
@@ -40,6 +40,13 @@ type RetryConfig struct {
 	Logger     *slog.Logger
 	Metrics    *Metrics
 
+	// BackfillStore, when non-nil, is the shared *Store the runner uses for
+	// all metadata reads/writes instead of constructing its own over Store.
+	// The steady-state path injects the same instance the LiveEnqueuer holds
+	// so their counts/host-aggregate read-modify-writes serialize on one
+	// countsMu; two Stores over the same pebble db would race those RMWs.
+	BackfillStore *Store
+
 	Interval    time.Duration
 	Workers     int
 	HostWorkers int
@@ -134,7 +141,10 @@ func newRetryRunner(cfg RetryConfig) (*retryRunner, error) {
 		HTTPClient: gt.Some(cfg.HTTPClient),
 		Retry:      gt.Some(xrpc.RetryPolicy{MaxAttempts: gt.Some(1)}),
 	}
-	st := NewStore(cfg.Store, cfg.Metrics)
+	st := cfg.BackfillStore
+	if st == nil {
+		st = NewStore(cfg.Store, cfg.Metrics)
+	}
 	handler := NewSegmentHandler(cfg.Writer, cfg.Logger, cfg.Metrics)
 	return &retryRunner{
 		cfg:        cfg,
@@ -217,7 +227,12 @@ func (r *retryRunner) scanDue(ctx context.Context, now time.Time, yield func(ret
 		if err != nil {
 			return err
 		}
-		if rs.Backfill.Status != StatusFailed || !rs.Active {
+		// Both failed repos (exhausted bootstrap retry) and pending repos
+		// (net-new DIDs first seen on the steady-state firehose, issue #188)
+		// are retry-eligible: a pending row is a repo we have never attempted
+		// to download, so the same getRepo→verify→complete pass that retries a
+		// failure performs its initial backfill.
+		if !isRetryEligibleStatus(rs.Backfill.Status) || !rs.Active {
 			continue
 		}
 		if !rs.Backfill.NextAttemptAt.IsZero() && rs.Backfill.NextAttemptAt.After(now) {
@@ -386,6 +401,14 @@ func retryFailureHost(candidateHost, responseHost string) string {
 		return candidateHost
 	}
 	return failedRepoRetryUnknownHost
+}
+
+// isRetryEligibleStatus reports whether a repo row should be picked up by a
+// steady-state retry pass. StatusFailed covers repos that exhausted their
+// bootstrap retry budget; StatusPending covers net-new DIDs first observed on
+// the steady-state firehose that have never been downloaded (issue #188).
+func isRetryEligibleStatus(st Status) bool {
+	return st == StatusFailed || st == StatusPending
 }
 
 func isLocalRetryError(err error) bool {

--- a/internal/ingest/backfill/retry_test.go
+++ b/internal/ingest/backfill/retry_test.go
@@ -108,6 +108,151 @@ func TestRetryRunner_ScanDueRejectsCorruptRows(t *testing.T) {
 	require.ErrorContains(t, err, "decode RepoStatus")
 }
 
+func TestRetryRunner_ScanDueIncludesPending(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	now := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+
+	rows := map[atmos.DID]*RepoStatus{
+		// Net-new pending DID with zero NextAttemptAt: immediately due.
+		"did:plc:pending-due": {
+			Backfill: RepoBackfillStatus{Status: StatusPending},
+			Host:     "pds-a.example.com",
+			Active:   true,
+		},
+		// Pending but inactive: skipped like any inactive row.
+		"did:plc:pending-inactive": {
+			Backfill: RepoBackfillStatus{Status: StatusPending},
+			Host:     "pds-b.example.com",
+			Active:   false,
+		},
+		// Pending but deferred into the future (host was parked): skipped.
+		"did:plc:pending-future": {
+			Backfill: RepoBackfillStatus{Status: StatusPending, NextAttemptAt: now.Add(time.Hour)},
+			Host:     "pds-c.example.com",
+			Active:   true,
+		},
+	}
+	for did, rs := range rows {
+		require.NoError(t, s.putRepoStatus(did, rs))
+	}
+
+	r := &retryRunner{cfg: RetryConfig{Store: s.db}}
+	var got []retryCandidate
+	require.NoError(t, r.scanDue(context.Background(), now, func(c retryCandidate) error {
+		got = append(got, c)
+		return nil
+	}))
+
+	require.Equal(t, []retryCandidate{
+		{DID: "did:plc:pending-due", Host: "pds-a.example.com", Retry: 0},
+	}, got)
+}
+
+func TestRetryRunner_PendingNetNewBackfillsToComplete(t *testing.T) {
+	t.Parallel()
+	st, w, segmentsDir := newRetryTestWriter(t)
+	bs := NewStore(st, nil)
+	ctx := context.Background()
+	did := atmos.DID("did:plc:netnew")
+	fixture := buildRepoFixture(t, did)
+	srv := newStubServer(t, map[atmos.DID]repoFixture{did: fixture})
+	now := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+
+	// Simulate the steady-state enqueuer creating a pending row for a net-new
+	// DID first seen on the firehose.
+	created, err := bs.EnqueueNetNewRepo(ctx, did, true)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	r, err := newRetryRunner(RetryConfig{
+		Store:         st,
+		BackfillStore: bs,
+		Writer:        w,
+		HTTPClient:    srv.srv.Client(),
+		RelayURL:      srv.srv.URL,
+		Logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Interval:      time.Hour,
+		Workers:       1,
+		HostWorkers:   1,
+		MaxDelay:      24 * time.Hour,
+		now:           func() time.Time { return now },
+	})
+	require.NoError(t, err)
+	require.NoError(t, r.runPass(ctx))
+
+	// The pending repo is backfilled exactly like a failed-repo retry: a
+	// KindSync tombstone followed by KindCreateResync rows.
+	events := collectActiveEvents(t, filepath.Join(segmentsDir, ingest.SegmentFilename(0)))
+	require.Len(t, events, 2)
+	require.Equal(t, segment.KindSync, events[0].Kind)
+	require.Equal(t, segment.KindCreateResync, events[1].Kind)
+
+	rs, err := bs.readRepoStatus(did)
+	require.NoError(t, err)
+	require.Equal(t, StatusComplete, rs.Backfill.Status)
+
+	// Counts must reflect pending -> complete with no double-counting.
+	counts, ok, err := LoadCounts(st)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint64(1), counts.Total)
+	require.Equal(t, uint64(0), counts.Pending)
+	require.Equal(t, uint64(1), counts.Complete)
+	scanned, scanErr := CountStatuses(st)
+	require.NoError(t, scanErr)
+	require.Equal(t, counts, scanned)
+}
+
+func TestRetryRunner_PendingFailureTransitionsToFailed(t *testing.T) {
+	t.Parallel()
+	st, w, _ := newRetryTestWriter(t)
+	bs := NewStore(st, nil)
+	ctx := context.Background()
+	did := atmos.DID("did:plc:netnewfail")
+	now := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+
+	srv := newStubServer(t, map[atmos.DID]repoFixture{})
+	srv.failGetRepo = map[atmos.DID]bool{did: true}
+	srv.failGetRepoCode = http.StatusServiceUnavailable
+
+	created, err := bs.EnqueueNetNewRepo(ctx, did, true)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	r, err := newRetryRunner(RetryConfig{
+		Store:         st,
+		BackfillStore: bs,
+		Writer:        w,
+		HTTPClient:    srv.srv.Client(),
+		RelayURL:      srv.srv.URL,
+		Logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Interval:      time.Hour,
+		Workers:       1,
+		HostWorkers:   1,
+		MaxDelay:      24 * time.Hour,
+		now:           func() time.Time { return now },
+	})
+	require.NoError(t, err)
+	require.NoError(t, r.runPass(ctx))
+
+	rs, err := bs.readRepoStatus(did)
+	require.NoError(t, err)
+	require.Equal(t, StatusFailed, rs.Backfill.Status, "a pending DID whose getRepo fails becomes failed")
+	require.False(t, rs.Backfill.NextAttemptAt.IsZero(), "failed row should be rescheduled")
+
+	// Counts: pending -> failed, no double count.
+	counts, ok, err := LoadCounts(st)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint64(1), counts.Total)
+	require.Equal(t, uint64(0), counts.Pending)
+	require.Equal(t, uint64(1), counts.Failed)
+	scanned, scanErr := CountStatuses(st)
+	require.NoError(t, scanErr)
+	require.Equal(t, counts, scanned)
+}
+
 func TestRetryRunner_SuccessAppendsResyncAndCompletes(t *testing.T) {
 	t.Parallel()
 	st, w, segmentsDir := newRetryTestWriter(t)

--- a/internal/ingest/backfill/status.go
+++ b/internal/ingest/backfill/status.go
@@ -28,6 +28,18 @@ const (
 	StatusNotStarted Status = "not_started"
 	StatusComplete   Status = "complete"
 	StatusFailed     Status = "failed"
+	// StatusPending is a net-new DID first observed on the steady-state
+	// firehose (issue #188): an account whose events we are now archiving
+	// but whose historical repo we never backfilled (its PDS was
+	// unreachable or private during bootstrap, then became reachable). The
+	// row is created at pending with NextAttemptAt zero so the steady-state
+	// failed-repo retry loop picks it up on its next pass and runs a full
+	// getRepo, reusing the exact same download/verify/complete machinery as
+	// a failed-repo retry. It is distinct from StatusFailed so dashboards do
+	// not conflate "discovered live, never attempted" with repos that
+	// actually failed to download, and distinct from StatusNotStarted, which
+	// is reserved for the bootstrap engine's listRepos discovery.
+	StatusPending Status = "pending"
 	// StatusUnavailable is a terminal, non-failure state: the account
 	// exists but its repo cannot be fetched (deactivated, suspended, or
 	// taken down per com.atproto.sync.getRepo). Unlike StatusFailed it
@@ -110,6 +122,7 @@ type HostStatus struct {
 	Total            uint64                `json:"total"`
 	Active           uint64                `json:"active"`
 	NotStarted       uint64                `json:"not_started"`
+	Pending          uint64                `json:"pending"`
 	Complete         uint64                `json:"complete"`
 	Failed           uint64                `json:"failed"`
 	Unavailable      uint64                `json:"unavailable"`

--- a/internal/ingest/backfill/store.go
+++ b/internal/ingest/backfill/store.go
@@ -78,6 +78,14 @@ func (s *Store) Lookup(_ context.Context, did atmos.DID) (atmosbackfill.StoreEnt
 	switch rs.Backfill.Status {
 	case StatusNotStarted:
 		st = atmosbackfill.StateDiscovered
+	case StatusPending:
+		// Net-new steady-state DID awaiting its first getRepo (issue #188).
+		// atmos has no dedicated "discovered live, retry-eligible" state, so
+		// project to StateFailed: the steady-state retry loop treats failed
+		// and pending rows identically (scanDue selects both), and the atmos
+		// bootstrap engine never sees a pending row — those are only created
+		// after bootstrap, in steady state.
+		st = atmosbackfill.StateFailed
 	case StatusComplete:
 		st = atmosbackfill.StateComplete
 	case StatusFailed:
@@ -119,13 +127,26 @@ func (s *Store) putRepoStatusAndCounts(
 	old Status,
 	updateHost func(*HostStatus),
 ) error {
+	s.countsMu.Lock()
+	defer s.countsMu.Unlock()
+	return s.putRepoStatusAndCountsLocked(did, rs, hadRow, old, updateHost)
+}
+
+// putRepoStatusAndCountsLocked is putRepoStatusAndCounts's body with the
+// caller already holding countsMu. Extracted so callers that must perform a
+// read-check-create atomically (EnqueueNetNewRepo) can hold the lock across
+// the existence check and the write without a TOCTOU window.
+func (s *Store) putRepoStatusAndCountsLocked(
+	did atmos.DID,
+	rs *RepoStatus,
+	hadRow bool,
+	old Status,
+	updateHost func(*HostStatus),
+) error {
 	enc, err := encodeRepoStatus(rs)
 	if err != nil {
 		return err
 	}
-
-	s.countsMu.Lock()
-	defer s.countsMu.Unlock()
 
 	counts, ok, err := LoadCounts(s.db)
 	if err != nil {
@@ -431,6 +452,8 @@ func countBucket(c *Counts, st Status) *uint64 {
 	switch st {
 	case StatusNotStarted:
 		return &c.Discovered
+	case StatusPending:
+		return &c.Pending
 	case StatusComplete:
 		return &c.Complete
 	case StatusFailed:
@@ -690,6 +713,56 @@ func (s *Store) OnDiscover(_ context.Context, entry atmossync.ListReposEntry) er
 	return nil
 }
 
+// EnqueueNetNewRepo durably creates a repo/<did> row at StatusPending for a
+// net-new DID first observed on the steady-state firehose (issue #188), so the
+// failed-repo retry loop performs a full getRepo on its next pass. It is
+// idempotent: if any row already exists for the DID — at any status, including
+// a prior pending/failed/complete/unavailable — it is a no-op and returns
+// (false, nil). The bool reports whether a new pending row was created.
+//
+// The existence check and the create are performed under countsMu so two
+// concurrent observers of the same brand-new DID cannot both create a row (and
+// double-count it). NextAttemptAt is left zero so the row is immediately due.
+//
+// This is intentionally NOT part of the atmos bootstrap Store contract: during
+// bootstrap a DID that first appears mid-sweep is still enumerated later in the
+// same listRepos pagination, so the bootstrap engine discovers it correctly via
+// OnDiscover. The net-new gap only exists in steady state, after the listRepos
+// sweep has completed, which is the only phase this method is wired into.
+func (s *Store) EnqueueNetNewRepo(ctx context.Context, did atmos.DID, active bool) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+
+	s.countsMu.Lock()
+	defer s.countsMu.Unlock()
+
+	existing, err := s.readRepoStatus(did)
+	if err != nil {
+		return false, err
+	}
+	if existing != nil {
+		// Already known — the firehose seen-cache missed (eviction or cold
+		// start), but the durable row is the source of truth. No-op.
+		s.metrics.incEnqueueAlreadyKnown()
+		return false, nil
+	}
+
+	now := timeNow()
+	rs := &RepoStatus{
+		Backfill: RepoBackfillStatus{
+			Status:    StatusPending,
+			StartedAt: now,
+		},
+		Active: active,
+	}
+	if err := s.putRepoStatusAndCountsLocked(did, rs, false, "", nil); err != nil {
+		return false, err
+	}
+	s.metrics.incEnqueuedNetNew()
+	return true, nil
+}
+
 // OnUpdate flips the Active flag on an existing row. The lifecycle
 // Status is preserved — atmos fires OnUpdate only when the
 // listRepos.Active value differs from what the Store last saw, and
@@ -891,7 +964,12 @@ func (s *Store) RecordRetryFailure(ctx context.Context, did atmos.DID, host stri
 		if !hadRow {
 			return nil, fmt.Errorf("backfill: retry failure %s: missing row", did)
 		}
-		if old != StatusFailed {
+		// Guard against a concurrent terminal transition (e.g. a completion
+		// that raced this attempt): only record a failure for a row still in a
+		// retry-eligible state. A pending row (net-new DID, issue #188) whose
+		// first getRepo fails transitions pending->failed here, after which it
+		// is retried on the failed-repo cadence like any other failure.
+		if !isRetryEligibleStatus(old) {
 			return nil, nil
 		}
 		rs.Backfill.Status = StatusFailed
@@ -921,10 +999,12 @@ func (s *Store) RecordRetryFailure(ctx context.Context, did atmos.DID, host stri
 	return nil
 }
 
-// DeferRetryAttempt persists host-level backpressure for a due failed repo
-// that was not actually attempted because another repo on the same host
-// received a rate-limit response. It intentionally does not increment
-// Attempts, RetryCount, LastAttemptedAt, or host error samples.
+// DeferRetryAttempt persists host-level backpressure for a due retry-eligible
+// repo (failed, or pending per issue #188) that was not actually attempted
+// because another repo on the same host received a rate-limit response. It
+// intentionally does not increment Attempts, RetryCount, LastAttemptedAt, or
+// host error samples — the repo keeps its current status and is simply
+// rescheduled past the host's parked-until instant.
 func (s *Store) DeferRetryAttempt(ctx context.Context, did atmos.DID, nextAttemptAt time.Time) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -940,7 +1020,7 @@ func (s *Store) DeferRetryAttempt(ctx context.Context, did atmos.DID, nextAttemp
 	if rs == nil {
 		return fmt.Errorf("backfill: defer retry %s: missing row", did)
 	}
-	if rs.Backfill.Status != StatusFailed {
+	if !isRetryEligibleStatus(rs.Backfill.Status) {
 		return nil
 	}
 	next := nextAttemptAt.UTC()

--- a/internal/ingest/backfill/store.go
+++ b/internal/ingest/backfill/store.go
@@ -734,6 +734,17 @@ func (s *Store) EnqueueNetNewRepo(ctx context.Context, did atmos.DID, active boo
 		return false, err
 	}
 
+	// Reject a DID we cannot round-trip through ParseDID before it becomes a
+	// durable row. The steady-state firehose only signature-verifies #commit
+	// and #sync events; #identity events (and #account verification failures)
+	// flow through to the enqueuer unverified, so a malformed upstream DID can
+	// reach here. scanDue ParseDIDs every repo/ key on each retry pass, so a
+	// persisted unparseable key would otherwise wedge the whole retry loop
+	// (and survive restarts). Drop it at the durable boundary instead.
+	if _, err := atmos.ParseDID(string(did)); err != nil {
+		return false, fmt.Errorf("backfill: enqueue net-new repo %q: invalid DID: %w", did, err)
+	}
+
 	s.countsMu.Lock()
 	defer s.countsMu.Unlock()
 

--- a/internal/ingest/orchestrator/orchestrator_test.go
+++ b/internal/ingest/orchestrator/orchestrator_test.go
@@ -82,6 +82,55 @@ func TestRun_EndToEnd_BootstrapToSteadyState(t *testing.T) {
 	}
 }
 
+// TestRun_SteadyState_WithNetNewEnqueuerWired exercises the steady-state path
+// with FailedRepoRetryInterval set, which is what activates the net-new DID
+// enqueuer (issue #188): its construction, the background worker goroutine, and
+// the OnEvent-wrapping hot-path hook. The fake relay emits no firehose events,
+// so this asserts the wiring stands up and tears down cleanly rather than the
+// enqueue behavior itself (covered by backfill unit tests).
+func TestRun_SteadyState_WithNetNewEnqueuerWired(t *testing.T) {
+	t.Parallel()
+
+	dataDir := t.TempDir()
+	st, err := store.Open(dataDir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	relay := newFakeRelay(t, nil)
+	verifier := newTestVerifier(t, relay.URL())
+
+	o, err := New(Config{
+		DataDir:                 dataDir,
+		Store:                   st,
+		RelayURL:                relay.URL(),
+		HTTPClient:              &http.Client{Timeout: 5 * time.Second},
+		Directory:               testIdentityDirectory(),
+		Verifier:                verifier,
+		Logger:                  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		FailedRepoRetryInterval: time.Hour,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	done := make(chan error, 1)
+	go func() { done <- o.Run(ctx) }()
+
+	require.Eventually(t, func() bool {
+		got, err := lifecycle.ReadPhase(st)
+		return err == nil && got == lifecycle.PhaseSteadyState
+	}, 10*time.Second, 50*time.Millisecond, "phase did not reach steady_state")
+
+	cancel()
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after cancel")
+	}
+}
+
 func TestRun_BarrierAfterBootstrapBlocksBeforeMerge(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ingest/orchestrator/steady.go
+++ b/internal/ingest/orchestrator/steady.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bluesky-social/jetstream/internal/ingest/backfill"
 	"github.com/bluesky-social/jetstream/internal/ingest/live"
 	"github.com/bluesky-social/jetstream/internal/obs"
+	"github.com/bluesky-social/jetstream/segment"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -53,6 +54,43 @@ func (o *Orchestrator) runSteadyState(ctx context.Context) error {
 			tombstoneCap = 0
 		}
 
+		// Net-new DID backfill (issue #188). A DID can first appear on the
+		// firehose in steady state that we never backfilled — e.g. a PDS that
+		// was unreachable during the bootstrap listRepos sweep becomes
+		// reachable and replays its backlog. We enqueue a StatusPending repo
+		// row for it so the failed-repo retry loop performs a full getRepo.
+		//
+		// This is wired ONLY in steady state, and only when that retry loop is
+		// enabled (it is what drains pending rows). During bootstrap the gap
+		// does not exist: a DID that first appears mid-sweep is still
+		// enumerated later in the same listRepos pagination, so the backfill
+		// engine discovers it correctly there.
+		//
+		// The enqueuer and the retry runner share ONE *backfill.Store so their
+		// counts/host-aggregate read-modify-writes serialize on a single
+		// countsMu. Two Stores over the same pebble db would race those RMWs
+		// and corrupt the aggregates.
+		var enqueuer *backfill.LiveEnqueuer
+		var backfillStore *backfill.Store
+		onEvent := o.cfg.OnEvent
+		if o.cfg.FailedRepoRetryInterval > 0 {
+			backfillStore = backfill.NewStore(o.cfg.Store, o.cfg.BackfillMetrics)
+			enqueuer = backfill.NewLiveEnqueuer(backfill.LiveEnqueuerConfig{
+				Store:   backfillStore,
+				Metrics: o.cfg.BackfillMetrics,
+				Logger:  o.cfg.Logger,
+			})
+			downstream := o.cfg.OnEvent
+			onEvent = func(ev *segment.Event) {
+				// Observe is non-blocking and pebble-free; safe to run inline on
+				// the live consumer's per-event hot path before fan-out.
+				enqueuer.Observe(ev.DID)
+				if downstream != nil {
+					downstream(ev)
+				}
+			}
+		}
+
 		c, err := live.Open(live.Config{
 			SegmentsDir: segmentsDir,
 			Store:       o.cfg.Store,
@@ -69,7 +107,7 @@ func (o *Orchestrator) runSteadyState(ctx context.Context) error {
 			TombstoneCap:      tombstoneCap,
 			CompactionTrigger: o.compactionTrigger,
 			SegmentMetrics:    o.cfg.SegmentMetrics,
-			OnEvent:           o.cfg.OnEvent,
+			OnEvent:           onEvent,
 			OnAfterSeal:       o.cfg.IngestOnAfterSeal,
 			ReconnectBackoff:  o.cfg.LiveReconnectBackoff,
 			Dial:              o.cfg.LiveDial,
@@ -106,17 +144,28 @@ func (o *Orchestrator) runSteadyState(ctx context.Context) error {
 		if o.cfg.FailedRepoRetryInterval > 0 {
 			g.Go(func() error {
 				err := backfill.RunFailedRepoRetry(gctx, backfill.RetryConfig{
-					Store:       o.cfg.Store,
-					Writer:      c.Writer(),
-					HTTPClient:  o.cfg.HTTPClient,
-					RelayURL:    o.cfg.RelayURL,
-					Logger:      o.cfg.Logger,
-					Metrics:     o.cfg.BackfillMetrics,
-					Interval:    o.cfg.FailedRepoRetryInterval,
-					Workers:     o.cfg.FailedRepoRetryWorkers,
-					HostWorkers: o.cfg.FailedRepoRetryHostWorkers,
-					MaxDelay:    o.cfg.FailedRepoRetryMaxDelay,
+					Store:         o.cfg.Store,
+					BackfillStore: backfillStore,
+					Writer:        c.Writer(),
+					HTTPClient:    o.cfg.HTTPClient,
+					RelayURL:      o.cfg.RelayURL,
+					Logger:        o.cfg.Logger,
+					Metrics:       o.cfg.BackfillMetrics,
+					Interval:      o.cfg.FailedRepoRetryInterval,
+					Workers:       o.cfg.FailedRepoRetryWorkers,
+					HostWorkers:   o.cfg.FailedRepoRetryHostWorkers,
+					MaxDelay:      o.cfg.FailedRepoRetryMaxDelay,
 				})
+				if errors.Is(err, context.Canceled) {
+					return nil
+				}
+				return err
+			})
+
+			// Background worker that drains net-new DID candidates from the
+			// firehose hot path and durably enqueues them (issue #188).
+			g.Go(func() error {
+				err := enqueuer.Run(gctx)
 				if errors.Is(err, context.Canceled) {
 					return nil
 				}

--- a/internal/status/collect.go
+++ b/internal/status/collect.go
@@ -106,6 +106,7 @@ func collectBackfill(s *store.Store) (BackfillStats, error) {
 	return BackfillStats{
 		TotalDIDs:       counts.Total,
 		Discovered:      counts.Discovered,
+		Pending:         counts.Pending,
 		Complete:        counts.Complete,
 		Failed:          counts.Failed,
 		Unavailable:     counts.Unavailable,
@@ -140,6 +141,7 @@ func collectBackfillFast(s *store.Store) (BackfillStats, error) {
 	return BackfillStats{
 		TotalDIDs:       counts.Total,
 		Discovered:      counts.Discovered,
+		Pending:         counts.Pending,
 		Complete:        counts.Complete,
 		Failed:          counts.Failed,
 		Unavailable:     counts.Unavailable,
@@ -240,6 +242,7 @@ func hostRowFromBackfill(hs *backfill.HostStatus) HostRow {
 		Total:            hs.Total,
 		Active:           hs.Active,
 		NotStarted:       hs.NotStarted,
+		Pending:          hs.Pending,
 		Complete:         hs.Complete,
 		Failed:           hs.Failed,
 		Unavailable:      hs.Unavailable,

--- a/internal/status/snapshot.go
+++ b/internal/status/snapshot.go
@@ -54,6 +54,7 @@ type PhaseInfo struct {
 type BackfillStats struct {
 	TotalDIDs       uint64
 	Discovered      uint64
+	Pending         uint64
 	Complete        uint64
 	Failed          uint64
 	Unavailable     uint64
@@ -76,6 +77,7 @@ type HostRow struct {
 	Total            uint64
 	Active           uint64
 	NotStarted       uint64
+	Pending          uint64
 	Complete         uint64
 	Failed           uint64
 	Unavailable      uint64

--- a/internal/web/templates/status.html
+++ b/internal/web/templates/status.html
@@ -271,6 +271,7 @@ document.addEventListener("input", function (event) {
         <dl>
           <dt>Discovered</dt><dd>{{humanInt .Backfill.TotalDIDs}} repos</dd>
           <dt>Downloaded</dt><dd>{{humanInt .Backfill.Complete}} repos</dd>
+          <dt>Pending</dt><dd>{{humanInt .Backfill.Pending}} repos</dd>
           <dt>Errored</dt><dd>{{humanInt .Backfill.Failed}} repos</dd>
           <dt>Unavailable</dt><dd>{{humanInt .Backfill.Unavailable}} repos</dd>
           {{template "backfillDuration" .}}


### PR DESCRIPTION
Closes #188.

## Problem

During steady state a repo can first appear on the firehose that we never backfilled — e.g. its PDS was firewalled during the bootstrap `listRepos` sweep and only later starts replaying, so the first event we see is #101 having missed #1–100. We archive the live events but are missing the account's history.

## Approach

Detect those DIDs and schedule a full `getRepo`, **reusing the existing failed-repo retry loop** rather than building a parallel download path.

- New `StatusPending` lifecycle state ("discovered live, never attempted, retry-eligible"), kept distinct from `StatusFailed` so dashboards don't conflate the two. Threaded through counts, host aggregates, `Lookup`, the status page, and docs.
- `Store.EnqueueNetNewRepo`: idempotent create-at-pending, atomic under `countsMu` so concurrent observers can't double-count; rejects malformed DIDs at the durable boundary so an unparseable `repo/` key can't wedge the retry scan.
- `LiveEnqueuer`: lock-free last-DID fast path absorbs `#sync` replay bursts (millions/sec, one DID), a bounded sharded-LRU seen cache covers recently-seen distinct DIDs, and a bounded channel feeds a single background worker — so the firehose hot path never touches pebble.
- Wired into **steady state only**, sharing one `*backfill.Store` between the enqueuer and retry runner to serialize aggregate read-modify-writes. During bootstrap the gap doesn't exist: a DID appearing mid-sweep still turns up later in the same `listRepos` pagination.

## Notes

- The retry path treats `StatusPending` and `StatusFailed` identically, downloading over the usual `getRepo` → verify → whole-repo-`#sync`-replacement path.
- Accepted limitation (documented in `enqueue.go`): `Observe` is async/pebble-free, so a net-new DID emitting exactly one event inside a crash window is unrecoverable; any multi-event DID self-heals. We accept this over a synchronous pebble write at firehose rate.
- Second commit applies fixes from an adversarial review (failed-enqueue retry suppression, malformed-DID handling at both layers).

## Testing

- Unit tests for the LRU cache, burst collapse, channel-full drop, idempotency, concurrent same-DID creation, and malformed-DID rejection.
- Retry-integration tests: `scanDue` picks up pending rows, pending→complete end-to-end, pending→failed transition.
- Orchestrator wiring test exercises the steady-state hookup.
- Full suite + `go vet` clean; backfill and orchestrator packages pass under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)