### PR TITLE
subscribe: close cold-read rotation seam in WalkFromCursor

### DIFF
--- a/internal/subscribe/export_test.go
+++ b/internal/subscribe/export_test.go
@@ -1,0 +1,10 @@
+package subscribe
+
+// WithSeamRetryObserver returns a copy of input with an observer that fires
+// once per rotation-seam convergence retry, carrying the seq at which the hole
+// was observed. Test-only: it exposes the unexported onSeamRetry hook to
+// external (subscribe_test) tests so they can assert the retry path is taken.
+func WithSeamRetryObserver(input WalkInput, fn func(holeSeq uint64)) WalkInput {
+	input.onSeamRetry = fn
+	return input
+}

--- a/internal/subscribe/replay.go
+++ b/internal/subscribe/replay.go
@@ -31,6 +31,14 @@ type WalkInput struct {
 	// BlockCache, when non-nil, serves sealed-block decodes through the shared
 	// cache instead of decoding directly. Optional; nil preserves direct decode.
 	BlockCache *blockCache
+
+	// onSeamRetry, when non-nil, is invoked once for each rotation-seam
+	// convergence retry (i.e. each time the active region reports a hole and
+	// the walk re-enters the sealed sweep to fill it). Optional; used by
+	// tests to assert the retry path is exercised, and a natural hook point
+	// for a future operator metric counting how often the cold-read seam is
+	// hit. It carries the seq at which the hole was observed.
+	onSeamRetry func(holeSeq uint64)
 }
 
 // WalkFromCursor invokes emit for every durable event with
