### PR TITLE
subscribe: remove ?extended=true, fold the extended wire into /subscribe-v2

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -392,7 +392,6 @@ func TestSubscribeLiveTailEndToEnd(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/subscribe-v2", r.URL.Path)
-		require.Equal(t, "true", r.URL.Query().Get("extended"))
 		conn, err := websocket.Accept(w, r, nil)
 		if err != nil {
 			return
@@ -497,8 +496,8 @@ func TestCloseStopsRunningEventsWithoutCtxCancel(t *testing.T) {
 	}
 }
 
-// liveCommitFrameJSON builds an extended commit frame with a minimal CBOR
-// record, base64-encoded, matching the /subscribe-v2 extended wire shape.
+// liveCommitFrameJSON builds a commit frame with a minimal CBOR
+// record, base64-encoded, matching the /subscribe-v2 wire shape.
 func liveCommitFrameJSON(seq uint64, did, coll, rkey string) string {
 	rec, _ := cbor.Marshal(map[string]any{"$type": coll, "text": "hi " + rkey})
 	b64 := base64.StdEncoding.EncodeToString(rec)

--- a/cmd/client/subscribe_test.go
+++ b/cmd/client/subscribe_test.go
@@ -37,7 +37,7 @@ func (b *syncBuffer) String() string {
 	return b.buf.String()
 }
 
-// liveServer serves a fixed set of extended /subscribe-v2 commit frames.
+// liveServer serves a fixed set of /subscribe-v2 commit frames.
 func liveServer(t *testing.T, frames []string) *httptest.Server {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,9 +20,9 @@ Jetstream v2 is designed with the following use-cases in mind:
 3. Transparently replace Jetstream v1 while providing the ability for independent parties to interrogate the validity of its data
 4. Provide a CDN-friendly downloadable archive for all known accounts and events
 5. Maintain a database of witness timestamps on records
-6. Dead-simple and cheap for us and others to operate on a single server or in a HA setup
+6. Dead-simple and cheap for us and others to operate on a single server
     1. The machine doesn't need much CPU, but it would benefit from a fair bit of ram for initial backfill, and a reasonably large disk (a few TB)
-    2. If you create a replica from another live jetstream instance, it actually shouldn't need much RAM either
+    2. High availability is a future goal; the earlier replication design was dropped (see Section 6)
 
 We also have the following non-goals, which are explicitly not included in this design:
 
@@ -33,7 +33,7 @@ We also have the following non-goals, which are explicitly not included in this 
 3. Query engine with arbitrary queries or point lookups
     1. This is a replay cache, not a general purpose database. We only support large range scans
 4. Distributed consensus
-    1. We instead support bootstrapping from a live instance to create a read-replica that could be promoted in disaster recovery scenarios
+    1. High availability will be addressed by a separate design later (see Section 6)
     2. Doing distributed consensus is quite challenging, and I want to ship a robust system quickly
     3. This isn’t a one-way door; we can add raft on segment blocks eventually. But I want to avoid ballooning the complexity of the original design so we can ship on reasonably short timelines
 
@@ -51,13 +51,13 @@ Finally, Jetstream v1 is a user-friendly tool and is cheap to run, but drops all
 
 ## 2. Architecture Overview
 
-Jetstream is a single static executable that runs on a single server. We support replication for an primary/read-replica HA setup. We do this for simplicity and so we can ship in a reasonable amount of time.
+Jetstream is a single static executable that runs on a single server. High availability is deferred to a future design (Section 6). We do this for simplicity and so we can ship in a reasonable amount of time.
 
 It completes full network backfill, transitions to the live tail seamlessly. Then, its clients to subscribe to the full network or certain data slices (similar to Jetstream v1).
 
 It tracks each event via its own `sequence number`, a monotonic 64-bit integer assigned at ingestion time (this sequence number is also known as the `cursor`). The cursor is *inclusive*: `?cursor=N` replays starting at the event with seq N (we deliver events with seq >= cursor). Sequence numbers start at 1; seq 0 is a reserved "nothing yet" sentinel, so `?cursor=0` replays from before the first event (i.e. everything). Combined with at-least-once delivery (see the invariants below), a client resuming from its last-seen cursor re-receives that last event, so clients must be idempotent (the bundled Go client dedups by seq, re-anchoring at last-seen-seq and dropping the re-delivery). The client can use this to either backfill data starting from the beginning of time, some arbitrary point, or just start streaming the current live tip.
 
-Same as the normal firehose, cursors are instance-local. Each jetstream instance assigns its own seq values independently, so on failover to a replica, clients should rewind their cursor by a small margin and rely on at-least-once delivery to cover the overlap.
+Same as the normal firehose, cursors are instance-local. Each jetstream instance assigns its own seq values independently, so when switching between instances, clients should rewind their cursor by a small margin and rely on at-least-once delivery to cover the overlap.
 
 We enforce some invariants that are required for building correctly on atproto:
 
@@ -166,7 +166,7 @@ Deletions and updates do not modify segment files synchronously. Every delete an
 
 Every so often, we compact updates/deletions into the sealed segments. Compaction snapshots tombstones above `compaction/seq`, rewrites sealed segments atomically, and refreshes serving metadata for changed files. See Section 3.3 for more details.
 
-The net of this is that segment files are immutable between compaction passes and only rewrite on the merge-tail pass or the steady-state compaction cadence. These files are CDN-friendly with etags, enabling parallel backfill for clients and easy replication to read-replicas that seed from a given jetstream instance.
+The net of this is that segment files are immutable between compaction passes and only rewrite on the merge-tail pass or the steady-state compaction cadence. These files are CDN-friendly with etags, enabling parallel backfill for clients and easy seeding of another instance from a given jetstream instance's archive.
 
 ### 3.1.2 File Format
 
@@ -412,7 +412,6 @@ compaction/seq          -> the highest-watermark sequence number of the most rec
 repo/<did>              -> JSON<RepoStatus> per-DID backfill and steady-state bookkeeping
 account/<did>           -> JSON<AccountStatus> hosting status, only present when non-active
 sync/<did>              -> JSON<SyncState> present while a resync is in progress
-replica/upstream_cursor -> uint64 (replica-only) last seq consumed from the upstream leader
 ```
 
 The `backfill/timing/*` keys are operator diagnostics, not control-plane state. When the bootstrap backfill engine drains, the orchestrator commits `phase=merging`, `phase/entered_at`, `backfill/timing/started_at`, and `backfill/timing/completed_at` in one synced pebble batch. That makes the status page's completed-backfill duration durable without creating a recovery dependency on it. Older data directories that predate these keys can still enter steady state; they simply render the completed backfill duration as unknown.
@@ -528,7 +527,7 @@ Internally, Jetstream doesn't care about handles, identity updates, or hosting s
 
 The legacy `/subscribe` (v1) endpoint preserves the original Jetstream contract: regardless of `wantedCollections`, all subscribers receive `#account` and `#identity` events (they are still gated by `wantedDids`). This is intentional backwards compatibility and must not change.
 
-`#account` and `#identity` are delivered **unconditionally** — regardless of `wantedCollections`, on **both** the simple and extended wires of `/subscribe` (v1) and `/subscribe-v2`, and by the Go client (still gated by `wantedDids`). `#sync` is also unconditional with respect to `wantedCollections`, but it is only emitted on the **extended** wire (`?extended=true`): the simple, v1-compatible JSON wire skips `#sync` for v1 parity (v1 never emitted it — `encoder.go` returns `errSkipEvent` for the simple `Encode`, while `EncodeExtended` emits it). The bundled Go client connects in extended mode, so it receives `#sync`; a third party on the plain JSON wire does not. Earlier drafts dropped `#identity` (and hid `#account`) under a collection filter; that policy is gone (see [#142](https://github.com/bluesky-social/jetstream/issues/142), [#171](https://github.com/bluesky-social/jetstream/issues/171)). The reason is correctness, not just intuitiveness: a DID-level marker (an account delete `active=false, status=deleted`, or a `#sync` divergence) is what a folding consumer uses to purge a dead account's records, so it must reach every subscriber — including a collection-scoped one. There is no client-side suppression and no "fold before the delivery filter" step; the markers are delivered as ordinary events and the consumer folds them. (For the *backfill* path, the same coverage is provided in the archive by the DID-marker sentinel index described in Section 3.3, so a collection-filtered backfill selects those marker blocks too.)
+`#account` and `#identity` are delivered **unconditionally** — regardless of `wantedCollections`, on **both** `/subscribe` (v1) and `/subscribe-v2`, and by the Go client (still gated by `wantedDids`). `#sync` is also unconditional with respect to `wantedCollections`, but it is only emitted on **`/subscribe-v2`**: the v1-compatible JSON wire skips `#sync` for v1 parity (v1 never emitted it — `encoder.go` returns `errSkipEvent` for the v1 `Encode`, while `EncodeV2` emits it). The bundled Go client connects to `/subscribe-v2`, so it receives `#sync`; a v1 `/subscribe` consumer does not. Earlier drafts dropped `#identity` (and hid `#account`) under a collection filter; that policy is gone (see [#142](https://github.com/bluesky-social/jetstream/issues/142), [#171](https://github.com/bluesky-social/jetstream/issues/171)). The reason is correctness, not just intuitiveness: a DID-level marker (an account delete `active=false, status=deleted`, or a `#sync` divergence) is what a folding consumer uses to purge a dead account's records, so it must reach every subscriber — including a collection-scoped one. There is no client-side suppression and no "fold before the delivery filter" step; the markers are delivered as ordinary events and the consumer folds them. (For the *backfill* path, the same coverage is provided in the archive by the DID-marker sentinel index described in Section 3.3, so a collection-filtered backfill selects those marker blocks too.)
 
 Jetstream respects sync 1.1. In the case where a `#sync` event indicates a repo has diverged and requires a full resync, we store the `KindSync` row followed by the authoritative replacement records returned by the verifier. The `KindSync` row is a DID tombstone for compaction (see Section 3.3), so older pre-divergence record rows are physically removed once the relevant sealed segment is compacted.
 
@@ -583,65 +582,26 @@ Cursor lookback is bounded to the most recent 36 hours by default (matching jets
 
 Cursors in the future drop into live-tip mode (no replay) on both endpoints.
 
-### 5.2 Extended JSON Payload
+### 5.2 The /subscribe-v2 JSON Payload
 
-Subscribers that need everything Jetstream knows about an event can opt in by appending `?extended=true` to the websocket URL. The extended form is a strict superset of the simple form: all the same fields are present, plus:
+The `/subscribe-v2` endpoint delivers a strict superset of the v1 shape: all the same fields are present (including the decoded `commit.record` JSON), plus:
 
-- `seq`: Jetstream's own monotonic 64-bit cursor assigned to this event at ingestion time.
-- `upstream_relay_cursor`: the upstream relay firehose cursor this event came from. Useful to any subscriber that wants to eventually promote itself into a primary and pick up from the relay with minimal overlap.
+- `seq`: Jetstream's own monotonic 64-bit cursor assigned to this event at ingestion time (the same value as `cursor`; v1 only carries `cursor`).
 - `commit.record_cbor`: the raw DAG-CBOR payload of the record, base64-encoded. Only populated for `kind: "commit"`. This is the byte-exact form written to the segment file, suitable for verifying against a PDS or reconstructing the MST.
-- `sync`: the archived `#sync` event. `sync.blocks` is the raw CAR payload, base64-encoded. Only populated for `kind: "sync"`.
+- `sync`: the archived `#sync` event, which v1 never emits. `sync.blocks` is the raw CAR payload, base64-encoded. Only populated for `kind: "sync"`.
 - TODO: `prevRev`  on all events (Fig suggestion)
 
-A replica is just an extended-mode subscriber with the additional behavior of writing what it receives into its own segments. See Section 6.
+The bundled Go client consumes this wire on its live tail; the raw DAG-CBOR is what lets a typed consumer decode records with its own lexicon codegen, byte-exactly.
 
-On extended connections, the stream also interleaves control events that don't flow on simple connections. These use new `kind` values:
+`/subscribe-v2` also diverges from v1 in presentation policy (both are deliberate, per-endpoint contracts): it emits Sync 1.1 resync replacement rows (v1 advances over them silently for wire parity), and it rejects a below-floor seq cursor with a pre-upgrade HTTP 400 as described in Section 5.1 (v1 silently clamps).
 
-```
-kind values (extended-only):
-  segment_sealed      upstream sealed a segment file
-  segment_compacted   upstream rewrote a previously-sealed segment (tombstone compaction
-                      or timestamp import)
-  heartbeat           keepalive; carries cursor values for liveness detection
-```
+`/subscribe-v2` subscriptions are not authenticated, but they're more expensive to produce (base64-encoded CBOR, heavier per-event payload) so we may more strictly rate limit them compared to the v1 firehose on the Bluesky-hosted instance.
 
-Each control event carries a small payload: `segment_sealed` and `segment_compacted` carry `{name, sha256, min_seq, max_seq}`; `heartbeat` carries `{seq, upstream_relay_cursor}`.
-
-Extended-mode subscriptions are not authenticated, but they're more expensive to produce (base64-encoded CBOR, heavier per-event payload) so we may more strictly rate limit them compared to the simple firehose on the Bluesky-hosted instance.
+> Historical note: earlier drafts specified an `?extended=true` opt-in carrying `upstream_relay_cursor` and interleaved control events (`segment_sealed`, `segment_compacted`, `heartbeat`) to serve the Section 6 replication protocol. That replication design was dropped before shipping and the extended mode was removed with it; `/subscribe-v2` always carries the superset payload described above.
 
 ## 6. Replication
 
-NOTE (jrc): this section is still pretty early-days and I want to review it myself a fair bit more before getting seriously in-depth review from others. This will come much later in the implementation, so I'm not overly fixated on getting it perfect yet.
-
-We support a simple asynchronous replication protocol for active-passive high availability setups. This allows for the leader instance to handle writes and a relatively small read workload, and there can be some large number of read replicas (or read-replica chains) that can distribute read traffic across many sites.
-
-The guiding principle is that as much as possible, we only replicate source data, not metadata stores. Everything pebble holds on the leader is either derivable from the event stream the replica already consumes (per-DID `LatestRev`, `AccountStatus`), reconstructible on promotion by calling `com.atproto.sync.listRepos` on the relay (the DID list itself), or deliberately leader-only and not needed by a passive replica (retry attempt counters, `LastError` strings, in-flight sync state). A promoted replica rebuilds any missing per-DID backfill lifecycle rows from the authoritative DID list and its local archive state.
-
-### 6.1 The Replication Protocol
-
-Replication has two moving parts: bulk transfer of sealed segment files over plain HTTP downloads (the same CDN-friendly downloads that end-user clients use), and a persistent websocket between the replica and its upstream that carries live events and the control signals replicas depend on. That websocket is just an extended-mode subscription to the same streaming endpoint end-user clients use, as described in Section 5.2. There is no separate replication protocol.
-
-Everything a replica needs to stay caught up is already carried on an extended-mode connection: the raw DAG-CBOR of each record (so the replica can write bit-exact payloads into its own segments), the jetstream-local `seq` (so the replica can persist its own upstream cursor), the upstream relay cursor (so a promoted replica can pick up the relay firehose with minimal overlap), and the `segment_sealed` and `segment_compacted` control events. Because end-user clients with `?extended=true` receive the same frames, replicas aren't a privileged special case at the protocol layer; they're just the most aggressive consumer.
-
-Idempotency matters for the bootstrap-to-live handoff. Duplicate events are deduplicated by `(did, seq)` at the block boundary; duplicate segment-seal or segment-compacted events redownload the same file and produce the same on-disk state. This lets the bootstrap-time bulk transfers overlap with live control events at the boundary without a strict handoff.
-
-### 6.2 Bootstrapping a Replica
-
-To bootstrap a new read replica, start the server with the `--upstream=jetstream.us-east.bsky.network` flag. The replica goes through the following steps:
-
-1. Open an extended-mode websocket to the upstream with no cursor, and start buffering frames in memory. Doing this first ensures no live events or control signals are lost during the bulk-transfer phase.
-2. Download every sealed segment file the upstream currently lists, verifying each one's sha256 checksum against the value in its fixed header.
-3. Begin processing buffered websocket frames: write events into the active segment and handle `segment_sealed` and `segment_compacted` by downloading and swapping the named file.
-
-The replica writes events into its own active segment exactly as a primary would, and seals independently when its active segment fills. Replica sealed segments are not expected to be bitwise-identical to the upstream's, since block boundaries depend on local timing. They're logically equivalent, and each file's self-contained sha256 checksum is what we verify against.
-
-### 6.3 Promoting a Replica to Leader
-
-To promote a replica to leader, remove the `--upstream` flag and point it at a relay firehose instead. The promoted leader uses the last `upstream_relay_cursor` it observed on the extended stream as its starting point and rewinds slightly to lean on at-least-once delivery across the overlap. It then calls `com.atproto.sync.listRepos` to get the authoritative DID list, diffs it against `repo/<did>` in pebble and the local archive state, and queues unknown or incomplete active DIDs for initial backfill or retry. This means a promoted leader has a warmup window measured in minutes (dominated by `listRepos` pagination) before retry work resumes, which we consider acceptable given our non-goal of sub-minute failover.
-
-We accept a few cosmetic regressions on failover: `Attempts` counters reset to zero, `LastError` strings are lost (operators can consult logs for debugging history), and any accounts that are legitimately empty at the relay may be redundantly re-fetched once. None of these affect correctness.
-
-Timestamp imports (Section 8) flow to replicas entirely through `segment_compacted` events on the extended stream and do not need a parallel channel.
+> **STATUS: DROPPED — to be redesigned.** An earlier draft of this section specified an asynchronous active-passive replication protocol built on an `?extended=true` websocket payload (carrying `upstream_relay_cursor` and `segment_sealed`/`segment_compacted`/`heartbeat` control events). That design — and the extended wire mode it required — has been removed; nothing of it was ever implemented. High availability will be addressed by a different mechanism designed later; see `specs/notes/2026-06-27-high-availability-clustering.md` for the current exploration. Jetstream today runs single-node.
 
 ## 7. Rate Limits
 
@@ -667,7 +627,7 @@ Rather than maintaining a separate timestamp table that has to be kept in sync a
 
 We require uploads to be keyed by AT URI rather than by CID. URIs contain the DID, which lets us use the existing segment-level DID bloom to do almost all the filtering work. CID-keyed imports would force either a full scan of every segment or a second per-segment bloom over CIDs; both are expensive enough that it's not worth paying for unless we see a concrete need. Operators that only have CIDs can resolve them upstream before uploading.
 
-Once the compaction pass has rewritten all affected segments and resealed them with new checksums, the segment-compaction notification path from Section 6 fires for each touched file, and replicas re-download and swap them in exactly as they would for any other compaction. No additional replication mechanism is required for timestamps.
+Once the compaction pass has rewritten all affected segments and resealed them with new checksums, the manifest lists the new files and backfilling clients pick them up on their next segment listing. (The dropped Section 6 replication design would have pushed `segment_compacted` notifications to replicas; whatever HA mechanism replaces it must account for compacted-segment propagation.)
 
 ## 9. FAQ
 

--- a/event.go
+++ b/event.go
@@ -12,7 +12,7 @@ const (
 	// KindAccount is a #account event (hosting-status change). Account is non-nil.
 	KindAccount Kind = "account"
 	// KindSync is a #sync event (repo divergence / resync). Sync is non-nil.
-	// Sync events are delivered on backfill and on the extended live tail.
+	// Sync events are delivered on backfill and on the /subscribe-v2 live tail.
 	KindSync Kind = "sync"
 )
 
@@ -80,7 +80,7 @@ type Commit struct {
 	// RecordCBOR is the raw, byte-exact DAG-CBOR encoding of the record,
 	// suitable for verifying against a PDS or reconstructing the MST. nil for
 	// deletes. It is populated on both the backfill and live paths. Marshals
-	// to base64 (matching the extended wire's record_cbor).
+	// to base64 (matching the /subscribe-v2 wire's record_cbor).
 	RecordCBOR []byte `json:"record_cbor,omitempty"`
 }
 

--- a/internal/client/live.go
+++ b/internal/client/live.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	// defaultLiveReadLimit bounds a single websocket message. Extended frames
+	// defaultLiveReadLimit bounds a single websocket message. v2 frames
 	// carry base64 record CBOR; a generous ceiling tolerates large records
 	// without allowing an unbounded allocation from a hostile server.
 	defaultLiveReadLimit = 32 << 20 // 32 MiB
@@ -92,7 +92,7 @@ func (c liveConfig) maxBackoff() time.Duration {
 	return liveBackoffMax
 }
 
-// liveConsumer tails /subscribe-v2 in extended mode, decoding frames into
+// liveConsumer tails /subscribe-v2, decoding frames into
 // engine events, deduplicating the at-least-once overlap by seq, and
 // reconnecting with bounded exponential backoff. It is the live half of the
 // stream: the engine consumes its output during cutover (buffered) and in
@@ -246,7 +246,6 @@ func (c *liveConsumer) subscribeURL() string {
 	}
 	u.Path = "/subscribe-v2"
 	q := url.Values{}
-	q.Set("extended", "true")
 	// Wire cursor: once any event has been delivered, resume each new session at
 	// lastSeq (the highest seq delivered). subscribeURL is rebuilt on every
 	// reconnect, so anchoring at lastSeq is what keeps a stream from re-anchoring

--- a/internal/client/live_test.go
+++ b/internal/client/live_test.go
@@ -243,13 +243,12 @@ func TestLiveConsumerSubscribeURL(t *testing.T) {
 	c := newLiveConsumer(liveConfig{host: "https://jetstream.example", cursor: 123})
 	u := c.subscribeURL()
 	require.True(t, strings.HasPrefix(u, "wss://jetstream.example/subscribe-v2?"), "got %s", u)
-	require.Contains(t, u, "extended=true")
+	require.NotContains(t, u, "extended=", "the removed extended param must not be sent")
 	require.Contains(t, u, "cursor=123")
 
 	c2 := newLiveConsumer(liveConfig{host: "http://localhost:8080", fromTip: true})
 	u2 := c2.subscribeURL()
-	require.True(t, strings.HasPrefix(u2, "ws://localhost:8080/subscribe-v2?"), "got %s", u2)
-	require.Contains(t, u2, "extended=true")
+	require.True(t, strings.HasPrefix(u2, "ws://localhost:8080/subscribe-v2"), "got %s", u2)
 	require.NotContains(t, u2, "cursor=", "no cursor when fromTip (live from tip)")
 }
 

--- a/internal/client/livedecode.go
+++ b/internal/client/livedecode.go
@@ -13,7 +13,7 @@ import (
 // emitting.
 var errSkipFrame = errors.New("jetstream: skip live frame")
 
-// liveFrame is the extended Jetstream JSON wire shape (/subscribe-v2?extended=true).
+// liveFrame is the Jetstream /subscribe-v2 JSON wire shape.
 // Only the fields the client consumes are modeled; unknown fields are ignored,
 // and unknown kinds are skipped so future control frames don't break old
 // clients.
@@ -62,7 +62,7 @@ type liveSync struct {
 	Time string `json:"time"`
 }
 
-// decodeLiveFrame parses one extended JSON frame into an engine Event. It
+// decodeLiveFrame parses one /subscribe-v2 JSON frame into an engine Event. It
 // returns errSkipFrame for control frames and unknown kinds, and a wrapped
 // error for malformed data frames or server error frames. mode selects raw vs.
 // map record materialization (see recordDecodeMode), matching the backfill path
@@ -77,8 +77,8 @@ func decodeLiveFrame(data []byte, mode recordDecodeMode) (Event, error) {
 	}
 
 	out := Event{DID: f.DID, Seq: f.Seq, TimeUS: f.TimeUS}
-	// The simple wire format omits seq and carries the value only in cursor;
-	// extended always sets both. Fall back to cursor so a server that only
+	// The v1 wire format omits seq and carries the value only in cursor;
+	// v2 always sets both. Fall back to cursor so a server that only
 	// populates cursor still yields a usable seq.
 	if out.Seq == 0 {
 		out.Seq = f.Cursor
@@ -132,7 +132,7 @@ func liveCommitToEvent(c *liveCommit, mode recordDecodeMode) (*Commit, error) {
 	switch commit.Operation {
 	case OpCreate, OpUpdate:
 		if c.RecordCBOR == "" {
-			return nil, fmt.Errorf("jetstream: live %s commit missing record_cbor (collection=%s rkey=%s); connect with extended=true", c.Operation, c.Collection, c.Rkey)
+			return nil, fmt.Errorf("jetstream: live %s commit missing record_cbor (collection=%s rkey=%s); is the server a /subscribe-v2 endpoint?", c.Operation, c.Collection, c.Rkey)
 		}
 		raw, err := base64.StdEncoding.DecodeString(c.RecordCBOR)
 		if err != nil {

--- a/internal/client/livedecode_test.go
+++ b/internal/client/livedecode_test.go
@@ -24,14 +24,14 @@ func liveCommitFrame(t *testing.T, seq uint64, did, op, coll, rkey string, withR
 	return []byte(frame)
 }
 
-// liveIdentityFrame builds an extended-wire #identity frame.
+// liveIdentityFrame builds a v2-wire #identity frame.
 func liveIdentityFrame(seq uint64, did, handle string) []byte {
 	s := strconv.FormatUint(seq, 10)
 	return []byte(`{"did":"` + did + `","time_us":1,"cursor":` + s + `,"seq":` + s +
 		`,"kind":"identity","identity":{"did":"` + did + `","handle":"` + handle + `","seq":` + s + `,"time":"t"}}`)
 }
 
-// liveAccountFrame builds an extended-wire #account frame. A deleted account
+// liveAccountFrame builds a v2-wire #account frame. A deleted account
 // (active=false, status="deleted") doubles as a DID-level tombstone.
 func liveAccountFrame(seq uint64, did string, active bool, status string) []byte {
 	s := strconv.FormatUint(seq, 10)
@@ -68,7 +68,7 @@ func TestDecodeLiveFrameDelete(t *testing.T) {
 
 func TestDecodeLiveFrameCreateMissingCBOR(t *testing.T) {
 	t.Parallel()
-	// A create without record_cbor (i.e. not extended mode) must error.
+	// A create without record_cbor (i.e. not a v2 frame) must error.
 	_, err := decodeLiveFrame(liveCommitFrame(t, 1, "did:plc:a", "create", "c", "r", false), recordDecodeMode{})
 	require.ErrorContains(t, err, "record_cbor")
 }

--- a/internal/ingest/live/cursor_test.go
+++ b/internal/ingest/live/cursor_test.go
@@ -39,13 +39,13 @@ func TestUpstreamCursor_DistinctKeys(t *testing.T) {
 	st := newTestStore(t)
 
 	require.NoError(t, SaveUpstreamCursor(st, "relay/cursor", 10))
-	require.NoError(t, SaveUpstreamCursor(st, "replica/upstream_cursor", 20))
+	require.NoError(t, SaveUpstreamCursor(st, "other/cursor", 20))
 
 	a, err := LoadUpstreamCursor(st, "relay/cursor")
 	require.NoError(t, err)
 	require.Equal(t, int64(10), a)
 
-	b, err := LoadUpstreamCursor(st, "replica/upstream_cursor")
+	b, err := LoadUpstreamCursor(st, "other/cursor")
 	require.NoError(t, err)
 	require.Equal(t, int64(20), b)
 }

--- a/internal/jetstreamd/runtime.go
+++ b/internal/jetstreamd/runtime.go
@@ -401,15 +401,14 @@ func Build(ctx context.Context, opts Options) (*Runtime, error) {
 		Lookback:  opts.CursorLookback,
 	}))
 	srv.RegisterPublicRoute("GET /subscribe-v2", subscribe.NewHandler(subscribe.Subscription{
-		Tail:                      tail,
-		Store:                     metaStore,
-		Manifest:                  mft,
-		WriterRef:                 &writerPtr,
-		Logger:                    processLogger,
-		Metrics:                   subscribeMetrics,
-		Lookback:                  opts.CursorLookback,
-		EmitResyncReplacementRows: true,
-		RejectCursorBelowFloor:    true,
+		Tail:      tail,
+		Store:     metaStore,
+		Manifest:  mft,
+		WriterRef: &writerPtr,
+		Logger:    processLogger,
+		Metrics:   subscribeMetrics,
+		Lookback:  opts.CursorLookback,
+		V2:        true,
 	}))
 
 	// XRPC surface: whole-file segment download + listing. The atmos

--- a/internal/oracle/partb_harness_test.go
+++ b/internal/oracle/partb_harness_test.go
@@ -30,7 +30,7 @@ import (
 // partb_harness_test.go builds the hermetic, real-socket fixture the §16 Part-B
 // oracle scenarios drive: a single httptest server that serves BOTH the
 // paginated archive XRPC (planBackfill/getSegment/getBlock, mounted at /xrpc/)
-// and the live /subscribe-v2 websocket (with the v2 RejectCursorBelowFloor
+// and the live /subscribe-v2 websocket (with the v2 reject-below-floor
 // too-old policy), backed by one sealed-segment archive + manifest + writer +
 // hot-ring Tail. It deliberately avoids the synctest bubble — the oracle package
 // allows exactly one bubble per process (owned by TestOracle_DefaultLifecycle),
@@ -219,15 +219,14 @@ func newPagedCutoverServer(t *testing.T, cfg pagedCutoverConfig) *pagedCutoverSe
 		}
 	}))
 	mux.Handle("GET /subscribe-v2", subscribe.NewHandler(subscribe.Subscription{
-		Tail:                      tail,
-		Store:                     st,
-		Manifest:                  m,
-		Writer:                    w,
-		Logger:                    logger,
-		Metrics:                   subscribe.NewMetrics(prometheus.NewRegistry()),
-		Lookback:                  cfg.Lookback,
-		EmitResyncReplacementRows: true,
-		RejectCursorBelowFloor:    true,
+		Tail:     tail,
+		Store:    st,
+		Manifest: m,
+		Writer:   w,
+		Logger:   logger,
+		Metrics:  subscribe.NewMetrics(prometheus.NewRegistry()),
+		Lookback: cfg.Lookback,
+		V2:       true,
 	}))
 
 	ts := httptest.NewServer(mux)
@@ -281,7 +280,7 @@ func (s *pagedCutoverServer) tipLocked() uint64 { return s.nextSeq.Load() }
 // is the raw §14 signal the client's re-backfill keys on.
 func dialSubscribeV2(t *testing.T, baseURL string, cursor uint64) (status int, body string) {
 	t.Helper()
-	wsURL := "ws" + strings.TrimPrefix(baseURL, "http") + "/subscribe-v2?extended=true&cursor=" + strconv.FormatUint(cursor, 10)
+	wsURL := "ws" + strings.TrimPrefix(baseURL, "http") + "/subscribe-v2?cursor=" + strconv.FormatUint(cursor, 10)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	conn, resp, err := websocket.Dial(ctx, wsURL, nil)

--- a/internal/subscribe/doc.go
+++ b/internal/subscribe/doc.go
@@ -68,11 +68,11 @@
 //     subscribers receive Account and Identity events." Locked down by
 //     TestWants_IdentityBypassesCollectionFilter.
 //
-//   - #sync events are deliberately not emitted on the SIMPLE (non-extended)
-//     JSON wire — v1 didn't emit them either (encoder.go Encode →
-//     errSkipEvent). The EXTENDED wire (?extended=true) DOES emit #sync
-//     (EncodeExtended), which is what the bundled Go client uses. #account
-//     and #identity are emitted on both wires.
+//   - #sync events are deliberately not emitted on the v1 /subscribe wire —
+//     v1 didn't emit them either (encoder.go Encode → errSkipEvent). The
+//     /subscribe-v2 wire DOES emit #sync (EncodeV2), which is what the
+//     bundled Go client consumes. #account and #identity are emitted on
+//     both wires.
 //
 //   - Unknown SubscriberSourcedMessage.Type values are logged and
 //     ignored, not fatal. v1 has the same policy. Locked down by
@@ -110,7 +110,7 @@
 // ?cursor= replay IS supported (cursor.go + the cold reader), resolving a
 // seq or time_us cursor against the manifest, clamped to the configured
 // --cursor-lookback floor. The too-old-cursor policy is endpoint-specific
-// (Subscription.RejectCursorBelowFloor, set true only on /subscribe-v2):
+// (Subscription.V2, set true only on /subscribe-v2):
 //
 //   - /subscribe (v1): a seq cursor below the floor is silently CLAMPED up
 //     to the floor (legacy v1 wire parity), made observable via the
@@ -121,7 +121,7 @@
 //     last seq instead of silently skipping (requestedSeq, floor].
 //   - The time_us cursor path always clamps under BOTH endpoints: a legacy
 //     timestamp cursor's documented contract is to start at the oldest
-//     retained event, and RejectCursorBelowFloor governs only the seq path.
+//     retained event, and the v2 reject policy governs only the seq path.
 //
 // Setting --cursor-lookback=0 disables replay: a cursor param is then
 // accepted but resolves to the live tip rather than 400-ing, so v1 clients

--- a/internal/subscribe/encoder.go
+++ b/internal/subscribe/encoder.go
@@ -36,19 +36,20 @@ func Encode(evt *segment.Event) ([]byte, error) {
 	}
 }
 
-// EncodeExtended renders evt as the extended Jetstream v2 JSON wire
-// format. It is a superset of the v1-compatible shape for v1-visible
-// events, and additionally emits archived #sync events.
-func EncodeExtended(evt *segment.Event) ([]byte, error) {
+// EncodeV2 renders evt as the Jetstream /subscribe-v2 JSON wire format.
+// It is a superset of the v1-compatible shape for v1-visible events
+// (adding seq and commit.record_cbor), and additionally emits archived
+// #sync events.
+func EncodeV2(evt *segment.Event) ([]byte, error) {
 	switch evt.Kind {
 	case segment.KindCreate, segment.KindUpdate, segment.KindDelete, segment.KindCreateResync:
-		return encodeExtendedCommit(evt)
+		return encodeV2Commit(evt)
 	case segment.KindIdentity:
-		return encodeExtendedIdentity(evt)
+		return encodeV2Identity(evt)
 	case segment.KindAccount:
-		return encodeExtendedAccount(evt)
+		return encodeV2Account(evt)
 	case segment.KindSync:
-		return encodeExtendedSync(evt)
+		return encodeV2Sync(evt)
 	default:
 		return nil, fmt.Errorf("subscribe: unknown event kind %d", evt.Kind)
 	}
@@ -85,20 +86,19 @@ func encodeCommit(evt *segment.Event) ([]byte, error) {
 	return json.Marshal(env)
 }
 
-type extendedEvent struct {
-	DID                 string                                  `json:"did"`
-	TimeUS              int64                                   `json:"time_us"`
-	Cursor              uint64                                  `json:"cursor"`
-	Kind                string                                  `json:"kind"`
-	Seq                 uint64                                  `json:"seq"`
-	UpstreamRelayCursor int64                                   `json:"upstream_relay_cursor"`
-	Commit              *extendedCommit                         `json:"commit,omitempty"`
-	Account             *comatproto.SyncSubscribeRepos_Account  `json:"account,omitempty"`
-	Identity            *comatproto.SyncSubscribeRepos_Identity `json:"identity,omitempty"`
-	Sync                *extendedSync                           `json:"sync,omitempty"`
+type v2Event struct {
+	DID      string                                  `json:"did"`
+	TimeUS   int64                                   `json:"time_us"`
+	Cursor   uint64                                  `json:"cursor"`
+	Kind     string                                  `json:"kind"`
+	Seq      uint64                                  `json:"seq"`
+	Commit   *v2Commit                               `json:"commit,omitempty"`
+	Account  *comatproto.SyncSubscribeRepos_Account  `json:"account,omitempty"`
+	Identity *comatproto.SyncSubscribeRepos_Identity `json:"identity,omitempty"`
+	Sync     *v2Sync                                 `json:"sync,omitempty"`
 }
 
-type extendedCommit struct {
+type v2Commit struct {
 	Rev        string          `json:"rev"`
 	Operation  string          `json:"operation"`
 	Collection string          `json:"collection"`
@@ -108,9 +108,9 @@ type extendedCommit struct {
 	RecordCBOR string          `json:"record_cbor,omitempty"`
 }
 
-// Keep Jetstream's extended wire shape independent from atmos's generated
+// Keep Jetstream's v2 wire shape independent from atmos's generated
 // atproto JSON encoding for bytes, which uses DAG-JSON {"$bytes": "..."}.
-type extendedSync struct {
+type v2Sync struct {
 	LexiconTypeID string `json:"$type,omitempty"`
 	Blocks        []byte `json:"blocks"`
 	DID           string `json:"did"`
@@ -119,19 +119,18 @@ type extendedSync struct {
 	Time          string `json:"time"`
 }
 
-func extendedEnvelope(evt *segment.Event, kind string) extendedEvent {
-	return extendedEvent{
-		DID:                 evt.DID,
-		TimeUS:              evt.IndexedAt,
-		Cursor:              evt.Seq,
-		Kind:                kind,
-		Seq:                 evt.Seq,
-		UpstreamRelayCursor: evt.UpstreamRelayCursor,
+func v2Envelope(evt *segment.Event, kind string) v2Event {
+	return v2Event{
+		DID:    evt.DID,
+		TimeUS: evt.IndexedAt,
+		Cursor: evt.Seq,
+		Kind:   kind,
+		Seq:    evt.Seq,
 	}
 }
 
-func encodeExtendedCommit(evt *segment.Event) ([]byte, error) {
-	commit := &extendedCommit{
+func encodeV2Commit(evt *segment.Event) ([]byte, error) {
+	commit := &v2Commit{
 		Rev:        evt.Rev,
 		Operation:  commitOpString(evt.Kind),
 		Collection: evt.Collection,
@@ -152,7 +151,7 @@ func encodeExtendedCommit(evt *segment.Event) ([]byte, error) {
 		commit.RecordCBOR = base64.StdEncoding.EncodeToString(evt.Payload)
 	}
 
-	env := extendedEnvelope(evt, streaming.JetstreamKindCommit)
+	env := v2Envelope(evt, streaming.JetstreamKindCommit)
 	env.Commit = commit
 	return json.Marshal(&env)
 }
@@ -170,33 +169,33 @@ func commitOpString(k segment.Kind) string {
 	}
 }
 
-func encodeExtendedIdentity(evt *segment.Event) ([]byte, error) {
+func encodeV2Identity(evt *segment.Event) ([]byte, error) {
 	var id comatproto.SyncSubscribeRepos_Identity
 	if err := id.UnmarshalCBOR(evt.Payload); err != nil {
 		return nil, fmt.Errorf("subscribe: decode identity: %w", err)
 	}
-	env := extendedEnvelope(evt, streaming.JetstreamKindIdentity)
+	env := v2Envelope(evt, streaming.JetstreamKindIdentity)
 	env.Identity = &id
 	return json.Marshal(&env)
 }
 
-func encodeExtendedAccount(evt *segment.Event) ([]byte, error) {
+func encodeV2Account(evt *segment.Event) ([]byte, error) {
 	var acct comatproto.SyncSubscribeRepos_Account
 	if err := acct.UnmarshalCBOR(evt.Payload); err != nil {
 		return nil, fmt.Errorf("subscribe: decode account: %w", err)
 	}
-	env := extendedEnvelope(evt, streaming.JetstreamKindAccount)
+	env := v2Envelope(evt, streaming.JetstreamKindAccount)
 	env.Account = &acct
 	return json.Marshal(&env)
 }
 
-func encodeExtendedSync(evt *segment.Event) ([]byte, error) {
+func encodeV2Sync(evt *segment.Event) ([]byte, error) {
 	var sync comatproto.SyncSubscribeRepos_Sync
 	if err := sync.UnmarshalCBOR(evt.Payload); err != nil {
 		return nil, fmt.Errorf("subscribe: decode sync: %w", err)
 	}
-	env := extendedEnvelope(evt, "sync")
-	env.Sync = &extendedSync{
+	env := v2Envelope(evt, "sync")
+	env.Sync = &v2Sync{
 		LexiconTypeID: sync.LexiconTypeID,
 		Blocks:        sync.Blocks,
 		DID:           sync.DID,

--- a/internal/subscribe/encoder_fuzz_test.go
+++ b/internal/subscribe/encoder_fuzz_test.go
@@ -60,9 +60,9 @@ func FuzzEncode(f *testing.F) {
 	})
 }
 
-// FuzzEncodeExtended mirrors FuzzEncode for the extended protocol path:
+// FuzzEncodeV2 mirrors FuzzEncode for the /subscribe-v2 protocol path:
 // arbitrary event fields must never panic and successful encodes must be JSON.
-func FuzzEncodeExtended(f *testing.F) {
+func FuzzEncodeV2(f *testing.F) {
 	seeds := []struct {
 		kind                       uint8
 		did, collection, rkey, rev string
@@ -80,24 +80,23 @@ func FuzzEncodeExtended(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, kind uint8, did, collection, rkey, rev string, payload []byte) {
 		evt := &segment.Event{
-			Kind:                segment.Kind(kind),
-			DID:                 did,
-			Collection:          collection,
-			Rkey:                rkey,
-			Rev:                 rev,
-			Payload:             payload,
-			IndexedAt:           1,
-			UpstreamRelayCursor: 2,
+			Kind:       segment.Kind(kind),
+			DID:        did,
+			Collection: collection,
+			Rkey:       rkey,
+			Rev:        rev,
+			Payload:    payload,
+			IndexedAt:  1,
 		}
 
-		out, err := EncodeExtended(evt)
+		out, err := EncodeV2(evt)
 		if err != nil {
 			return
 		}
 
 		var v any
 		if err := json.Unmarshal(out, &v); err != nil {
-			t.Fatalf("EncodeExtended produced invalid JSON: %v\nbytes: %s", err, out)
+			t.Fatalf("EncodeV2 produced invalid JSON: %v\nbytes: %s", err, out)
 		}
 	})
 }

--- a/internal/subscribe/encoder_test.go
+++ b/internal/subscribe/encoder_test.go
@@ -82,7 +82,6 @@ func TestEncode_CommitGoldenRoundTrips(t *testing.T) {
 	golden := loadGolden(t)
 
 	for i, want := range golden {
-		i, want := i, want
 		kind, ok := want["kind"].(string)
 		if !ok || kind != "commit" {
 			continue
@@ -342,66 +341,63 @@ func TestEncode_CursorFieldOnAccount(t *testing.T) {
 	require.Contains(t, string(body), `"cursor":12345`)
 }
 
-func TestEncodeExtended_CommitSupersetWithRecordCBOR(t *testing.T) {
+func TestEncodeV2_CommitSupersetWithRecordCBOR(t *testing.T) {
 	t.Parallel()
 	payload := []byte{0xa0}
 	evt := &segment.Event{
-		Seq:                 12345,
-		IndexedAt:           1_700_000_000_000_000,
-		UpstreamRelayCursor: 98765,
-		Kind:                segment.KindCreate,
-		DID:                 "did:plc:test",
-		Collection:          "app.bsky.feed.post",
-		Rkey:                "abc",
-		Rev:                 "rev1",
-		Payload:             payload,
+		Seq:        12345,
+		IndexedAt:  1_700_000_000_000_000,
+		Kind:       segment.KindCreate,
+		DID:        "did:plc:test",
+		Collection: "app.bsky.feed.post",
+		Rkey:       "abc",
+		Rev:        "rev1",
+		Payload:    payload,
 	}
 
-	simpleBody, err := Encode(evt)
+	v1Body, err := Encode(evt)
 	require.NoError(t, err)
-	extendedBody, err := EncodeExtended(evt)
+	v2Body, err := EncodeV2(evt)
 	require.NoError(t, err)
 
-	var simple, extended map[string]any
-	require.NoError(t, json.Unmarshal(simpleBody, &simple))
-	require.NoError(t, json.Unmarshal(extendedBody, &extended))
+	var v1, v2 map[string]any
+	require.NoError(t, json.Unmarshal(v1Body, &v1))
+	require.NoError(t, json.Unmarshal(v2Body, &v2))
 
 	for _, key := range []string{"did", "time_us", "cursor", "kind"} {
-		require.Equal(t, simple[key], extended[key], "extended must preserve simple top-level field %q", key)
+		require.Equal(t, v1[key], v2[key], "v2 must preserve v1 top-level field %q", key)
 	}
-	require.Equal(t, float64(12345), extended["seq"])
-	require.Equal(t, float64(98765), extended["upstream_relay_cursor"])
+	require.Equal(t, float64(12345), v2["seq"])
+	require.NotContains(t, v2, "upstream_relay_cursor", "internal relay cursor must not leak onto the wire")
 
-	simpleCommit, ok := simple["commit"].(map[string]any)
-	require.True(t, ok, "simple commit not a map")
-	extendedCommit, ok := extended["commit"].(map[string]any)
-	require.True(t, ok, "extended commit not a map")
+	v1Commit, ok := v1["commit"].(map[string]any)
+	require.True(t, ok, "v1 commit not a map")
+	v2Commit, ok := v2["commit"].(map[string]any)
+	require.True(t, ok, "v2 commit not a map")
 	for _, key := range []string{"rev", "operation", "collection", "rkey", "cid", "record"} {
-		require.Equal(t, simpleCommit[key], extendedCommit[key], "extended must preserve simple commit field %q", key)
+		require.Equal(t, v1Commit[key], v2Commit[key], "v2 must preserve v1 commit field %q", key)
 	}
-	require.Equal(t, base64.StdEncoding.EncodeToString(payload), extendedCommit["record_cbor"])
+	require.Equal(t, base64.StdEncoding.EncodeToString(payload), v2Commit["record_cbor"])
 }
 
-func TestEncodeExtended_CommitDeleteOmitsRecordPayloads(t *testing.T) {
+func TestEncodeV2_CommitDeleteOmitsRecordPayloads(t *testing.T) {
 	t.Parallel()
 	evt := &segment.Event{
-		Seq:                 9,
-		IndexedAt:           123,
-		UpstreamRelayCursor: 456,
-		Kind:                segment.KindDelete,
-		DID:                 "did:plc:test",
-		Collection:          "app.bsky.feed.post",
-		Rkey:                "abc",
-		Rev:                 "rev1",
+		Seq:        9,
+		IndexedAt:  123,
+		Kind:       segment.KindDelete,
+		DID:        "did:plc:test",
+		Collection: "app.bsky.feed.post",
+		Rkey:       "abc",
+		Rev:        "rev1",
 	}
 
-	body, err := EncodeExtended(evt)
+	body, err := EncodeV2(evt)
 	require.NoError(t, err)
 	var got map[string]any
 	require.NoError(t, json.Unmarshal(body, &got))
 	require.Equal(t, "commit", got["kind"])
 	require.Equal(t, float64(9), got["seq"])
-	require.Equal(t, float64(456), got["upstream_relay_cursor"])
 
 	commit, ok := got["commit"].(map[string]any)
 	require.True(t, ok, "commit not a map")
@@ -411,7 +407,7 @@ func TestEncodeExtended_CommitDeleteOmitsRecordPayloads(t *testing.T) {
 	require.NotContains(t, commit, "record_cbor")
 }
 
-func TestEncodeExtended_IdentityAndAccountCarryCursors(t *testing.T) {
+func TestEncodeV2_IdentityAndAccountCarryCursors(t *testing.T) {
 	t.Parallel()
 	ident := &comatproto.SyncSubscribeRepos_Identity{
 		DID: "did:plc:test", Seq: 99, Time: "2026-05-25T00:00:00Z",
@@ -435,13 +431,12 @@ func TestEncodeExtended_IdentityAndAccountCarryCursors(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			body, err := EncodeExtended(&segment.Event{
-				Seq:                 123,
-				IndexedAt:           1_700_000_000_000_000,
-				UpstreamRelayCursor: 321,
-				Kind:                tc.kind,
-				DID:                 "did:plc:test",
-				Payload:             tc.payload,
+			body, err := EncodeV2(&segment.Event{
+				Seq:       123,
+				IndexedAt: 1_700_000_000_000_000,
+				Kind:      tc.kind,
+				DID:       "did:plc:test",
+				Payload:   tc.payload,
 			})
 			require.NoError(t, err)
 			var got map[string]any
@@ -449,13 +444,12 @@ func TestEncodeExtended_IdentityAndAccountCarryCursors(t *testing.T) {
 			require.Equal(t, tc.name, got["kind"])
 			require.Equal(t, float64(123), got["cursor"])
 			require.Equal(t, float64(123), got["seq"])
-			require.Equal(t, float64(321), got["upstream_relay_cursor"])
 			require.Contains(t, got, tc.wantKey)
 		})
 	}
 }
 
-func TestEncodeExtended_SyncEmitsArchivedEvent(t *testing.T) {
+func TestEncodeV2_SyncEmitsArchivedEvent(t *testing.T) {
 	t.Parallel()
 	sync := &comatproto.SyncSubscribeRepos_Sync{
 		DID:    "did:plc:test",
@@ -466,14 +460,13 @@ func TestEncodeExtended_SyncEmitsArchivedEvent(t *testing.T) {
 	}
 	payload, err := sync.MarshalCBOR()
 	require.NoError(t, err)
-	body, err := EncodeExtended(&segment.Event{
-		Seq:                 77,
-		IndexedAt:           1_700_000_000_000_000,
-		UpstreamRelayCursor: 444,
-		Kind:                segment.KindSync,
-		DID:                 "did:plc:test",
-		Rev:                 "rev-sync",
-		Payload:             payload,
+	body, err := EncodeV2(&segment.Event{
+		Seq:       77,
+		IndexedAt: 1_700_000_000_000_000,
+		Kind:      segment.KindSync,
+		DID:       "did:plc:test",
+		Rev:       "rev-sync",
+		Payload:   payload,
 	})
 	require.NoError(t, err)
 
@@ -481,7 +474,6 @@ func TestEncodeExtended_SyncEmitsArchivedEvent(t *testing.T) {
 	require.NoError(t, json.Unmarshal(body, &got))
 	require.Equal(t, "sync", got["kind"])
 	require.Equal(t, float64(77), got["seq"])
-	require.Equal(t, float64(444), got["upstream_relay_cursor"])
 	require.Contains(t, got, "sync")
 
 	syncJSON, ok := got["sync"].(map[string]any)
@@ -491,9 +483,9 @@ func TestEncodeExtended_SyncEmitsArchivedEvent(t *testing.T) {
 	require.Equal(t, base64.StdEncoding.EncodeToString(sync.Blocks), syncJSON["blocks"])
 }
 
-func TestEncodeExtended_UnknownKindReturnsError(t *testing.T) {
+func TestEncodeV2_UnknownKindReturnsError(t *testing.T) {
 	t.Parallel()
-	_, err := EncodeExtended(&segment.Event{Kind: segment.Kind(99)})
+	_, err := EncodeV2(&segment.Event{Kind: segment.Kind(99)})
 	require.Error(t, err)
 	require.NotErrorIs(t, err, errSkipEvent)
 }

--- a/internal/subscribe/entry.go
+++ b/internal/subscribe/entry.go
@@ -17,23 +17,23 @@ type Entry struct {
 	body []byte
 	err  error
 
-	extendedOnce sync.Once
-	extendedBody []byte
-	extendedErr  error
+	v2Once sync.Once
+	v2Body []byte
+	v2Err  error
 
 	compressedOnce sync.Once
 	compressedBody []byte
 	compressedErr  error
 
-	compressedExtendedOnce sync.Once
-	compressedExtendedBody []byte
-	compressedExtendedErr  error
+	compressedV2Once sync.Once
+	compressedV2Body []byte
+	compressedV2Err  error
 
 	// encodeFn defaults to Encode; overridable in tests.
 	encodeFn func(*segment.Event) ([]byte, error)
 
-	// encodeExtendedFn defaults to EncodeExtended; overridable in tests.
-	encodeExtendedFn func(*segment.Event) ([]byte, error)
+	// encodeV2Fn defaults to EncodeV2; overridable in tests.
+	encodeV2Fn func(*segment.Event) ([]byte, error)
 }
 
 // newEntry wraps ev. The event's Payload is treated as read-only (it may
@@ -57,16 +57,16 @@ func (e *Entry) Encoded() ([]byte, error) {
 	return e.body, e.err
 }
 
-// EncodedExtended returns the memoized extended wire encoding for this entry.
-func (e *Entry) EncodedExtended() ([]byte, error) {
-	e.extendedOnce.Do(func() {
-		fn := e.encodeExtendedFn
+// EncodedV2 returns the memoized /subscribe-v2 wire encoding for this entry.
+func (e *Entry) EncodedV2() ([]byte, error) {
+	e.v2Once.Do(func() {
+		fn := e.encodeV2Fn
 		if fn == nil {
-			fn = EncodeExtended
+			fn = EncodeV2
 		}
-		e.extendedBody, e.extendedErr = fn(e.Event)
+		e.v2Body, e.v2Err = fn(e.Event)
 	})
-	return e.extendedBody, e.extendedErr
+	return e.v2Body, e.v2Err
 }
 
 // Compressed returns the memoized v1-shape JSON encoding compressed as a
@@ -87,17 +87,17 @@ func (e *Entry) Compressed() ([]byte, error) {
 	return e.compressedBody, e.compressedErr
 }
 
-// CompressedExtended is Compressed for the extended (v2) wire shape.
-func (e *Entry) CompressedExtended() ([]byte, error) {
-	e.compressedExtendedOnce.Do(func() {
-		body, err := e.EncodedExtended()
+// CompressedV2 is Compressed for the /subscribe-v2 wire shape.
+func (e *Entry) CompressedV2() ([]byte, error) {
+	e.compressedV2Once.Do(func() {
+		body, err := e.EncodedV2()
 		if err != nil {
-			e.compressedExtendedErr = err
+			e.compressedV2Err = err
 			return
 		}
-		e.compressedExtendedBody = compressFrame(body)
+		e.compressedV2Body = compressFrame(body)
 	})
-	return e.compressedExtendedBody, e.compressedExtendedErr
+	return e.compressedV2Body, e.compressedV2Err
 }
 
 // approxBytes estimates the entry's memory footprint for the hot ring's
@@ -105,7 +105,7 @@ func (e *Entry) CompressedExtended() ([]byte, error) {
 // memoized encodings are intentionally excluded — they are bounded by the
 // same ring (evicted FIFO with the entry) and counting them would
 // double-count the shared bytes. An entry may memoize up to four payloads
-// (simple/extended JSON × plain/zstd) when a mix of subscriber types is
+// (v1/v2 JSON × plain/zstd) when a mix of subscriber types is
 // connected; the off-budget overhang stays O(ring length).
 func (e *Entry) approxBytes() int {
 	ev := e.Event

--- a/internal/subscribe/entry_test.go
+++ b/internal/subscribe/entry_test.go
@@ -57,32 +57,32 @@ func TestEntry_MemoizesSkipSentinel(t *testing.T) {
 	require.Nil(t, body2)
 }
 
-func TestEntry_MemoizesSimpleAndExtendedIndependently(t *testing.T) {
+func TestEntry_MemoizesV1AndV2Independently(t *testing.T) {
 	t.Parallel()
-	var simpleCalls atomic.Int64
-	var extendedCalls atomic.Int64
+	var v1Calls atomic.Int64
+	var v2Calls atomic.Int64
 	e := newEntry(&segment.Event{Seq: 1, Kind: segment.KindDelete, DID: "did:plc:s"})
 	e.encodeFn = func(*segment.Event) ([]byte, error) {
-		simpleCalls.Add(1)
-		return []byte(`{"mode":"simple"}`), nil
+		v1Calls.Add(1)
+		return []byte(`{"mode":"v1"}`), nil
 	}
-	e.encodeExtendedFn = func(*segment.Event) ([]byte, error) {
-		extendedCalls.Add(1)
-		return []byte(`{"mode":"extended"}`), nil
+	e.encodeV2Fn = func(*segment.Event) ([]byte, error) {
+		v2Calls.Add(1)
+		return []byte(`{"mode":"v2"}`), nil
 	}
 
 	for range 3 {
 		body, err := e.Encoded()
 		require.NoError(t, err)
-		require.Equal(t, []byte(`{"mode":"simple"}`), body)
+		require.Equal(t, []byte(`{"mode":"v1"}`), body)
 
-		body, err = e.EncodedExtended()
+		body, err = e.EncodedV2()
 		require.NoError(t, err)
-		require.Equal(t, []byte(`{"mode":"extended"}`), body)
+		require.Equal(t, []byte(`{"mode":"v2"}`), body)
 	}
 
-	require.Equal(t, int64(1), simpleCalls.Load())
-	require.Equal(t, int64(1), extendedCalls.Load())
+	require.Equal(t, int64(1), v1Calls.Load())
+	require.Equal(t, int64(1), v2Calls.Load())
 }
 
 func TestEntry_CompressedMemoizesOnceAndDecodes(t *testing.T) {
@@ -132,12 +132,12 @@ func TestEntry_CompressedPropagatesSkipSentinel(t *testing.T) {
 	require.Nil(t, body)
 }
 
-// TestEntry_CompressedExtended_SyncEmitsDecodableFrame pins the divergence
-// between the v1 and extended wire shapes for KindSync events: the v1 path
-// returns errSkipEvent (no frame emitted) while the extended path emits a
-// real frame. This catches any future mis-wiring of CompressedExtended to
+// TestEntry_CompressedV2_SyncEmitsDecodableFrame pins the divergence
+// between the v1 and v2 wire shapes for KindSync events: the v1 path
+// returns errSkipEvent (no frame emitted) while the v2 path emits a
+// real frame. This catches any future mis-wiring of CompressedV2 to
 // the v1 source.
-func TestEntry_CompressedExtended_SyncEmitsDecodableFrame(t *testing.T) {
+func TestEntry_CompressedV2_SyncEmitsDecodableFrame(t *testing.T) {
 	t.Parallel()
 
 	sync := &comatproto.SyncSubscribeRepos_Sync{
@@ -151,13 +151,12 @@ func TestEntry_CompressedExtended_SyncEmitsDecodableFrame(t *testing.T) {
 	require.NoError(t, err)
 
 	e := newEntry(&segment.Event{
-		Seq:                 77,
-		IndexedAt:           1_700_000_000_000_000,
-		UpstreamRelayCursor: 555,
-		Kind:                segment.KindSync,
-		DID:                 "did:plc:testsync",
-		Rev:                 "rev-sync-test",
-		Payload:             payload,
+		Seq:       77,
+		IndexedAt: 1_700_000_000_000_000,
+		Kind:      segment.KindSync,
+		DID:       "did:plc:testsync",
+		Rev:       "rev-sync-test",
+		Payload:   payload,
 	})
 
 	// v1 path must skip #sync events.
@@ -165,15 +164,15 @@ func TestEntry_CompressedExtended_SyncEmitsDecodableFrame(t *testing.T) {
 	require.ErrorIs(t, compressedErr, errSkipEvent, "v1 Compressed must return errSkipEvent for KindSync")
 	require.Nil(t, compressedBody)
 
-	// Extended path must emit a decodable frame.
-	extBody, extErr := e.CompressedExtended()
-	require.NoError(t, extErr, "CompressedExtended must not return an error for KindSync")
-	require.NotNil(t, extBody, "CompressedExtended must return a non-nil frame for KindSync")
+	// v2 path must emit a decodable frame.
+	v2Body, v2Err := e.CompressedV2()
+	require.NoError(t, v2Err, "CompressedV2 must not return an error for KindSync")
+	require.NotNil(t, v2Body, "CompressedV2 must return a non-nil frame for KindSync")
 
 	dec, err := zstd.NewReader(nil, zstd.WithDecoderDicts(zstdDictionary))
 	require.NoError(t, err)
 	defer dec.Close()
-	decoded, err := dec.DecodeAll(extBody, nil)
+	decoded, err := dec.DecodeAll(v2Body, nil)
 	require.NoError(t, err)
 
 	require.Contains(t, string(decoded), `"kind":"sync"`, "decoded frame must contain kind:sync")

--- a/internal/subscribe/handler.go
+++ b/internal/subscribe/handler.go
@@ -52,16 +52,19 @@ type Subscription struct {
 	// cursor replay entirely (cursors are silently dropped to live).
 	Lookback time.Duration
 
-	// EmitResyncReplacementRows enables the v2 presentation policy used by
-	// /subscribe-v2. The default false preserves Jetstream v1 behavior by
-	// advancing over Sync 1.1 resync replacement rows without emitting them.
-	EmitResyncReplacementRows bool
-
-	// RejectCursorBelowFloor enables the v2 too-old policy: a seq cursor that
-	// resolves below the lookback floor returns a pre-upgrade HTTP 400 carrying
-	// the floor seq, instead of being silently clamped. Set true on
-	// /subscribe-v2; the default false preserves v1's legacy silent clamp.
-	RejectCursorBelowFloor bool
+	// V2 selects the /subscribe-v2 presentation policy as a bundle:
+	//
+	//   - the v2 wire shape (seq + commit.record_cbor on every event, and
+	//     archived #sync events emitted rather than skipped),
+	//   - Sync 1.1 resync replacement rows are emitted (v1 advances over
+	//     them silently for wire parity),
+	//   - a seq cursor below the lookback floor is REJECTED with a
+	//     pre-upgrade HTTP 400 carrying the floor seq (v1 silently clamps).
+	//
+	// The default false preserves Jetstream v1 behavior on /subscribe.
+	// These are deliberately one flag: the policies describe one endpoint
+	// contract and must not be mixed and matched.
+	V2 bool
 }
 
 func (d Subscription) writer() *ingest.Writer {
@@ -120,7 +123,6 @@ func serve(w http.ResponseWriter, r *http.Request, deps Subscription, logger *sl
 	}
 
 	requireHello := parseRequireHello(values)
-	extended := values.Get("extended") == "true"
 
 	// Resolve cursor BEFORE upgrade so a bad cursor returns HTTP 400.
 	rawCursor := values.Get("cursor")
@@ -172,7 +174,7 @@ func serve(w http.ResponseWriter, r *http.Request, deps Subscription, logger *sl
 			Manifest:         deps.Manifest,
 			NextSeq:          deps.writer().NextSeq(),
 			Lookback:         deps.Lookback,
-			RejectBelowFloor: deps.RejectCursorBelowFloor,
+			RejectBelowFloor: deps.V2,
 		})
 		deps.Metrics.observeCursorResolveSeconds(time.Since(resolveStart).Seconds())
 		if err != nil {
@@ -295,7 +297,7 @@ func serve(w http.ResponseWriter, r *http.Request, deps Subscription, logger *sl
 		startSeq = deps.Tail.Tip()
 	}
 
-	runSubscriberLoop(ctx, conn, deps, &filterPtr, startSeq, extended, wantZstd, logger)
+	runSubscriberLoop(ctx, conn, deps, &filterPtr, startSeq, wantZstd, logger)
 }
 
 func runReader(
@@ -363,7 +365,6 @@ func runSubscriberLoop(
 	deps Subscription,
 	filterPtr *atomic.Pointer[Filter],
 	startSeq uint64,
-	extended bool,
 	compress bool,
 	logger *slog.Logger,
 ) {
@@ -426,7 +427,7 @@ func runSubscriberLoop(
 
 		for _, e := range batch {
 			f := filterPtr.Load()
-			if e.Event.Kind.IsResyncReplacement() && !deps.EmitResyncReplacementRows {
+			if e.Event.Kind.IsResyncReplacement() && !deps.V2 {
 				deps.Metrics.incEventsSkippedResync()
 				continue
 			}
@@ -442,8 +443,8 @@ func runSubscriberLoop(
 			// A deliberate, documented divergence from v1.
 			var body []byte
 			var eerr error
-			if extended {
-				body, eerr = e.EncodedExtended()
+			if deps.V2 {
+				body, eerr = e.EncodedV2()
 			} else {
 				body, eerr = e.Encoded()
 			}
@@ -471,8 +472,8 @@ func runSubscriberLoop(
 			payload := body
 			if compress {
 				var cerr error
-				if extended {
-					payload, cerr = e.CompressedExtended()
+				if deps.V2 {
+					payload, cerr = e.CompressedV2()
 				} else {
 					payload, cerr = e.Compressed()
 				}

--- a/internal/subscribe/handler_integration_test.go
+++ b/internal/subscribe/handler_integration_test.go
@@ -167,10 +167,10 @@ func newCursorReplaySubscription(t *testing.T, minSeq, maxSeq uint64, rejectBelo
 
 	srv := httptest.NewServer(subscribe.NewHandler(subscribe.Subscription{
 		Tail: b, Store: st, Manifest: m, Writer: w,
-		Logger:                 slog.New(slog.NewTextHandler(io.Discard, nil)),
-		Metrics:                subscribe.NewMetrics(prometheus.NewRegistry()),
-		Lookback:               36 * time.Hour,
-		RejectCursorBelowFloor: rejectBelowFloor,
+		Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Metrics:  subscribe.NewMetrics(prometheus.NewRegistry()),
+		Lookback: 36 * time.Hour,
+		V2:       rejectBelowFloor,
 	}))
 	t.Cleanup(srv.Close)
 	return srv

--- a/internal/subscribe/handler_test.go
+++ b/internal/subscribe/handler_test.go
@@ -238,10 +238,10 @@ func TestHandler_ResyncModeEmitsResyncReplacementRows(t *testing.T) {
 	require.NoError(t, err)
 
 	h := NewHandler(Subscription{
-		Tail:                      b,
-		Store:                     st,
-		Logger:                    slog.New(slog.NewTextHandler(io.Discard, nil)),
-		EmitResyncReplacementRows: true,
+		Tail:   b,
+		Store:  st,
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		V2:     true,
 	})
 	srv := httptest.NewServer(h)
 	defer srv.Close()
@@ -295,10 +295,10 @@ func TestHandler_DIDLevelEventsBypassCollectionFilter(t *testing.T) {
 	require.NoError(t, err)
 
 	h := NewHandler(Subscription{
-		Tail:                      b,
-		Store:                     st,
-		Logger:                    slog.New(slog.NewTextHandler(io.Discard, nil)),
-		EmitResyncReplacementRows: true,
+		Tail:   b,
+		Store:  st,
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		V2:     true,
 	})
 	srv := httptest.NewServer(h)
 	defer srv.Close()
@@ -353,7 +353,7 @@ func TestHandler_DIDLevelEventsBypassCollectionFilter(t *testing.T) {
 	require.Equal(t, "commit", gotCommit["kind"])
 }
 
-func TestHandler_ExtendedDeliversRecordCBORAndSync(t *testing.T) {
+func TestHandler_V2DeliversRecordCBORAndSync(t *testing.T) {
 	t.Parallel()
 
 	st := newSteadyStateStore(t)
@@ -364,11 +364,12 @@ func TestHandler_ExtendedDeliversRecordCBORAndSync(t *testing.T) {
 		Tail:   b,
 		Store:  st,
 		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		V2:     true,
 	})
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
-	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "?extended=true"
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -385,14 +386,13 @@ func TestHandler_ExtendedDeliversRecordCBORAndSync(t *testing.T) {
 	var seq uint64
 	payload := []byte{0xa0}
 	appendSeq(b, &seq, &segment.Event{
-		IndexedAt:           1779719010267528,
-		UpstreamRelayCursor: 111,
-		Kind:                segment.KindCreate,
-		DID:                 "did:plc:extended",
-		Collection:          "app.bsky.feed.post",
-		Rkey:                "abcd1234",
-		Rev:                 "3lXrev",
-		Payload:             payload,
+		IndexedAt:  1779719010267528,
+		Kind:       segment.KindCreate,
+		DID:        "did:plc:v2",
+		Collection: "app.bsky.feed.post",
+		Rkey:       "abcd1234",
+		Rev:        "3lXrev",
+		Payload:    payload,
 	})
 
 	commitFrame := readOneFrame(t, ctx, conn)
@@ -401,24 +401,23 @@ func TestHandler_ExtendedDeliversRecordCBORAndSync(t *testing.T) {
 	require.Equal(t, "commit", commit["kind"])
 	require.Equal(t, float64(0), commit["cursor"])
 	require.Equal(t, float64(0), commit["seq"])
-	require.Equal(t, float64(111), commit["upstream_relay_cursor"])
+	require.NotContains(t, commit, "upstream_relay_cursor")
 	commitPayload, ok := commit["commit"].(map[string]any)
 	require.True(t, ok, "commit payload not a map")
 	require.Equal(t, base64.StdEncoding.EncodeToString(payload), commitPayload["record_cbor"])
 
 	syncEvt := &comatproto.SyncSubscribeRepos_Sync{
-		DID: "did:plc:extended", Rev: "rev-sync", Seq: 222, Time: "2026-05-25T00:00:00Z",
+		DID: "did:plc:v2", Rev: "rev-sync", Seq: 222, Time: "2026-05-25T00:00:00Z",
 		Blocks: []byte{0x01},
 	}
 	syncPayload, err := syncEvt.MarshalCBOR()
 	require.NoError(t, err)
 	appendSeq(b, &seq, &segment.Event{
-		IndexedAt:           1779719010267529,
-		UpstreamRelayCursor: 222,
-		Kind:                segment.KindSync,
-		DID:                 "did:plc:extended",
-		Rev:                 "rev-sync",
-		Payload:             syncPayload,
+		IndexedAt: 1779719010267529,
+		Kind:      segment.KindSync,
+		DID:       "did:plc:v2",
+		Rev:       "rev-sync",
+		Payload:   syncPayload,
 	})
 
 	syncFrame := readOneFrame(t, ctx, conn)
@@ -426,11 +425,10 @@ func TestHandler_ExtendedDeliversRecordCBORAndSync(t *testing.T) {
 	require.NoError(t, json.Unmarshal(syncFrame, &syncGot))
 	require.Equal(t, "sync", syncGot["kind"])
 	require.Equal(t, float64(1), syncGot["cursor"])
-	require.Equal(t, float64(222), syncGot["upstream_relay_cursor"])
 	require.Contains(t, syncGot, "sync")
 }
 
-func TestHandler_DefaultModeDoesNotEmitExtendedFields(t *testing.T) {
+func TestHandler_V1ModeDoesNotEmitV2Fields(t *testing.T) {
 	t.Parallel()
 
 	st := newSteadyStateStore(t)
@@ -461,14 +459,13 @@ func TestHandler_DefaultModeDoesNotEmitExtendedFields(t *testing.T) {
 
 	var seq uint64
 	appendSeq(b, &seq, &segment.Event{
-		IndexedAt:           1779719010267528,
-		UpstreamRelayCursor: 111,
-		Kind:                segment.KindCreate,
-		DID:                 "did:plc:simple",
-		Collection:          "app.bsky.feed.post",
-		Rkey:                "abcd1234",
-		Rev:                 "3lXrev",
-		Payload:             []byte{0xa0},
+		IndexedAt:  1779719010267528,
+		Kind:       segment.KindCreate,
+		DID:        "did:plc:simple",
+		Collection: "app.bsky.feed.post",
+		Rkey:       "abcd1234",
+		Rev:        "3lXrev",
+		Payload:    []byte{0xa0},
 	})
 
 	frame := readOneFrame(t, ctx, conn)

--- a/segment/event.go
+++ b/segment/event.go
@@ -68,8 +68,9 @@ type Event struct {
 	IndexedAt  int64
 	RenderedAt int64
 	// UpstreamRelayCursor is the relay subscribeRepos cursor that produced
-	// this event. It is carried in memory for extended websocket clients;
-	// the current segment block format does not persist it.
+	// this event. It is carried in memory for internal consumers (sync-state
+	// hosting promotion, the simulator oracle); it is not on any subscriber
+	// wire and the current segment block format does not persist it.
 	UpstreamRelayCursor int64
 	Kind                Kind
 

--- a/specs/notes/2026-06-18-go-client-design.md
+++ b/specs/notes/2026-06-18-go-client-design.md
@@ -1,7 +1,10 @@
 # Go Client Design
 
 Date: 2026-06-18
-Status: design / planning
+Status: design / planning (historical note: the `?extended=true` mode referenced
+below was later folded into `/subscribe-v2` unconditionally and the query param,
+`upstream_relay_cursor` wire field, and extended control events were removed —
+see docs/README.md §5.2)
 Labels: `client`, `testing`
 Related: #77 (oracle: drive historical reads through the real Go client)
 

--- a/specs/oracle.md
+++ b/specs/oracle.md
@@ -275,8 +275,8 @@ reads go through the client-driven tier above (the archive transport real
 clients use), per issue #77.
 
 The replay tier validates hot tail / cold reader handoff, cursor semantics,
-JSON encoding, extended events, pending writer snapshots, manifest refresh,
-and compaction cache invalidation.
+JSON encoding (v1 and v2 wire shapes), pending writer snapshots, manifest
+refresh, and compaction cache invalidation.
 
 ### XRPC Segment Egress Tier
 


### PR DESCRIPTION
Closes #194.

## What

Removes the `?extended=true` payload mode. `/subscribe-v2` now always emits the former extended shape; `/subscribe` (v1) is unchanged.

- **Wire**: v2 frames always carry envelope `seq` and `commit.record_cbor` (base64 DAG-CBOR), and archived `#sync` events are emitted rather than skipped. v2 remains a strict superset of v1 — `commit.record` (decoded JSON) stays alongside `record_cbor`.
- **`upstream_relay_cursor` removed from the wire.** The in-memory `segment.Event.UpstreamRelayCursor` field stays for internal consumers (syncstate hosting promotion, oracle eventlog); it was only on the wire for the dropped §6 replication design.
- **Policy consolidation**: `EmitResyncReplacementRows` + `RejectCursorBelowFloor` collapse into a single `Subscription.V2` bool. The v2 wire shape, resync replacement rows, and below-floor cursor rejection (pre-upgrade HTTP 400 vs v1's silent clamp) are one endpoint contract, deliberately not mix-and-match.
- **Renames**: `EncodeExtended` → `EncodeV2` and the `extended*` types → `v2*`; hot-ring entry memoization slots follow (`EncodedV2`/`CompressedV2`, still four `sync.Once`-guarded payloads: v1/v2 JSON × plain/zstd).
- **Go client**: stops sending `extended=true`; a regression guard in `live_test.go` asserts the param never reappears on the subscribe URL. Live decode error messages now point at `/subscribe-v2` when `record_cbor` is missing.
- **Docs**: README §5.2 rewritten as "The /subscribe-v2 JSON Payload" with a historical note on the dropped design; §6 Replication stubbed as DROPPED pointing at the HA clustering note; `specs/oracle.md` and the go-client design note updated. Dated historical spec notes are otherwise left intact as records of past decisions.

## Why

The extended mode existed solely for the docs §6 replication scheme, which we are not implementing — HA will be redesigned later without an extended subscriber wire. Nothing has shipped to production, so there are no external users; the bundled Go client (the one real consumer, needing `record_cbor` + `#sync` on live) moves to the unconditional v2 shape.

## Verification

- `golangci-lint run ./...`: 0 issues
- `just test` (short): 1719 tests pass
- `just test-long`: 3684 tests pass
- `FuzzEncodeV2` 10s smoke run: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)