@@ -46,73 +54,239 @@ type WalkInput struct {
 // Pure-function design: WalkFromCursor holds no subscriber state. The
 // bounded cold reader (NewColdReader) composes it with a batch limit and
 // the shared block cache to serve Tail's cold-path reads.
+//
+// # Rotation-seam convergence
+//
+// The three sources are read non-atomically: sealed segments come from the
+// manifest (under the manifest lock), the active region from the writer
+// (under the writer lock). A segment rotation completing BETWEEN the sealed
+// read and the active read used to drop a whole segment's seq range. The
+// rotation (ingest.Writer.rotateLocked) does, all under the writer lock:
+//
+//	seal(N) -> publish N to the manifest -> activeIdx = N+1
+//
+// So a walker could snapshot the manifest BEFORE N was published (its sealed
+// loop sees nothing at/after the cursor and stops), then read the active
+// region AFTER the rotation (activeIdx already N+1) — leaving N reachable via
+// neither source. The old code then emitted N+1's events (all above the
+// cursor), jumping PAST N's seq range and silently dropping it. See issue #190.
+//
+// Two properties close the seam:
+//
+//   - Strict contiguity (correctness / no silent loss): the active region
+//     never emits an event whose Seq is ABOVE the running cursor. The instant
+//     it sees a hole (the next available event is past `current`), it stops.
+//     A walk therefore emits a gap-free prefix and the caller's cursor lands
+//     exactly at the hole — the skipped range is re-fetched on the next read,
+//     never jumped over. This holds even if the loop below did nothing.
+//
+//   - Convergence (seamlessness / no spurious disconnect): on a detected hole
+//     we re-enter the sealed sweep from `current` and retry. This fills the
+//     hole within the same call instead of forcing a caller re-invocation
+//     (which, at a hot-ring miss, would surface as a disconnect). It is sound
+//     and bounded because:
+//
+//   - rotateLocked publishes N to the manifest BEFORE bumping activeIdx,
+//     so once this goroutine has observed activeIdx >= N+1 (which a hole
+//     implies — the active file sits above the hole), a SUBSEQUENT
+//     manifest read in the same goroutine is guaranteed to contain N.
+//     The retry's sealed sweep therefore fills exactly the missed
+//     segment(s) and `current` strictly advances.
+//
+//   - events are only ever MOVED active->sealed, never deleted from under
+//     the cursor (compaction preserves each segment's historical seq
+//     envelope), so a hole is always fillable, never a true void.
+//     Because each retry that observed a hole must strictly advance `current`
+//     on its successor pass, two consecutive holes with no advance is an
+//     invariant violation (e.g. the publish-before-bump ordering broke); we
+//     surface that loudly rather than spin.
 func WalkFromCursor(ctx context.Context, input WalkInput, emit func(*segment.Event) error) error {
 	current := input.StartSeq
 
-	// 1. Sealed segments.
-	if input.Manifest != nil {
-		if err := input.Manifest.Wait(ctx); err != nil {
+	if input.Manifest == nil {
+		// No sealed segments to race against: read the active region once,
+		// leniently (there is no manifest that could later fill a hole, so
+		// stopping at one would just wedge the caller). This preserves the
+		// documented nil-manifest contract.
+		_, _, err := walkActiveRegion(input, current, false, emit)
+		return err
+	}
+
+	if err := input.Manifest.Wait(ctx); err != nil {
+		return err
+	}
+
+	noAdvanceHoles := 0
+	for {
+		if err := ctx.Err(); err != nil {
 			return err
 		}
-		for {
-			if err := ctx.Err(); err != nil {
-				return err
+		passStart := current
+
+		// 1. Sealed segments.
+		next, err := walkSealedRegion(ctx, input, current, emit)
+		if err != nil {
+			return err
+		}
+		current = next
+
+		// 2. Active segment's flushed blocks + 3. pending in-memory block.
+		// activeIdx is read fresh inside walkActiveRegion each pass, so a
+		// rotation since the last pass moves us onto the new active file and
+		// the just-sealed file is recovered by the next sealed sweep.
+		next, hole, err := walkActiveRegion(input, current, true, emit)
+		if err != nil {
+			return err
+		}
+		current = next
+
+		if !hole {
+			return nil
+		}
+
+		// A hole was detected: the active region sits above an unfilled gap.
+		// Retry the sealed sweep, which (per the happens-before above) now
+		// sees the freshly-published segment(s).
+		if input.onSeamRetry != nil {
+			input.onSeamRetry(current)
+		}
+		if current == passStart {
+			noAdvanceHoles++
+			if noAdvanceHoles >= 2 {
+				// We retried after observing a hole and STILL neither swept
+				// past it nor advanced. The publish-before-bump invariant
+				// guarantees a post-hole manifest read contains the missing
+				// segment, so this should be unreachable; crash loud rather
+				// than spin (CLAUDE.md: crashing > corruption/hangs).
+				return fmt.Errorf("subscribe: walk did not converge at seq %d "+
+					"(rotation seam invariant violated)", current)
 			}
-			bounds, ok := input.Manifest.SegmentForSeq(current)
-			if !ok {
-				break
+		} else {
+			noAdvanceHoles = 0
+		}
+	}
+}
+
+// walkSealedRegion emits every event with Seq >= start that resides in the
+// manifest's sealed segments, in seq order, and returns the next unemitted
+// seq. Only invoked when input.Manifest != nil.
+func walkSealedRegion(ctx context.Context, input WalkInput, start uint64, emit func(*segment.Event) error) (uint64, error) {
+	current := start
+	for {
+		if err := ctx.Err(); err != nil {
+			return current, err
+		}
+		bounds, ok := input.Manifest.SegmentForSeq(current)
+		if !ok {
+			return current, nil
+		}
+		next, err := walkSealedSegment(input.Manifest, bounds, current, input.BlockCache, emit)
+		if err != nil {
+			return current, err
+		}
+		if next <= bounds.MaxSeq {
+			// The segment was fully scanned and emitted nothing at or
+			// above next. Compaction preserves a segment's historical seq
+			// envelope while dropping rows, so the trailing seqs up to
+			// bounds.MaxSeq may simply no longer exist; without this bump
+			// SegmentForSeq would return the same segment forever and the
+			// walk would spin.
+			next = bounds.MaxSeq + 1
+		}
+		current = next
+	}
+}
+
+// walkActiveRegion emits events with Seq >= start from the active segment's
+// flushed blocks and then its in-memory pending block, in seq order, and
+// returns the next unemitted seq.
+//
+// When strict is true it enforces contiguity: it emits only events whose Seq
+// equals the running cursor, and stops at the first event ABOVE the cursor
+// (a hole), reporting hole=true. The caller fills the hole from the manifest
+// and retries. When strict is false (nil-manifest callers, who have no
+// manifest that could ever fill a hole) it emits every event >= the cursor,
+// matching the legacy lenient contract; hole is always false.
+//
+// A concurrent seal of the active file is benign: segment.Seal only appends
+// the footer and patches the fixed header, never rewriting the frame region,
+// so the flushed frames stay byte-intact. If WalkActive runs past them into
+// footer bytes it fails loud (the footer's leading bytes don't decode as a
+// zstd frame) and emits nothing partial; that error propagates here and the
+// subscriber reconnects, by which point the file is a normal sealed segment
+// the sealed sweep will serve. See segment/walkactive_seal_test.go.
+func walkActiveRegion(input WalkInput, start uint64, strict bool, emit func(*segment.Event) error) (next uint64, hole bool, err error) {
+	current := start
+
+	// emitErr captures an error returned by the CALLER's emit (including the
+	// cold reader's errBatchFull control signal). It is kept distinct from a
+	// WalkActive I/O/decode error so the former propagates verbatim while only
+	// the latter is wrapped as "walk active". WalkActive's callback signals
+	// "stop now" via errStopWalk regardless of which case fired.
+	var emitErr error
+
+	// emitOne applies the skip/emit/hole decision for a single event, setting
+	// emitErr (and returning stop=true) on a caller emit error, or setting
+	// hole (and stop=true) at a strict-contiguity gap.
+	emitOne := func(ev *segment.Event) (stop bool) {
+		switch {
+		case ev.Seq < current:
+			return false // already emitted or below start
+		case strict && ev.Seq > current:
+			hole = true
+			return true // halt at the hole; caller fills it
+		default:
+			cp := *ev
+			if e := emit(&cp); e != nil {
+				emitErr = e
+				return true
 			}
-			next, err := walkSealedSegment(input.Manifest, bounds, current, input.BlockCache, emit)
-			if err != nil {
-				return err
-			}
-			if next <= bounds.MaxSeq {
-				// The segment was fully scanned and emitted nothing at
-				// or above next. Compaction preserves a segment's
-				// historical seq envelope while dropping rows, so the
-				// trailing seqs up to bounds.MaxSeq may simply no
-				// longer exist; without this bump SegmentForSeq would
-				// return the same segment forever and the walk would
-				// spin.
-				next = bounds.MaxSeq + 1
-			}
-			current = next
+			current = ev.Seq + 1
+			return false
 		}
 	}
 
-	// 2. Active segment's flushed blocks.
 	activeIdx := input.Writer.ActiveIndex()
 	activePath := filepath.Join(input.Writer.SegmentsDir(), ingest.SegmentFilename(activeIdx))
 	walkErr := segment.WalkActive(activePath, func(events []segment.Event) error {
 		for i := range events {
-			if events[i].Seq < current {
-				continue
+			if emitOne(&events[i]) {
+				return errStopWalk
 			}
-			ev := events[i]
-			if err := emit(&ev); err != nil {
-				return err
-			}
-			current = events[i].Seq + 1
 		}
 		return nil
 	})
-	if walkErr != nil && !errors.Is(walkErr, os.ErrNotExist) {
-		return fmt.Errorf("walk active: %w", walkErr)
+	switch {
+	case emitErr != nil:
+		// Caller's emit error/control signal: propagate verbatim.
+		return current, hole, emitErr
+	case errors.Is(walkErr, errStopWalk):
+		// Strict hole inside the flushed region: do not read pending — it
+		// only sits ABOVE the flushed tail, so it cannot fill a hole below.
+		return current, hole, nil
+	case walkErr != nil && !errors.Is(walkErr, os.ErrNotExist):
+		return current, hole, fmt.Errorf("walk active: %w", walkErr)
 	}
 
-	// 3. Pending in-memory block.
+	// Pending in-memory block (only reached when the flushed walk did not
+	// hit a hole).
 	pending := input.Writer.SnapshotPending()
 	for i := range pending {
-		if pending[i].Seq < current {
-			continue
+		if emitOne(&pending[i]) {
+			// stop: either a caller emit error (propagate) or a strict hole
+			// (current/hole already set). Either way, halt the pending scan.
+			if emitErr != nil {
+				return current, hole, emitErr
+			}
+			break
 		}
-		if err := emit(&pending[i]); err != nil {
-			return err
-		}
-		current = pending[i].Seq + 1
 	}
-	return nil
+	return current, hole, nil
 }
+
+// errStopWalk is an internal sentinel used to halt segment.WalkActive at a
+// strict-contiguity hole. It never escapes walkActiveRegion.
+var errStopWalk = errors.New("subscribe: stop active walk at hole")
 
 func decodeSealedBlock(cache *blockCache, segIdx uint64, blockIdx int, r *segment.Reader) ([]segment.Event, error) {
 	if cache == nil {

--- a/internal/subscribe/replay.go
+++ b/internal/subscribe/replay.go
@@ -33,8 +33,9 @@ type WalkInput struct {
 	BlockCache *blockCache
 
 	// onSeamRetry, when non-nil, is invoked once for each rotation-seam
-	// convergence retry (i.e. each time the active region reports a hole and
-	// the walk re-enters the sealed sweep to fill it). Optional; used by
+	// convergence retry (i.e. each time the active region reports a hole — or
+	// an empty active successor leaves a sub-tip gap — and the walk re-enters
+	// the sealed sweep to fill it). Optional; used by
 	// tests to assert the retry path is exercised, and a natural hook point
 	// for a future operator metric counting how often the cold-read seam is
 	// hit. It carries the seq at which the hole was observed.
@@ -81,7 +82,11 @@ type WalkInput struct {
 //     never jumped over. This holds even if the loop below did nothing.
 //
 //   - Convergence (seamlessness / no spurious disconnect): on a detected hole
-//     we re-enter the sealed sweep from `current` and retry. This fills the
+//     we re-enter the sealed sweep from `current` and retry. A hole is either
+//     an in-band gap (the active region saw an event above `current`) or a
+//     sub-tip gap with NO in-band signal: rotation sealed+published N, bumped
+//     activeIdx to N+1, and opened an EMPTY N+1, so the active sweep emits
+//     nothing yet `current < Writer.NextSeq()`. Both retry. This fills the
 //     hole within the same call instead of forcing a caller re-invocation
 //     (which, at a hot-ring miss, would surface as a disconnect). It is sound
 //     and bounded because:
@@ -141,12 +146,31 @@ func WalkFromCursor(ctx context.Context, input WalkInput, emit func(*segment.Eve
 		current = next
 
 		if !hole {
-			return nil
+			// The active region reported no in-band hole, but a rotation can
+			// still have left an UNFILLED gap below the live tip that the
+			// active sweep cannot see: rotateLocked seals+publishes segment N,
+			// bumps activeIdx to N+1, and opens an EMPTY N+1. A walk that read
+			// the manifest before N was published then sees an empty active
+			// successor — it emits nothing and reports hole=false, yet
+			// current still sits at the start of N's range. Returning here
+			// would hand the caller a non-advancing batch (next==cursor) and
+			// disconnect the subscriber even though N is now recoverable from
+			// the manifest. So: if the writer has durably allocated seqs at or
+			// above current, the gap is fillable — treat it as a hole and
+			// retry the sealed sweep, which (per the happens-before below)
+			// now sees the freshly-published segment(s). Only when current has
+			// reached the live tip is the walk genuinely complete.
+			if current >= input.Writer.NextSeq() {
+				return nil
+			}
+			hole = true
 		}
 
-		// A hole was detected: the active region sits above an unfilled gap.
-		// Retry the sealed sweep, which (per the happens-before above) now
-		// sees the freshly-published segment(s).
+		// A hole was detected (either the active region saw an event above
+		// current, or the convergence check above found durable seqs the
+		// active successor could not serve). Retry the sealed sweep, which
+		// (per the happens-before above) now sees the freshly-published
+		// segment(s).
 		if input.onSeamRetry != nil {
 			input.onSeamRetry(current)
 		}

--- a/internal/subscribe/replay.go
+++ b/internal/subscribe/replay.go
@@ -163,7 +163,9 @@ func WalkFromCursor(ctx context.Context, input WalkInput, emit func(*segment.Eve
 			if current >= input.Writer.NextSeq() {
 				return nil
 			}
-			hole = true
+			// Otherwise fall through to the retry: a sub-tip gap the empty
+			// active successor could not serve. (We do not set hole=true —
+			// it is not read again before the next pass reassigns it.)
 		}
 
 		// A hole was detected (either the active region saw an event above

--- a/internal/subscribe/walk_seam_test.go
+++ b/internal/subscribe/walk_seam_test.go
@@ -1,0 +1,601 @@
+package subscribe_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/bluesky-social/jetstream/internal/ingest"
+	"github.com/bluesky-social/jetstream/internal/manifest"
+	"github.com/bluesky-social/jetstream/internal/store"
+	"github.com/bluesky-social/jetstream/internal/subscribe"
+	"github.com/bluesky-social/jetstream/segment"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWalkFromCursor_ConcurrentRotationSeam stresses the hypothesis that
+// WalkFromCursor can silently drop events when ingest rotates/flushes the
+// active segment concurrently, because the walk reads its three sources
+// (sealed manifest, active flushed blocks, in-memory pending) non-atomically.
+//
+// Invariant under test: with strictly contiguous seqs and no compaction, a
+// WalkFromCursor(StartSeq=S) must emit S, S+1, ..., up to some tip with NO
+// holes. Any hole is a dropped durable/pending event.
+//
+// Regression test for the cold-read rotation seam (issue #190), fixed by the
+// convergence loop in WalkFromCursor.
+func TestWalkFromCursor_ConcurrentRotationSeam(t *testing.T) {
+	dir := t.TempDir()
+	segDir := filepath.Join(dir, "segments")
+	require.NoError(t, os.MkdirAll(segDir, 0o755))
+
+	st, err := store.Open(dir, store.NewMetrics(prometheus.NewRegistry()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	// Open the manifest on the (empty) segments dir BEFORE any segment
+	// exists; OnSegmentSealed publishes each segment as ingest seals it.
+	m, err := manifest.Open(manifest.Options{
+		SegmentsDir: segDir,
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	require.NoError(t, err)
+	require.NoError(t, m.Wait(context.Background()))
+
+	// Tiny block + segment thresholds so the writer rotates and flushes
+	// constantly, maximizing the chance of hitting the seam windows.
+	w, err := ingest.Open(ingest.Config{
+		SegmentsDir:       segDir,
+		Store:             st,
+		MaxEventsPerBlock: 4,
+		MaxSegmentBytes:   512, // rotate every few blocks
+		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Metrics:           ingest.NewMetrics(prometheus.NewRegistry()),
+		OnAfterSeal:       m.OnSegmentSealed,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var (
+		wg          sync.WaitGroup
+		appendStop  atomic.Bool
+		highestSeq  atomic.Uint64 // highest seq durably appended (NextSeq-1)
+		walkRuns    atomic.Uint64
+		holeFound   atomic.Bool
+		holeMessage atomic.Pointer[string]
+	)
+
+	// Producer: append contiguous events forever until told to stop.
+	wg.Go(func() {
+		for !appendStop.Load() {
+			ev := segment.Event{
+				IndexedAt:  time.Now().UnixMicro(),
+				Kind:       segment.KindCreate,
+				DID:        "did:plc:seamtest",
+				Collection: "app.bsky.feed.post",
+				Rkey:       "rkey",
+				Rev:        "rev",
+				Payload:    []byte{0xa0},
+			}
+			if err := w.Append(ctx, &ev); err != nil {
+				return
+			}
+			highestSeq.Store(ev.Seq)
+		}
+	})
+
+	// Walkers: repeatedly walk from a trailing cursor that straddles the
+	// sealed -> active boundary and assert contiguity of the emitted seqs.
+	checkWalk := func() {
+		tip := highestSeq.Load()
+		if tip < 2 {
+			return
+		}
+		start := uint64(1)
+		if tip > 96 {
+			start = tip - 96 // straddle several recent segments + active
+		}
+
+		var emitted []uint64
+		err := subscribe.WalkFromCursor(ctx, subscribe.WalkInput{
+			StartSeq: start,
+			Manifest: m,
+			Writer:   w,
+		}, func(ev *segment.Event) error {
+			emitted = append(emitted, ev.Seq)
+			return nil
+		})
+		if err != nil {
+			return // ctx cancel / transient; not the property under test
+		}
+		walkRuns.Add(1)
+
+		for i := 1; i < len(emitted); i++ {
+			// Strictly increasing is a separate invariant; the bug shows
+			// as a forward hole (gap > 1) where the missing seqs exist.
+			if emitted[i] != emitted[i-1]+1 {
+				// Only a hole BELOW a value we know was durably appended
+				// counts: the missing seqs provably existed.
+				if emitted[i-1]+1 <= highestSeq.Load() {
+					msg := fmt.Sprintf(
+						"HOLE: walk(start=%d) emitted ...%v -> %d (skipped %d..%d); writerNextSeq=%d activeIdx=%d",
+						start, tailOf(emitted, i), emitted[i],
+						emitted[i-1]+1, emitted[i]-1,
+						w.NextSeq(), w.ActiveIndex(),
+					)
+					holeMessage.Store(&msg)
+					holeFound.Store(true)
+					return
+				}
+			}
+		}
+	}
+
+	const walkers = 4
+	for range walkers {
+		wg.Go(func() {
+			for !holeFound.Load() {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+				checkWalk()
+			}
+		})
+	}
+
+	// Run for a bounded budget, or stop early once a hole is found.
+	deadline := time.After(20 * time.Second)
+	for {
+		if holeFound.Load() {
+			break
+		}
+		select {
+		case <-deadline:
+			goto done
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+done:
+	appendStop.Store(true)
+	cancel()
+	wg.Wait()
+
+	t.Logf("walk runs completed: %d, highest seq appended: %d, active idx: %d",
+		walkRuns.Load(), highestSeq.Load(), w.ActiveIndex())
+
+	if holeFound.Load() {
+		t.Fatalf("data-loss gap reproduced: %s", *holeMessage.Load())
+	}
+}
+
+// TestWalkFromCursor_RotationSeamDeterministic proves the exact mechanism
+// behind the stress-test failure WITHOUT relying on timing.
+//
+// WalkFromCursor samples its sources in this order:
+//  1. the manifest (sealed segments), then
+//  2. the writer's ActiveIndex() + its flushed/pending events.
+//
+// Between those two reads, ingest's rotateLocked does, all under w.mu:
+//
+//	seal(N) -> OnAfterSeal publishes N to the manifest -> activeIdx = N+1.
+//
+// So a walk can observe the manifest BEFORE N is published (tier 1 sees
+// nothing at/after the cursor and stops) yet observe the writer AFTER the
+// rotation (tier 2 reads activeIdx=N+1, whose events are all > the cursor and
+// get emitted) — segment N is read by neither tier. We reconstruct exactly
+// that torn state: a manifest that has not yet learned about segment N, and a
+// writer that has already rotated to N+1.
+//
+// Regression test for the cold-read rotation seam (issue #190), fixed by the
+// convergence loop in WalkFromCursor.
+func TestWalkFromCursor_RotationSeamDeterministic(t *testing.T) {
+	dir := t.TempDir()
+	segDir := filepath.Join(dir, "segments")
+	require.NoError(t, os.MkdirAll(segDir, 0o755))
+
+	st, err := store.Open(dir, store.NewMetrics(prometheus.NewRegistry()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	// Capture seal callbacks instead of forwarding them to the manifest,
+	// so we can deterministically WITHHOLD the publish of the last segment
+	// — modeling the instant after rotateLocked sealed it but before the
+	// walk's tier-1 manifest read observed it.
+	m, err := manifest.Open(manifest.Options{
+		SegmentsDir: segDir,
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	require.NoError(t, err)
+	require.NoError(t, m.Wait(context.Background()))
+
+	type sealEvent struct {
+		idx  uint64
+		path string
+	}
+	var seals []sealEvent
+	w, err := ingest.Open(ingest.Config{
+		SegmentsDir:       segDir,
+		Store:             st,
+		MaxEventsPerBlock: 4,
+		MaxSegmentBytes:   512,
+		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Metrics:           ingest.NewMetrics(prometheus.NewRegistry()),
+		OnAfterSeal: func(idx uint64, path string) error {
+			seals = append(seals, sealEvent{idx, path})
+			return nil
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	// Append until the writer has rotated several times AND the current
+	// active segment holds events, so there are durable seqs BOTH inside a
+	// middle withheld segment AND above it (later sealed segments + the
+	// active file). That "events exist above the hole" condition is what
+	// makes the pre-fix silent JUMP possible — without it the walk merely
+	// runs dry at the hole.
+	for w.ActiveIndex() < 3 {
+		ev := segment.Event{
+			IndexedAt: time.Now().UnixMicro(), Kind: segment.KindCreate,
+			DID: "did:plc:seam", Collection: "app.bsky.feed.post",
+			Rkey: "r", Rev: "v", Payload: []byte{0xa0},
+		}
+		require.NoError(t, w.Append(context.Background(), &ev))
+	}
+	// Add a few more events into the (now active) segment 3 so the active
+	// file is non-empty: these are the "events above the hole" served from
+	// the active region.
+	for range 3 {
+		ev := segment.Event{
+			IndexedAt: time.Now().UnixMicro(), Kind: segment.KindCreate,
+			DID: "did:plc:seam", Collection: "app.bsky.feed.post",
+			Rkey: "r", Rev: "v", Payload: []byte{0xa0},
+		}
+		require.NoError(t, w.Append(context.Background(), &ev))
+	}
+
+	require.GreaterOrEqual(t, len(seals), 3, "need >= 3 sealed segments")
+
+	// Publish every sealed segment EXCEPT a MIDDLE one (segment 1). The
+	// manifest is missing exactly that middle segment, while segments above
+	// it AND the active file are fully reachable — the torn read in which a
+	// rotation published higher segments but the walk's manifest snapshot
+	// still lacks the gap segment.
+	withheld := seals[1]
+	for _, s := range seals {
+		if s.idx == withheld.idx {
+			continue
+		}
+		require.NoError(t, m.OnSegmentSealed(s.idx, s.path))
+	}
+
+	// Determine the seq range of the withheld segment by reading it.
+	r, err := segment.Open(segment.ReaderConfig{Path: withheld.path})
+	require.NoError(t, err)
+	withheldMin := r.Header().MinSeq
+	withheldMax := r.Header().MaxSeq
+	require.NoError(t, r.Close())
+	t.Logf("withheld MIDDLE segment idx=%d covers seqs [%d..%d]; writer activeIdx=%d nextSeq=%d",
+		withheld.idx, withheldMin, withheldMax, w.ActiveIndex(), w.NextSeq())
+
+	// Walk from a cursor that lands at the start of the withheld segment,
+	// while it stays permanently withheld (an artificial break of the
+	// publish-before-bump invariant). The PRE-FIX bug silently jumped the
+	// gap and emitted the active segment's seqs (> withheldMax). The FIX's
+	// strict contiguity must NEVER emit past the hole; with the manifest
+	// permanently unable to fill it, the bounded convergence guard then
+	// surfaces a loud error rather than silently dropping or spinning.
+	var emitted []uint64
+	err = subscribe.WalkFromCursor(context.Background(), subscribe.WalkInput{
+		StartSeq: withheldMin,
+		Manifest: m,
+		Writer:   w,
+	}, func(ev *segment.Event) error {
+		emitted = append(emitted, ev.Seq)
+		return nil
+	})
+
+	t.Logf("walk(start=%d) err=%v emitted %d events: first=%v", withheldMin, err, len(emitted), firstN(emitted, 8))
+
+	// Safety property: no silent jump. The walk must not emit ANY seq from
+	// the active segment (everything > withheldMax) while the hole at
+	// withheldMin is unfilled. That is the exact data loss issue #190
+	// described.
+	for _, s := range emitted {
+		require.LessOrEqualf(t, s, withheldMax,
+			"SILENT JUMP: walk emitted seq %d past the unfilled hole [%d..%d] (issue #190 regression)",
+			s, withheldMin, withheldMax)
+	}
+
+	// Liveness property: with the gap permanently unfillable, the walk must
+	// terminate loudly (bounded convergence guard), not hang and not return
+	// a clean nil that would hide the drop.
+	require.Error(t, err, "permanently-withheld segment must surface a loud non-convergence error, not silent success")
+	require.Contains(t, err.Error(), "converge")
+}
+
+// TestWalkFromCursor_RotationSeamConverges proves the convergence loop's
+// success path: a segment that is missing from the manifest at walk start but
+// becomes visible DURING the walk is recovered, yielding a gap-free stream.
+// This is the realistic shape of the seam — the rotation's manifest publish
+// lands a moment after the walk began — and exercises the re-sweep that fills
+// the hole instead of dropping it.
+func TestWalkFromCursor_RotationSeamConverges(t *testing.T) {
+	dir := t.TempDir()
+	segDir := filepath.Join(dir, "segments")
+	require.NoError(t, os.MkdirAll(segDir, 0o755))
+
+	st, err := store.Open(dir, store.NewMetrics(prometheus.NewRegistry()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	m, err := manifest.Open(manifest.Options{
+		SegmentsDir: segDir,
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	require.NoError(t, err)
+	require.NoError(t, m.Wait(context.Background()))
+
+	type sealEvent struct {
+		idx  uint64
+		path string
+	}
+	var seals []sealEvent
+	w, err := ingest.Open(ingest.Config{
+		SegmentsDir:       segDir,
+		Store:             st,
+		MaxEventsPerBlock: 4,
+		MaxSegmentBytes:   512,
+		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Metrics:           ingest.NewMetrics(prometheus.NewRegistry()),
+		OnAfterSeal: func(idx uint64, path string) error {
+			seals = append(seals, sealEvent{idx, path})
+			return nil
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	for w.ActiveIndex() < 3 {
+		ev := segment.Event{
+			IndexedAt: time.Now().UnixMicro(), Kind: segment.KindCreate,
+			DID: "did:plc:seam", Collection: "app.bsky.feed.post",
+			Rkey: "r", Rev: "v", Payload: []byte{0xa0},
+		}
+		require.NoError(t, w.Append(context.Background(), &ev))
+	}
+	require.GreaterOrEqual(t, len(seals), 3, "need >= 3 sealed segments")
+
+	// Publish segment 0 immediately; withhold segment 1 (the "gap"). We will
+	// publish segment 1 mid-walk, the first time the emit callback fires, to
+	// model the manifest catching up while the walk is in flight.
+	seg0 := seals[0]
+	seg1 := seals[1]
+	require.NoError(t, m.OnSegmentSealed(seg0.idx, seg0.path))
+	for _, s := range seals[2:] { // publish everything above the gap too
+		require.NoError(t, m.OnSegmentSealed(s.idx, s.path))
+	}
+
+	r, err := segment.Open(segment.ReaderConfig{Path: seg0.path})
+	require.NoError(t, err)
+	seg0Min := r.Header().MinSeq
+	require.NoError(t, r.Close())
+
+	highest := w.NextSeq() - 1
+
+	var published atomic.Bool
+	var emitted []uint64
+	err = subscribe.WalkFromCursor(context.Background(), subscribe.WalkInput{
+		StartSeq: seg0Min,
+		Manifest: m,
+		Writer:   w,
+	}, func(ev *segment.Event) error {
+		// Publish the withheld gap segment exactly once, as soon as the walk
+		// starts producing — the manifest "catches up" mid-walk.
+		if published.CompareAndSwap(false, true) {
+			require.NoError(t, m.OnSegmentSealed(seg1.idx, seg1.path))
+		}
+		emitted = append(emitted, ev.Seq)
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Must be the full contiguous run seg0Min..highest with no holes.
+	require.NotEmpty(t, emitted)
+	require.Equal(t, seg0Min, emitted[0])
+	for i := 1; i < len(emitted); i++ {
+		require.Equalf(t, emitted[i-1]+1, emitted[i],
+			"hole in converged walk at index %d: %v", i, tailOf(emitted, i+1))
+	}
+	require.Equalf(t, highest, emitted[len(emitted)-1],
+		"converged walk stopped short: last emitted %d, highest durable %d", emitted[len(emitted)-1], highest)
+	t.Logf("converged: emitted contiguous [%d..%d] (%d events)", emitted[0], emitted[len(emitted)-1], len(emitted))
+}
+
+// TestWalkFromCursor_SeamRetryFillsHoleViaActiveRegion deterministically drives
+// the ACTIVE-REGION hole -> retry -> sealed-fill path (distinct from the
+// converge test, where tier 1 fills the gap before the active sweep runs).
+//
+// We withhold a middle segment so that on pass 1 the active region reads
+// events ABOVE the gap and reports a hole. The gap segment is published from
+// inside the onSeamRetry hook — i.e. exactly at the moment the walk decides to
+// retry — so the SECOND sealed sweep is what recovers it. This proves the
+// retry mechanic itself fills holes, contiguously, with no jump.
+func TestWalkFromCursor_SeamRetryFillsHoleViaActiveRegion(t *testing.T) {
+	dir := t.TempDir()
+	segDir := filepath.Join(dir, "segments")
+	require.NoError(t, os.MkdirAll(segDir, 0o755))
+
+	st, err := store.Open(dir, store.NewMetrics(prometheus.NewRegistry()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	m, err := manifest.Open(manifest.Options{
+		SegmentsDir: segDir,
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	require.NoError(t, err)
+	require.NoError(t, m.Wait(context.Background()))
+
+	type sealEvent struct {
+		idx  uint64
+		path string
+	}
+	var seals []sealEvent
+	w, err := ingest.Open(ingest.Config{
+		SegmentsDir:       segDir,
+		Store:             st,
+		MaxEventsPerBlock: 4,
+		MaxSegmentBytes:   512,
+		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Metrics:           ingest.NewMetrics(prometheus.NewRegistry()),
+		OnAfterSeal: func(idx uint64, path string) error {
+			seals = append(seals, sealEvent{idx, path})
+			return nil
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	for w.ActiveIndex() < 3 {
+		ev := segment.Event{
+			IndexedAt: time.Now().UnixMicro(), Kind: segment.KindCreate,
+			DID: "did:plc:seam", Collection: "app.bsky.feed.post",
+			Rkey: "r", Rev: "v", Payload: []byte{0xa0},
+		}
+		require.NoError(t, w.Append(context.Background(), &ev))
+	}
+	for range 3 { // non-empty active segment: events above the gap
+		ev := segment.Event{
+			IndexedAt: time.Now().UnixMicro(), Kind: segment.KindCreate,
+			DID: "did:plc:seam", Collection: "app.bsky.feed.post",
+			Rkey: "r", Rev: "v", Payload: []byte{0xa0},
+		}
+		require.NoError(t, w.Append(context.Background(), &ev))
+	}
+	require.GreaterOrEqual(t, len(seals), 3)
+
+	// Publish everything EXCEPT middle segment 1.
+	gap := seals[1]
+	for _, s := range seals {
+		if s.idx != gap.idx {
+			require.NoError(t, m.OnSegmentSealed(s.idx, s.path))
+		}
+	}
+
+	r, err := segment.Open(segment.ReaderConfig{Path: seals[0].path})
+	require.NoError(t, err)
+	startSeq := r.Header().MinSeq
+	require.NoError(t, r.Close())
+	highest := w.NextSeq() - 1
+
+	var retries []uint64
+	input := subscribe.WithSeamRetryObserver(
+		subscribe.WalkInput{StartSeq: startSeq, Manifest: m, Writer: w},
+		func(holeSeq uint64) {
+			retries = append(retries, holeSeq)
+			// Publish the gap segment the first time the walk retries, so the
+			// SECOND sealed sweep recovers it. Idempotent re-publish is safe.
+			require.NoError(t, m.OnSegmentSealed(gap.idx, gap.path))
+		},
+	)
+
+	var emitted []uint64
+	err = subscribe.WalkFromCursor(context.Background(), input, func(ev *segment.Event) error {
+		emitted = append(emitted, ev.Seq)
+		return nil
+	})
+	require.NoError(t, err)
+
+	require.NotEmpty(t, retries, "active-region hole -> retry path was not exercised")
+	t.Logf("seam retries observed at seqs %v; emitted [%d..%d] (%d events)",
+		retries, emitted[0], emitted[len(emitted)-1], len(emitted))
+
+	// Gap-free, full coverage.
+	require.Equal(t, startSeq, emitted[0])
+	for i := 1; i < len(emitted); i++ {
+		require.Equalf(t, emitted[i-1]+1, emitted[i], "hole at index %d: %v", i, tailOf(emitted, i+1))
+	}
+	require.Equal(t, highest, emitted[len(emitted)-1])
+}
+
+// TestWalkFromCursor_NilManifestLenient pins the nil-manifest contract that
+// the convergence restructuring must preserve: with no manifest there are no
+// sealed segments and nothing that could ever fill a hole, so the active
+// region is read leniently (every event >= cursor, no strict-contiguity stop)
+// in a single pass. A strict walk here would wedge: it would stop at the first
+// event above the start cursor and never resume.
+func TestWalkFromCursor_NilManifestLenient(t *testing.T) {
+	dir := t.TempDir()
+	segDir := filepath.Join(dir, "segments")
+	require.NoError(t, os.MkdirAll(segDir, 0o755))
+
+	st, w := openWriterAtTip(t, dir, 1)
+	t.Cleanup(func() { _ = w.Close(); _ = st.Close() })
+
+	// Append events into the active segment, flushing some to disk and
+	// leaving the rest pending, so both the flushed-block and pending paths
+	// are exercised under a nil manifest.
+	const total = 10
+	for range total {
+		ev := segment.Event{
+			IndexedAt: time.Now().UnixMicro(), Kind: segment.KindCreate,
+			DID: "did:plc:nilman", Collection: "app.bsky.feed.post",
+			Rkey: "r", Rev: "v", Payload: []byte{0xa0},
+		}
+		require.NoError(t, w.Append(context.Background(), &ev))
+	}
+	require.NoError(t, w.Flush(context.Background())) // flush some; later appends stay pending
+	for range 4 {
+		ev := segment.Event{
+			IndexedAt: time.Now().UnixMicro(), Kind: segment.KindCreate,
+			DID: "did:plc:nilman", Collection: "app.bsky.feed.post",
+			Rkey: "r", Rev: "v", Payload: []byte{0xa0},
+		}
+		require.NoError(t, w.Append(context.Background(), &ev))
+	}
+	highest := w.NextSeq() - 1
+
+	var emitted []uint64
+	err := subscribe.WalkFromCursor(context.Background(), subscribe.WalkInput{
+		StartSeq: 3, // start mid-stream to confirm the lenient skip below start
+		Manifest: nil,
+		Writer:   w,
+	}, func(ev *segment.Event) error {
+		emitted = append(emitted, ev.Seq)
+		return nil
+	})
+	require.NoError(t, err)
+
+	require.NotEmpty(t, emitted)
+	require.Equal(t, uint64(3), emitted[0])
+	for i := 1; i < len(emitted); i++ {
+		require.Equalf(t, emitted[i-1]+1, emitted[i], "hole in nil-manifest walk at %d: %v", i, tailOf(emitted, i+1))
+	}
+	require.Equalf(t, highest, emitted[len(emitted)-1],
+		"nil-manifest walk stopped short: last %d, highest %d", emitted[len(emitted)-1], highest)
+}
+
+func firstN(s []uint64, n int) []uint64 {
+	if len(s) < n {
+		return s
+	}
+	return s[:n]
+}
+
+func tailOf(s []uint64, i int) []uint64 {
+	return s[max(i-4, 0):i]
+}

--- a/internal/subscribe/walk_seam_test.go
+++ b/internal/subscribe/walk_seam_test.go
@@ -589,6 +589,135 @@ func TestWalkFromCursor_NilManifestLenient(t *testing.T) {
 		"nil-manifest walk stopped short: last %d, highest %d", emitted[len(emitted)-1], highest)
 }
 
+// TestWalkFromCursor_EmptyActiveSuccessorSeam pins the rotation seam variant
+// with NO in-band hole signal: rotation sealed+published segment N, bumped
+// activeIdx to N+1, and opened an EMPTY N+1 with no events yet appended. A walk
+// whose sealed sweep snapshotted the manifest BEFORE N was published stops at
+// the start of N's range, then reads the empty active successor — which emits
+// nothing and reports hole=false because no event sits ABOVE the cursor.
+//
+// The other seam tests all keep the active segment NON-empty (events above the
+// gap drive hole=true); none exercise this empty-successor state. Without the
+// convergence check on Writer.NextSeq(), WalkFromCursor returns here with the
+// cursor unchanged, so ColdReader.Read hands the subscriber loop a
+// non-advancing (next==cursor) batch and handler.go disconnects it — even
+// though N is durable and recoverable from the manifest. This test withholds N,
+// publishes it from the onSeamRetry hook (the only callback that fires, since
+// nothing is emitted on pass 1), and asserts the walk converges to the full
+// contiguous range. Regression test for the cold-read rotation seam (issue
+// #190), empty-active-successor variant.
+func TestWalkFromCursor_EmptyActiveSuccessorSeam(t *testing.T) {
+	dir := t.TempDir()
+	segDir := filepath.Join(dir, "segments")
+	require.NoError(t, os.MkdirAll(segDir, 0o755))
+
+	st, err := store.Open(dir, store.NewMetrics(prometheus.NewRegistry()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	m, err := manifest.Open(manifest.Options{
+		SegmentsDir: segDir,
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	require.NoError(t, err)
+	require.NoError(t, m.Wait(context.Background()))
+
+	type sealEvent struct {
+		idx  uint64
+		path string
+	}
+	var seals []sealEvent
+	w, err := ingest.Open(ingest.Config{
+		SegmentsDir:       segDir,
+		Store:             st,
+		MaxEventsPerBlock: 4,
+		MaxSegmentBytes:   512,
+		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Metrics:           ingest.NewMetrics(prometheus.NewRegistry()),
+		OnAfterSeal: func(idx uint64, path string) error {
+			seals = append(seals, sealEvent{idx, path})
+			return nil
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	// Append until the writer has rotated to active index 3. The append that
+	// triggers each rotation seals the just-filled segment and opens an empty
+	// successor; we stop the instant ActiveIndex first reaches 3, so segment 3
+	// (the active file) holds ZERO events and ZERO pending — the empty
+	// successor this test is about. seals == [0,1,2].
+	for w.ActiveIndex() < 3 {
+		ev := segment.Event{
+			IndexedAt: time.Now().UnixMicro(), Kind: segment.KindCreate,
+			DID: "did:plc:emptyseam", Collection: "app.bsky.feed.post",
+			Rkey: "r", Rev: "v", Payload: []byte{0xa0},
+		}
+		require.NoError(t, w.Append(context.Background(), &ev))
+	}
+	require.GreaterOrEqual(t, len(seals), 3, "need segments 0,1,2 sealed with 3 active+empty")
+	require.Empty(t, w.SnapshotPending(), "active successor must be empty for this seam")
+
+	// Publish segments 0 and 1; WITHHOLD segment 2 (the gap N). The walk's
+	// first sealed sweep therefore stops at the start of segment 2's range,
+	// and the empty active successor (index 3) cannot fill it.
+	require.NoError(t, m.OnSegmentSealed(seals[0].idx, seals[0].path))
+	require.NoError(t, m.OnSegmentSealed(seals[1].idx, seals[1].path))
+	segN := seals[2]
+
+	rN, err := segment.Open(segment.ReaderConfig{Path: segN.path})
+	require.NoError(t, err)
+	segNMin := rN.Header().MinSeq
+	require.NoError(t, rN.Close())
+
+	// With segment 2 the last sealed and the active successor empty, the live
+	// tip is exactly one past segment 2's max.
+	highest := w.NextSeq() - 1
+	require.Greater(t, highest, segNMin, "withheld segment must hold >= 1 event above the start cursor")
+
+	var published atomic.Bool
+	var retries []uint64
+	var emitted []uint64
+	input := subscribe.WithSeamRetryObserver(subscribe.WalkInput{
+		StartSeq: segNMin,
+		Manifest: m,
+		Writer:   w,
+	}, func(holeSeq uint64) {
+		retries = append(retries, holeSeq)
+		// Publish the withheld gap segment exactly once, at the moment the walk
+		// detects the sub-tip gap and decides to retry. This is the ONLY
+		// callback that fires on pass 1 — the empty active emits nothing — so
+		// the seam is invisible to the emit callback the converge test relies
+		// on. A walk that returned at !hole would never reach this hook.
+		if published.CompareAndSwap(false, true) {
+			require.NoError(t, m.OnSegmentSealed(segN.idx, segN.path))
+		}
+	})
+	err = subscribe.WalkFromCursor(context.Background(), input, func(ev *segment.Event) error {
+		emitted = append(emitted, ev.Seq)
+		return nil
+	})
+	require.NoError(t, err)
+
+	// The seam must have been detected with no in-band hole signal: the only
+	// way to observe it is the NextSeq() convergence check.
+	require.NotEmpty(t, retries, "empty-active-successor seam was not detected (no retry fired)")
+
+	// The walk must converge to the full contiguous run [segNMin..highest].
+	// Without the fix, emitted is empty (the walk returns at the unchanged
+	// cursor) and these assertions fail.
+	require.NotEmpty(t, emitted, "walk emitted nothing: empty-active seam dropped the withheld segment")
+	require.Equal(t, segNMin, emitted[0])
+	for i := 1; i < len(emitted); i++ {
+		require.Equalf(t, emitted[i-1]+1, emitted[i],
+			"hole in converged walk at index %d: %v", i, tailOf(emitted, i+1))
+	}
+	require.Equalf(t, highest, emitted[len(emitted)-1],
+		"converged walk stopped short: last emitted %d, highest durable %d", emitted[len(emitted)-1], highest)
+	t.Logf("empty-active seam converged: retries at %v, emitted contiguous [%d..%d] (%d events)",
+		retries, emitted[0], emitted[len(emitted)-1], len(emitted))
+}
+
 func firstN(s []uint64, n int) []uint64 {
 	if len(s) < n {
 		return s

--- a/internal/subscribe/walk_seam_test.go
+++ b/internal/subscribe/walk_seam_test.go
@@ -33,6 +33,7 @@ import (
 // Regression test for the cold-read rotation seam (issue #190), fixed by the
 // convergence loop in WalkFromCursor.
 func TestWalkFromCursor_ConcurrentRotationSeam(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	segDir := filepath.Join(dir, "segments")
 	require.NoError(t, os.MkdirAll(segDir, 0o755))
@@ -67,18 +68,27 @@ func TestWalkFromCursor_ConcurrentRotationSeam(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	// Bound by WORK, not wall-clock: the producer appends until the writer
+	// has rotated targetRotations times, then stops. Each rotation is one
+	// seal->publish->bump->open cycle — exactly the seam window — so a few
+	// hundred of them, hammered concurrently by the walkers, gives dense
+	// coverage and completes in a fraction of a second. (The pre-fix bug
+	// reproduced within the first ~5 rotations, 100% of runs.)
+	const targetRotations = 300
+
 	var (
 		wg          sync.WaitGroup
-		appendStop  atomic.Bool
+		producerErr atomic.Pointer[error]
 		highestSeq  atomic.Uint64 // highest seq durably appended (NextSeq-1)
 		walkRuns    atomic.Uint64
 		holeFound   atomic.Bool
 		holeMessage atomic.Pointer[string]
 	)
 
-	// Producer: append contiguous events forever until told to stop.
+	// Producer: append contiguous events until the writer has rotated
+	// targetRotations times (activeIdx counts rotations, starting at 0).
 	wg.Go(func() {
-		for !appendStop.Load() {
+		for w.ActiveIndex() < targetRotations {
 			ev := segment.Event{
 				IndexedAt:  time.Now().UnixMicro(),
 				Kind:       segment.KindCreate,
@@ -89,6 +99,7 @@ func TestWalkFromCursor_ConcurrentRotationSeam(t *testing.T) {
 				Payload:    []byte{0xa0},
 			}
 			if err := w.Append(ctx, &ev); err != nil {
+				producerErr.Store(&err)
 				return
 			}
 			highestSeq.Store(ev.Seq)
@@ -97,14 +108,18 @@ func TestWalkFromCursor_ConcurrentRotationSeam(t *testing.T) {
 
 	// Walkers: repeatedly walk from a trailing cursor that straddles the
 	// sealed -> active boundary and assert contiguity of the emitted seqs.
+	// The trailing window is kept short (a couple of segments' worth) so each
+	// walk is cheap and many interleave with live rotations rather than a few
+	// long cold scans dominating the run.
+	const trailingWindow = 24 // ~1.5 segments at 16 events/segment
 	checkWalk := func() {
 		tip := highestSeq.Load()
 		if tip < 2 {
 			return
 		}
 		start := uint64(1)
-		if tip > 96 {
-			start = tip - 96 // straddle several recent segments + active
+		if tip > trailingWindow {
+			start = tip - trailingWindow // straddle the active boundary
 		}
 
 		var emitted []uint64
@@ -142,39 +157,33 @@ func TestWalkFromCursor_ConcurrentRotationSeam(t *testing.T) {
 		}
 	}
 
-	const walkers = 4
+	// Walkers run until the producer is done (activeIdx reached the target)
+	// or a hole is found. They keep pace with the producer so walks interleave
+	// with live rotations across the whole run.
+	const walkers = 16
 	for range walkers {
 		wg.Go(func() {
-			for !holeFound.Load() {
-				select {
-				case <-ctx.Done():
+			for !holeFound.Load() && w.ActiveIndex() < targetRotations {
+				if err := ctx.Err(); err != nil {
 					return
-				default:
 				}
 				checkWalk()
 			}
+			// A final sweep after the producer stopped, so a hole created by
+			// the very last rotation is still exercised.
+			checkWalk()
 		})
 	}
 
-	// Run for a bounded budget, or stop early once a hole is found.
-	deadline := time.After(20 * time.Second)
-	for {
-		if holeFound.Load() {
-			break
-		}
-		select {
-		case <-deadline:
-			goto done
-		case <-time.After(20 * time.Millisecond):
-		}
-	}
-done:
-	appendStop.Store(true)
-	cancel()
 	wg.Wait()
+	cancel()
 
-	t.Logf("walk runs completed: %d, highest seq appended: %d, active idx: %d",
+	if perr := producerErr.Load(); perr != nil {
+		require.NoError(t, *perr, "producer append failed")
+	}
+	t.Logf("walk runs completed: %d, highest seq appended: %d, rotations: %d",
 		walkRuns.Load(), highestSeq.Load(), w.ActiveIndex())
+	require.Positive(t, walkRuns.Load(), "no walks ran concurrently with rotations")
 
 	if holeFound.Load() {
 		t.Fatalf("data-loss gap reproduced: %s", *holeMessage.Load())
@@ -202,6 +211,7 @@ done:
 // Regression test for the cold-read rotation seam (issue #190), fixed by the
 // convergence loop in WalkFromCursor.
 func TestWalkFromCursor_RotationSeamDeterministic(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	segDir := filepath.Join(dir, "segments")
 	require.NoError(t, os.MkdirAll(segDir, 0o755))
@@ -334,6 +344,7 @@ func TestWalkFromCursor_RotationSeamDeterministic(t *testing.T) {
 // lands a moment after the walk began — and exercises the re-sweep that fills
 // the hole instead of dropping it.
 func TestWalkFromCursor_RotationSeamConverges(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	segDir := filepath.Join(dir, "segments")
 	require.NoError(t, os.MkdirAll(segDir, 0o755))
@@ -435,6 +446,7 @@ func TestWalkFromCursor_RotationSeamConverges(t *testing.T) {
 // retry — so the SECOND sealed sweep is what recovers it. This proves the
 // retry mechanic itself fills holes, contiguously, with no jump.
 func TestWalkFromCursor_SeamRetryFillsHoleViaActiveRegion(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	segDir := filepath.Join(dir, "segments")
 	require.NoError(t, os.MkdirAll(segDir, 0o755))
@@ -539,6 +551,7 @@ func TestWalkFromCursor_SeamRetryFillsHoleViaActiveRegion(t *testing.T) {
 // in a single pass. A strict walk here would wedge: it would stop at the first
 // event above the start cursor and never resume.
 func TestWalkFromCursor_NilManifestLenient(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	segDir := filepath.Join(dir, "segments")
 	require.NoError(t, os.MkdirAll(segDir, 0o755))
@@ -607,6 +620,7 @@ func TestWalkFromCursor_NilManifestLenient(t *testing.T) {
 // contiguous range. Regression test for the cold-read rotation seam (issue
 // #190), empty-active-successor variant.
 func TestWalkFromCursor_EmptyActiveSuccessorSeam(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	segDir := filepath.Join(dir, "segments")
 	require.NoError(t, os.MkdirAll(segDir, 0o755))

--- a/segment/walkactive_seal_test.go
+++ b/segment/walkactive_seal_test.go
@@ -66,6 +66,7 @@ func collectWalk(path string) ([]uint64, error) {
 // are always intact. The risk is purely what walkActiveFrames does when it
 // continues past footerOffset into the footer bytes.
 func TestWalkActive_AfterSeal_StaticParse(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "seg_active.jss")
 
@@ -129,6 +130,7 @@ func TestWalkActive_AfterSeal_StaticParse(t *testing.T) {
 // torn/duplicated/holed event stream. The producer writes a fixed active file
 // once; a sealer seals it at a random-ish moment while many walkers read.
 func TestWalkActive_ConcurrentSeal(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 
 	var (

--- a/segment/walkactive_seal_test.go
+++ b/segment/walkactive_seal_test.go
@@ -1,0 +1,200 @@
+package segment
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// writeActiveWithFlushedBlocks creates an active (unsealed) segment file at
+// path with `blocks` flushed blocks of `perBlock` events each, contiguous seqs
+// starting at 1. Returns the writer (still open/active) and the highest seq.
+func writeActiveWithFlushedBlocks(t *testing.T, path string, blocks, perBlock int) (*Writer, uint64) {
+	t.Helper()
+	w, err := New(Config{Path: path, MaxEventsPerBlock: perBlock})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	var seq uint64 = 1
+	for range blocks {
+		for range perBlock {
+			full, err := w.Append(Event{
+				Seq: seq, IndexedAt: int64(seq) * 1000, Kind: KindCreate,
+				DID: "did:plc:walkseal", Collection: "app.bsky.feed.post",
+				Rkey: "r", Rev: "v", Payload: []byte{0xa0},
+			})
+			if err != nil {
+				t.Fatalf("Append seq=%d: %v", seq, err)
+			}
+			seq++
+			// Flush exactly when the block fills.
+			if full {
+				if err := w.Flush(); err != nil {
+					t.Fatalf("Flush: %v", err)
+				}
+			}
+		}
+	}
+	return w, seq - 1
+}
+
+// collectWalk runs WalkActive on path and returns the emitted seqs in order
+// plus any error.
+func collectWalk(path string) ([]uint64, error) {
+	var got []uint64
+	err := WalkActive(path, func(events []Event) error {
+		for i := range events {
+			got = append(got, events[i].Seq)
+		}
+		return nil
+	})
+	return got, err
+}
+
+// TestWalkActive_AfterSeal_StaticParse isolates Leak 2's core question:
+// when WalkActive reads a file whose size now INCLUDES an appended footer
+// (i.e. the file was sealed after the walker decided to read it), does the
+// frame walk (a) read the real frames then stop cleanly, (b) fail loud, or
+// (c) silently mis-decode footer bytes as events?
+//
+// Seal only appends the footer at the old EOF and patches the 256-byte header;
+// it never rewrites the frame region [256, footerOffset). So the real frames
+// are always intact. The risk is purely what walkActiveFrames does when it
+// continues past footerOffset into the footer bytes.
+func TestWalkActive_AfterSeal_StaticParse(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "seg_active.jss")
+
+	w, maxSeq := writeActiveWithFlushedBlocks(t, path, 3, 4) // 12 events, 3 blocks
+
+	// Sanity: walking the active (pre-seal) file yields all 12 contiguous seqs.
+	pre, err := collectWalk(path)
+	if err != nil {
+		t.Fatalf("pre-seal WalkActive: %v", err)
+	}
+	if len(pre) != int(maxSeq) {
+		t.Fatalf("pre-seal: want %d events, got %d (%v)", maxSeq, len(pre), pre)
+	}
+	for i, s := range pre {
+		if s != uint64(i+1) {
+			t.Fatalf("pre-seal: non-contiguous at %d: %v", i, pre)
+		}
+	}
+
+	preInfo, _ := os.Stat(path)
+
+	// Seal the file: appends footer + patches header. File grows.
+	if _, err := w.Seal(); err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	postInfo, _ := os.Stat(path)
+	t.Logf("file size pre-seal=%d post-seal=%d (footer added %d bytes)",
+		preInfo.Size(), postInfo.Size(), postInfo.Size()-preInfo.Size())
+
+	// Now walk the SEALED file via the active walker (the exact thing that
+	// happens when WalkActive stats the post-seal size and walks frames).
+	post, postErr := collectWalk(path)
+
+	t.Logf("post-seal WalkActive: err=%v, emitted %d seqs: %v", postErr, len(post), post)
+
+	// Document the three possible outcomes explicitly.
+	switch {
+	case postErr != nil:
+		t.Logf("OUTCOME: WalkActive FAILS LOUD after seal (acceptable: client disconnects+heals)")
+		// Still assert it didn't emit phantom/duplicate events before failing.
+		for i, s := range post {
+			if s != uint64(i+1) {
+				t.Fatalf("LOUD-but-CORRUPT: emitted non-contiguous seq before erroring at idx %d: %v", i, post)
+			}
+		}
+	case len(post) == int(maxSeq):
+		t.Logf("OUTCOME: WalkActive reads real frames then stops cleanly at the footer (best case)")
+		for i, s := range post {
+			if s != uint64(i+1) {
+				t.Fatalf("clean-stop but non-contiguous at idx %d: %v", i, post)
+			}
+		}
+	default:
+		t.Fatalf("OUTCOME: SILENT CORRUPTION: WalkActive emitted %d seqs (want %d), no error; footer bytes likely mis-decoded as events: %v",
+			len(post), maxSeq, post)
+	}
+}
+
+// TestWalkActive_ConcurrentSeal hammers WalkActive against a file being sealed
+// concurrently, to surface any window where the walk mis-parses or returns a
+// torn/duplicated/holed event stream. The producer writes a fixed active file
+// once; a sealer seals it at a random-ish moment while many walkers read.
+func TestWalkActive_ConcurrentSeal(t *testing.T) {
+	dir := t.TempDir()
+
+	var (
+		corrupt atomic.Bool
+		message atomic.Pointer[string]
+	)
+
+	// Each iteration uses its own file so the seal happens-during-walk window
+	// is fresh; we run many iterations to vary timing.
+	const iterations = 200
+	for it := 0; it < iterations && !corrupt.Load(); it++ {
+		path := filepath.Join(dir, "seg.jss")
+		_ = os.Remove(path)
+		w, maxSeq := writeActiveWithFlushedBlocks(t, path, 4, 4) // 16 events
+
+		var iwg sync.WaitGroup
+
+		// Walkers read concurrently with the seal.
+		const walkers = 8
+		for range walkers {
+			iwg.Go(func() {
+				for k := 0; k < 50 && !corrupt.Load(); k++ {
+					got, err := collectWalk(path)
+					if err != nil {
+						// Loud failure during a concurrent seal is acceptable
+						// (the file is legitimately mid-mutation). What is NOT
+						// acceptable is a no-error result that is wrong.
+						continue
+					}
+					// No error => the emitted prefix MUST be a contiguous run
+					// 1..n for some n <= maxSeq, with NO phantom seqs beyond
+					// maxSeq and NO holes/dupes.
+					for i, s := range got {
+						if s != uint64(i+1) {
+							msg := "non-contiguous/dup seq in no-error walk: " + sprintSeqs(got)
+							message.Store(&msg)
+							corrupt.Store(true)
+							return
+						}
+					}
+					if len(got) > int(maxSeq) {
+						msg := "phantom events beyond maxSeq in no-error walk: " + sprintSeqs(got)
+						message.Store(&msg)
+						corrupt.Store(true)
+						return
+					}
+				}
+			})
+		}
+
+		// Sealer: seal at a slightly varied delay so the seal lands during a walk.
+		iwg.Go(func() {
+			time.Sleep(time.Duration(it%5) * time.Microsecond)
+			_, _ = w.Seal()
+		})
+
+		iwg.Wait()
+		_ = w.Close()
+	}
+
+	if corrupt.Load() {
+		t.Fatalf("Leak 2 confirmed (silent mis-decode under concurrent seal): %s", *message.Load())
+	}
+	t.Logf("no silent corruption observed across %d iterations", iterations)
+}
+
+func sprintSeqs(s []uint64) string {
+	return fmt.Sprintf("%v", s)
+}


### PR DESCRIPTION
Closes #190.

## Problem

`subscribe.WalkFromCursor` (the cold-read path behind `/subscribe`) could **silently drop ~one sealed segment's worth of events** (default ~256 MB) for a catching-up subscriber when a segment rotation completed concurrently with the walk. It is a time-of-check/time-of-use bug across two independently-locked sources (the manifest and the writer), not a memory race — the race detector reports nothing.

`WalkFromCursor` reads sealed segments (manifest), then the active segment's flushed blocks + pending block (writer), non-atomically. Ingest's `rotateLocked` does, all under the writer lock:

```
seal(N)  ->  publish N to the manifest  ->  activeIdx = N+1
```

A walk could snapshot the manifest **before** N was published (its sealed loop sees nothing at/after the cursor and stops), then read the active region **after** the rotation (`activeIdx` already `N+1`). Segment N is then reachable via neither source. The old code emitted N+1's events (all above the cursor), jumping past N's seq range and dropping it — undetected, because the subscriber loop's forward-progress guard only fires on a *non-advancing* cursor, not a forward jump.

## Fix

Converge instead of reading each tier once (`internal/subscribe/replay.go`):

- **Strict contiguity** — the active region never emits an event whose `Seq` is above the running cursor; it stops at the first hole. A walk can only emit a gap-free prefix, so the silent jump is structurally impossible and the cursor lands exactly at the hole.
- **Convergence** — on a hole, re-enter the sealed sweep. `rotateLocked` publishes N *before* bumping `activeIdx`, so a walker that observed the active file above the hole is guaranteed a subsequent manifest read contains N — the retry fills it. A bounded guard crashes loud rather than spinning if a hole ever survives a retry without progress (unreachable under the publish-before-bump invariant).

A second variant is also handled (see `fc5b10e`): when a rotation opens an **empty** new active segment, the active sweep emits nothing and reports no in-band hole, yet `current < Writer.NextSeq()`. That sub-tip gap is now treated as a fillable hole and retried, instead of returning a non-advancing batch that would spuriously disconnect the subscriber.

The `nil`-manifest path stays lenient (single pass, no strict stop) to preserve its contract. Caller emit errors and the cold reader's `errBatchFull` control signal propagate verbatim, distinct from active-walk I/O errors.

## A related window that is NOT a bug (verified)

`WalkActive` can read the active file while it is being sealed concurrently. Verified benign: `Seal` only appends the footer and patches the fixed header, never rewriting the frame region, so flushed frames stay byte-intact. A walk that runs into footer bytes fails loud (footer bytes don't decode as a zstd frame) and emits nothing partial; the subscriber reconnects and reads it as a normal sealed segment. Confirmed across 1–16 block sizes and ~80k concurrent walk/seal attempts (`segment/walkactive_seal_test.go`), race-clean. No `WalkActive` change needed.

## Tests (all green, including `-race`)

- `TestWalkFromCursor_ConcurrentRotationSeam` — original repro; bounded by work (300 rotations × 16 concurrent walkers), ~0.15s. Red-first: the pre-fix lenient walk reproduces the silent-jump hole.
- `TestWalkFromCursor_RotationSeamDeterministic` — timing-free proof of no silent jump + loud non-convergence on a permanently-unfillable hole.
- `TestWalkFromCursor_RotationSeamConverges` — manifest catches up mid-walk (tier-1 fill).
- `TestWalkFromCursor_SeamRetryFillsHoleViaActiveRegion` — drives the active-hole → retry → sealed-fill path.
- `TestWalkFromCursor_EmptyActiveSuccessorSeam` — the empty-successor variant; red-first verified.
- `TestWalkFromCursor_NilManifestLenient` — pins the nil-manifest contract.

The `internal/subscribe` suite runs in ~0.23s (was 20.23s before the test was rebound from a wall-clock soak to a work-bounded stress). `golangci-lint`: 0 issues.

## Notes

- Adds an unexported `onSeamRetry` hook to `WalkInput` (exposed to tests via `export_test.go`) as a natural hook point for a future operator metric counting how often the cold-read seam is hit. Not wired to a real metric in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
