### PR TITLE
cmd: exit 1 on unknown JETSTREAM env vars

### DIFF
--- a/.env
+++ b/.env
@@ -10,7 +10,3 @@ JETSTREAM_DATA_DIR=./data-sim
 JETSTREAM_SKIP_MERGE_DISCOVERY=true
 JETSTREAM_DISABLE_REPO_ACTION_RATE_LIMITS=true
 JETSTREAM_SIM_DATA_DIR=./data-sim
-
-# Make /status feel live during local development. Production
-# leaves this at the 30s default to amortize pebble scans.
-JETSTREAM_STATUS_CACHE_TTL=1s

--- a/cmd/jetstream/inspect_segment_test.go
+++ b/cmd/jetstream/inspect_segment_test.go
@@ -278,7 +278,7 @@ func TestInspectSegmentCommand_EndToEndAgainstRealFile(t *testing.T) {
 	path := makeSealedFixture(t)
 
 	var buf bytes.Buffer
-	app := newApp()
+	app := newTestApp()
 	app.Writer = &buf
 
 	err := app.Run(t.Context(), []string{
@@ -300,7 +300,7 @@ func TestInspectSegmentCommand_RejectsBadFlag(t *testing.T) {
 	t.Parallel()
 	path := makeSealedFixture(t)
 
-	app := newApp()
+	app := newTestApp()
 	app.Writer = new(bytes.Buffer)
 	err := app.Run(t.Context(), []string{
 		"jetstream", "inspect-segment", "--blocks=foo", path,
@@ -311,7 +311,7 @@ func TestInspectSegmentCommand_RejectsBadFlag(t *testing.T) {
 
 func TestInspectSegmentCommand_RejectsMissingArg(t *testing.T) {
 	t.Parallel()
-	app := newApp()
+	app := newTestApp()
 	app.Writer = new(bytes.Buffer)
 	err := app.Run(t.Context(), []string{"jetstream", "inspect-segment"})
 	require.Error(t, err)

--- a/cmd/jetstream/main.go
+++ b/cmd/jetstream/main.go
@@ -55,7 +55,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"os/signal"
 	"sort"
@@ -71,6 +70,10 @@ import (
 )
 
 const jetstreamEnvPrefix = "JETSTREAM_"
+
+var knownForeignJetstreamEnvPrefixes = []string{
+	"JETSTREAM_SIM_",
+}
 
 func main() {
 	if err := newApp().Run(context.Background(), os.Args); err != nil {
@@ -98,8 +101,7 @@ func newApp() *cli.Command {
 		Usage:   "Full-network archive and streaming service for atproto",
 		Version: fmt.Sprintf("%s (commit %s, built %s)", info.Version, info.Commit, info.Date),
 		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
-			warnUnknownJetstreamEnvVars(cmd.Root(), os.Environ())
-			return ctx, nil
+			return ctx, rejectUnknownJetstreamEnvVars(cmd.Root(), os.Environ())
 		},
 		Flags: []cli.Flag{
 			&cli.StringFlag{
@@ -485,9 +487,15 @@ func runServe(ctx context.Context, cmd *cli.Command) error {
 	return closeErr
 }
 
-func warnUnknownJetstreamEnvVars(root *cli.Command, environ []string) {
-	for _, key := range unknownJetstreamEnvVars(root, environ) {
-		_, _ = fmt.Fprintf(commandErrWriter(root), "jetstream: warning: unrecognized %s environment variable %s\n", jetstreamEnvPrefix, key)
+func rejectUnknownJetstreamEnvVars(root *cli.Command, environ []string) error {
+	unknown := unknownJetstreamEnvVars(root, environ)
+	switch len(unknown) {
+	case 0:
+		return nil
+	case 1:
+		return fmt.Errorf("unrecognized %s environment variable %s", jetstreamEnvPrefix, unknown[0])
+	default:
+		return fmt.Errorf("unrecognized %s environment variables: %s", jetstreamEnvPrefix, strings.Join(unknown, ", "))
 	}
 }
 
@@ -498,6 +506,9 @@ func unknownJetstreamEnvVars(root *cli.Command, environ []string) []string {
 	for _, entry := range environ {
 		key, _, _ := strings.Cut(entry, "=")
 		if !strings.HasPrefix(key, jetstreamEnvPrefix) {
+			continue
+		}
+		if hasAnyPrefix(key, knownForeignJetstreamEnvPrefixes) {
 			continue
 		}
 		if _, ok := known[key]; ok {
@@ -511,6 +522,15 @@ func unknownJetstreamEnvVars(root *cli.Command, environ []string) []string {
 	}
 	sort.Strings(unknown)
 	return unknown
+}
+
+func hasAnyPrefix(key string, prefixes []string) bool {
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func knownEnvVars(root *cli.Command) map[string]struct{} {
@@ -534,11 +554,4 @@ func walkCommands(cmd *cli.Command, visit func(*cli.Command)) {
 	for _, sub := range cmd.Commands {
 		walkCommands(sub, visit)
 	}
-}
-
-func commandErrWriter(cmd *cli.Command) io.Writer {
-	if cmd != nil && cmd.ErrWriter != nil {
-		return cmd.ErrWriter
-	}
-	return os.Stderr
 }

--- a/cmd/jetstream/main.go
+++ b/cmd/jetstream/main.go
@@ -55,8 +55,10 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -67,6 +69,8 @@ import (
 	"github.com/jcalabro/atmos"
 	"github.com/urfave/cli/v3"
 )
+
+const jetstreamEnvPrefix = "JETSTREAM_"
 
 func main() {
 	if err := newApp().Run(context.Background(), os.Args); err != nil {
@@ -93,6 +97,10 @@ func newApp() *cli.Command {
 		Name:    "jetstream",
 		Usage:   "Full-network archive and streaming service for atproto",
 		Version: fmt.Sprintf("%s (commit %s, built %s)", info.Version, info.Commit, info.Date),
+		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
+			warnUnknownJetstreamEnvVars(cmd.Root(), os.Environ())
+			return ctx, nil
+		},
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:    "log-level",
@@ -475,4 +483,62 @@ func runServe(ctx context.Context, cmd *cli.Command) error {
 		return runErr
 	}
 	return closeErr
+}
+
+func warnUnknownJetstreamEnvVars(root *cli.Command, environ []string) {
+	for _, key := range unknownJetstreamEnvVars(root, environ) {
+		_, _ = fmt.Fprintf(commandErrWriter(root), "jetstream: warning: unrecognized %s environment variable %s\n", jetstreamEnvPrefix, key)
+	}
+}
+
+func unknownJetstreamEnvVars(root *cli.Command, environ []string) []string {
+	known := knownEnvVars(root)
+	seen := make(map[string]struct{})
+	var unknown []string
+	for _, entry := range environ {
+		key, _, _ := strings.Cut(entry, "=")
+		if !strings.HasPrefix(key, jetstreamEnvPrefix) {
+			continue
+		}
+		if _, ok := known[key]; ok {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		unknown = append(unknown, key)
+	}
+	sort.Strings(unknown)
+	return unknown
+}
+
+func knownEnvVars(root *cli.Command) map[string]struct{} {
+	out := make(map[string]struct{})
+	walkCommands(root, func(cmd *cli.Command) {
+		for _, flag := range cmd.Flags {
+			docFlag, ok := flag.(cli.DocGenerationFlag)
+			if !ok {
+				continue
+			}
+			for _, key := range docFlag.GetEnvVars() {
+				out[key] = struct{}{}
+			}
+		}
+	})
+	return out
+}
+
+func walkCommands(cmd *cli.Command, visit func(*cli.Command)) {
+	visit(cmd)
+	for _, sub := range cmd.Commands {
+		walkCommands(sub, visit)
+	}
+}
+
+func commandErrWriter(cmd *cli.Command) io.Writer {
+	if cmd != nil && cmd.ErrWriter != nil {
+		return cmd.ErrWriter
+	}
+	return os.Stderr
 }

--- a/cmd/jetstream/main.go
+++ b/cmd/jetstream/main.go
@@ -95,13 +95,20 @@ func main() {
 // Concretely this means both `jetstream --log-level=debug serve` and
 // `JETSTREAM_LOG_LEVEL=debug jetstream serve` work.
 func newApp() *cli.Command {
+	return newAppWithEnviron(os.Environ)
+}
+
+func newAppWithEnviron(environ func() []string) *cli.Command {
+	if environ == nil {
+		environ = os.Environ
+	}
 	info := version.Get()
 	return &cli.Command{
 		Name:    "jetstream",
 		Usage:   "Full-network archive and streaming service for atproto",
 		Version: fmt.Sprintf("%s (commit %s, built %s)", info.Version, info.Commit, info.Date),
 		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
-			return ctx, rejectUnknownJetstreamEnvVars(cmd.Root(), os.Environ())
+			return ctx, rejectUnknownJetstreamEnvVars(cmd.Root(), environ())
 		},
 		Flags: []cli.Flag{
 			&cli.StringFlag{

--- a/cmd/jetstream/main_test.go
+++ b/cmd/jetstream/main_test.go
@@ -15,7 +15,7 @@ func TestNewApp_VersionCommandPrintsToStdout(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	app := newApp()
+	app := newTestApp()
 	app.Writer = &buf
 
 	err := app.Run(t.Context(), []string{"jetstream", "version"})
@@ -33,7 +33,7 @@ func TestNewApp_InspectSegmentRunsAgainstSealedFile(t *testing.T) {
 	path := makeSealedFixture(t)
 
 	var buf bytes.Buffer
-	app := newApp()
+	app := newTestApp()
 	app.Writer = &buf
 
 	err := app.Run(t.Context(), []string{"jetstream", "inspect-segment", path})

--- a/cmd/jetstream/serve_test.go
+++ b/cmd/jetstream/serve_test.go
@@ -92,62 +92,76 @@ func TestServeOptionsFromCLI_Defaults(t *testing.T) {
 	require.Equal(t, 60*time.Second, opts.SubscribeSlowWindow)
 	require.Equal(t, float64(5), opts.SubscribeSlowMinRate)
 	require.Equal(t, 32, opts.CursorBlockIndexCacheSize)
+	require.Equal(t, 4*time.Hour, opts.CompactionInterval)
+	require.Equal(t, 32_000_000, opts.CompactionTombstoneCap)
 	require.Equal(t, 0, opts.CompactionRewriteWorkers)
+	require.Equal(t, "", opts.TimestampImportToken)
+	require.Equal(t, "", opts.TimestampImportDir)
 	require.Nil(t, opts.BarrierAfterBootstrap)
 	require.Nil(t, opts.BarrierAfterMerge)
 	require.Nil(t, opts.OnSteadyStateEvent)
 }
 
-// withClearedEnv unsets every environment variable the serve flags bind
-// to, restoring the prior values via t.Cleanup. urfave/cli treats those
-// vars as flag sources, so a default-value assertion is only meaningful
-// in an environment where none of them are set. The caller must NOT be
-// parallel: this mutates global process state.
+// withClearedEnv unsets every JETSTREAM_* variable plus every non-prefixed
+// environment variable the flags bind to, restoring the prior values via
+// t.Cleanup. urfave/cli treats those vars as flag sources, so a default-value
+// assertion is only meaningful in an environment where none of them are set.
+// The caller must NOT be parallel: this mutates global process state.
 func withClearedEnv(t *testing.T) {
 	t.Helper()
-	for _, key := range []string{
-		"JETSTREAM_ADDR",
-		"JETSTREAM_DEBUG_ADDR",
-		"JETSTREAM_DATA_DIR",
-		"JETSTREAM_RELAY_URL",
-		"JETSTREAM_PLC_URL",
-		"OTEL_SERVICE_NAME",
-		"JETSTREAM_LOG_LEVEL",
-		"JETSTREAM_LOG_FORMAT",
-		"JETSTREAM_SHUTDOWN_TIMEOUT",
-		"JETSTREAM_CLIENT_DRAIN_TIMEOUT",
-		"JETSTREAM_MAX_BACKFILL_REPOS",
-		"JETSTREAM_BACKFILL_WORKERS",
-		"JETSTREAM_BACKFILL_BATCH_SIZE",
-		"JETSTREAM_BACKFILL_ASYNC_FLUSH_WORKERS",
-		"JETSTREAM_BACKFILL_REPOS",
-		"JETSTREAM_SKIP_MERGE_DISCOVERY",
-		"JETSTREAM_FAILED_REPO_RETRY_INTERVAL",
-		"JETSTREAM_FAILED_REPO_RETRY_WORKERS",
-		"JETSTREAM_FAILED_REPO_RETRY_HOST_WORKERS",
-		"JETSTREAM_FAILED_REPO_RETRY_MAX_DELAY",
-		"JETSTREAM_DISABLE_REPO_ACTION_RATE_LIMITS",
-		"JETSTREAM_CURSOR_LOOKBACK",
-		"JETSTREAM_SEGMENT_CACHE_MAX_AGE",
-		"JETSTREAM_PLAN_MAX_DIDS",
-		"JETSTREAM_PLAN_MAX_COLLECTIONS",
-		"JETSTREAM_PLAN_MAX_ENTRIES",
-		"JETSTREAM_PLAN_WHOLE_SEGMENT_THRESHOLD",
-		"JETSTREAM_SUBSCRIBE_HOT_TAIL_BYTES",
-		"JETSTREAM_SUBSCRIBE_BLOCK_CACHE_BYTES",
-		"JETSTREAM_SUBSCRIBE_READ_BATCH",
-		"JETSTREAM_SUBSCRIBE_SLOW_WINDOW",
-		"JETSTREAM_SUBSCRIBE_SLOW_MIN_RATE",
-		"JETSTREAM_CURSOR_BLOCK_INDEX_CACHE_SIZE",
-		"JETSTREAM_COMPACTION_INTERVAL",
-		"JETSTREAM_COMPACTION_TOMBSTONE_CAP",
-		"JETSTREAM_COMPACTION_REWRITE_WORKERS",
-	} {
+	keys := knownEnvVars(newApp())
+	for _, entry := range os.Environ() {
+		key, _, _ := strings.Cut(entry, "=")
+		if strings.HasPrefix(key, jetstreamEnvPrefix) {
+			keys[key] = struct{}{}
+		}
+	}
+	for key := range keys {
+		key := key
 		if prev, ok := os.LookupEnv(key); ok {
 			require.NoError(t, os.Unsetenv(key))
 			t.Cleanup(func() { _ = os.Setenv(key, prev) })
 		}
 	}
+}
+
+func TestNewApp_WarnsOnUnknownJetstreamEnvVars(t *testing.T) {
+	withClearedEnv(t)
+	t.Setenv("JETSTREAM_ADDR", "127.0.0.1:0")
+	t.Setenv("JETSTREAM_ADDR_TYPO", "127.0.0.1:1")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel.example.com:4318")
+
+	var errBuf bytes.Buffer
+	app := newApp()
+	app.ErrWriter = &errBuf
+	for _, cmd := range app.Commands {
+		if cmd.Name != "serve" {
+			continue
+		}
+		cmd.Action = func(context.Context, *cli.Command) error {
+			return nil
+		}
+		break
+	}
+
+	require.NoError(t, app.Run(t.Context(), []string{"jetstream", "serve"}))
+
+	errOut := errBuf.String()
+	require.Contains(t, errOut, "jetstream: warning: unrecognized JETSTREAM_ environment variable JETSTREAM_ADDR_TYPO")
+	require.NotContains(t, errOut, "JETSTREAM_ADDR\n")
+	require.NotContains(t, errOut, "OTEL_EXPORTER_OTLP_ENDPOINT")
+}
+
+func TestUnknownJetstreamEnvVars_SortedAndDedupesKnownFlags(t *testing.T) {
+	t.Parallel()
+
+	got := unknownJetstreamEnvVars(newApp(), []string{
+		"JETSTREAM_ZZZ=1",
+		"JETSTREAM_ADDR=127.0.0.1:0",
+		"OTEL_SERVICE_NAME=jetstream-test",
+		"JETSTREAM_AAA=value=with=equals",
+	})
+	require.Equal(t, []string{"JETSTREAM_AAA", "JETSTREAM_ZZZ"}, got)
 }
 
 func TestServeOptionsFromCLI_Overrides(t *testing.T) {
@@ -202,7 +216,11 @@ func TestServeOptionsFromCLI_Overrides(t *testing.T) {
 		"--subscribe-slow-window=22s",
 		"--subscribe-slow-min-rate=9.5",
 		"--cursor-block-index-cache-size=99",
+		"--compaction-interval=9h",
+		"--compaction-tombstone-cap=123456",
 		"--compaction-rewrite-workers=3",
+		"--timestamp-import-token=test-token",
+		"--timestamp-import-dir=/tmp/jetstream-imports",
 	}))
 	require.Equal(t, "127.0.0.1:18080", opts.PublicAddr)
 	require.Equal(t, "127.0.0.1:16060", opts.DebugAddr)
@@ -238,7 +256,11 @@ func TestServeOptionsFromCLI_Overrides(t *testing.T) {
 	require.Equal(t, 22*time.Second, opts.SubscribeSlowWindow)
 	require.Equal(t, 9.5, opts.SubscribeSlowMinRate)
 	require.Equal(t, 99, opts.CursorBlockIndexCacheSize)
+	require.Equal(t, 9*time.Hour, opts.CompactionInterval)
+	require.Equal(t, 123456, opts.CompactionTombstoneCap)
 	require.Equal(t, 3, opts.CompactionRewriteWorkers)
+	require.Equal(t, "test-token", opts.TimestampImportToken)
+	require.Equal(t, "/tmp/jetstream-imports", opts.TimestampImportDir)
 	require.Nil(t, opts.BarrierAfterBootstrap)
 	require.Nil(t, opts.BarrierAfterMerge)
 	require.Nil(t, opts.OnSteadyStateEvent)

--- a/cmd/jetstream/serve_test.go
+++ b/cmd/jetstream/serve_test.go
@@ -126,6 +126,8 @@ func withClearedEnv(t *testing.T) {
 }
 
 func TestNewApp_RejectsUnknownJetstreamEnvVars(t *testing.T) {
+	t.Parallel()
+
 	var actionCalled bool
 	app := newAppWithEnviron(func() []string {
 		return []string{

--- a/cmd/jetstream/serve_test.go
+++ b/cmd/jetstream/serve_test.go
@@ -43,7 +43,7 @@ func TestServeOptionsFromCLI_Defaults(t *testing.T) {
 	// env here is safe.
 	withClearedEnv(t)
 
-	app := newApp()
+	app := newTestApp()
 	var opts jetstreamd.Options
 	for _, cmd := range app.Commands {
 		if cmd.Name != "serve" {
@@ -109,7 +109,7 @@ func TestServeOptionsFromCLI_Defaults(t *testing.T) {
 // The caller must NOT be parallel: this mutates global process state.
 func withClearedEnv(t *testing.T) {
 	t.Helper()
-	keys := knownEnvVars(newApp())
+	keys := knownEnvVars(newTestApp())
 	for _, entry := range os.Environ() {
 		key, _, _ := strings.Cut(entry, "=")
 		if strings.HasPrefix(key, jetstreamEnvPrefix) {
@@ -126,13 +126,14 @@ func withClearedEnv(t *testing.T) {
 }
 
 func TestNewApp_RejectsUnknownJetstreamEnvVars(t *testing.T) {
-	withClearedEnv(t)
-	t.Setenv("JETSTREAM_ADDR", "127.0.0.1:0")
-	t.Setenv("JETSTREAM_ADDR_TYPO", "127.0.0.1:1")
-	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel.example.com:4318")
-
 	var actionCalled bool
-	app := newApp()
+	app := newAppWithEnviron(func() []string {
+		return []string{
+			"JETSTREAM_ADDR=127.0.0.1:0",
+			"JETSTREAM_ADDR_TYPO=127.0.0.1:1",
+			"OTEL_EXPORTER_OTLP_ENDPOINT=http://otel.example.com:4318",
+		}
+	})
 	for _, cmd := range app.Commands {
 		if cmd.Name != "serve" {
 			continue
@@ -156,7 +157,7 @@ func TestNewApp_RejectsUnknownJetstreamEnvVars(t *testing.T) {
 func TestUnknownJetstreamEnvVars_SortedAndDedupesKnownFlags(t *testing.T) {
 	t.Parallel()
 
-	got := unknownJetstreamEnvVars(newApp(), []string{
+	got := unknownJetstreamEnvVars(newTestApp(), []string{
 		"JETSTREAM_ZZZ=1",
 		"JETSTREAM_ADDR=127.0.0.1:0",
 		"JETSTREAM_SIM_DATA_DIR=./data-sim",
@@ -169,7 +170,7 @@ func TestUnknownJetstreamEnvVars_SortedAndDedupesKnownFlags(t *testing.T) {
 func TestServeOptionsFromCLI_Overrides(t *testing.T) {
 	t.Parallel()
 
-	app := newApp()
+	app := newTestApp()
 	var opts jetstreamd.Options
 	for _, cmd := range app.Commands {
 		if cmd.Name != "serve" {
@@ -271,7 +272,7 @@ func TestServeOptionsFromCLI_Overrides(t *testing.T) {
 func TestServeOptionsFromCLI_BackfillSchedulerEnv(t *testing.T) {
 	withClearedEnv(t)
 
-	app := newApp()
+	app := newTestApp()
 	var opts jetstreamd.Options
 	for _, cmd := range app.Commands {
 		if cmd.Name != "serve" {
@@ -306,7 +307,7 @@ func TestServeOptionsFromCLI_BackfillSchedulerEnv(t *testing.T) {
 func TestServeOptionsFromCLI_DisableRepoActionRateLimitsEnv(t *testing.T) {
 	withClearedEnv(t)
 
-	app := newApp()
+	app := newTestApp()
 	var opts jetstreamd.Options
 	for _, cmd := range app.Commands {
 		if cmd.Name != "serve" {
@@ -329,7 +330,7 @@ func TestServeOptionsFromCLI_DisableRepoActionRateLimitsEnv(t *testing.T) {
 func TestServeOptionsFromCLI_RejectsBackfillReposWithMaxBackfillRepos(t *testing.T) {
 	t.Parallel()
 
-	err := newApp().Run(t.Context(), []string{
+	err := newTestApp().Run(t.Context(), []string{
 		"jetstream", "serve",
 		"--max-backfill-repos=1",
 		"--backfill-repos=did:plc:aaa",
@@ -341,7 +342,7 @@ func TestServeOptionsFromCLI_RejectsBackfillReposWithMaxBackfillRepos(t *testing
 func TestServeOptionsFromCLI_MaxBackfillReposOverride(t *testing.T) {
 	t.Parallel()
 
-	app := newApp()
+	app := newTestApp()
 	var opts jetstreamd.Options
 	for _, cmd := range app.Commands {
 		if cmd.Name != "serve" {
@@ -366,7 +367,7 @@ func TestServeOptionsFromCLI_MaxBackfillReposOverride(t *testing.T) {
 func TestServeOptionsFromCLI_RejectsDuplicateBackfillRepos(t *testing.T) {
 	t.Parallel()
 
-	err := newApp().Run(t.Context(), []string{
+	err := newTestApp().Run(t.Context(), []string{
 		"jetstream", "serve",
 		"--backfill-repos=did:plc:aaa,did:plc:aaa",
 	})
@@ -448,7 +449,7 @@ func TestServe_BootstrapsAndShutsDownCleanly(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- newApp().Run(ctx, []string{
+		done <- newTestApp().Run(ctx, []string{
 			"jetstream",
 			"--log-format=text",
 			"--log-level=warn",
@@ -595,7 +596,7 @@ func TestServe_StartsInSteadyStatePhase(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- newApp().Run(ctx, []string{
+		done <- newTestApp().Run(ctx, []string{
 			"jetstream",
 			"--log-format=text",
 			"--log-level=warn",
@@ -671,7 +672,7 @@ func TestServe_AdvancesFromMergingToSteadyState(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- newApp().Run(ctx, []string{
+		done <- newTestApp().Run(ctx, []string{
 			"jetstream",
 			"--log-format=text",
 			"--log-level=warn",

--- a/cmd/jetstream/serve_test.go
+++ b/cmd/jetstream/serve_test.go
@@ -125,31 +125,32 @@ func withClearedEnv(t *testing.T) {
 	}
 }
 
-func TestNewApp_WarnsOnUnknownJetstreamEnvVars(t *testing.T) {
+func TestNewApp_RejectsUnknownJetstreamEnvVars(t *testing.T) {
 	withClearedEnv(t)
 	t.Setenv("JETSTREAM_ADDR", "127.0.0.1:0")
 	t.Setenv("JETSTREAM_ADDR_TYPO", "127.0.0.1:1")
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel.example.com:4318")
 
-	var errBuf bytes.Buffer
+	var actionCalled bool
 	app := newApp()
-	app.ErrWriter = &errBuf
 	for _, cmd := range app.Commands {
 		if cmd.Name != "serve" {
 			continue
 		}
 		cmd.Action = func(context.Context, *cli.Command) error {
+			actionCalled = true
 			return nil
 		}
 		break
 	}
 
-	require.NoError(t, app.Run(t.Context(), []string{"jetstream", "serve"}))
+	err := app.Run(t.Context(), []string{"jetstream", "serve"})
 
-	errOut := errBuf.String()
-	require.Contains(t, errOut, "jetstream: warning: unrecognized JETSTREAM_ environment variable JETSTREAM_ADDR_TYPO")
-	require.NotContains(t, errOut, "JETSTREAM_ADDR\n")
-	require.NotContains(t, errOut, "OTEL_EXPORTER_OTLP_ENDPOINT")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "unrecognized JETSTREAM_ environment variable JETSTREAM_ADDR_TYPO")
+	require.NotContains(t, err.Error(), "JETSTREAM_ADDR ")
+	require.NotContains(t, err.Error(), "OTEL_EXPORTER_OTLP_ENDPOINT")
+	require.False(t, actionCalled)
 }
 
 func TestUnknownJetstreamEnvVars_SortedAndDedupesKnownFlags(t *testing.T) {
@@ -158,6 +159,7 @@ func TestUnknownJetstreamEnvVars_SortedAndDedupesKnownFlags(t *testing.T) {
 	got := unknownJetstreamEnvVars(newApp(), []string{
 		"JETSTREAM_ZZZ=1",
 		"JETSTREAM_ADDR=127.0.0.1:0",
+		"JETSTREAM_SIM_DATA_DIR=./data-sim",
 		"OTEL_SERVICE_NAME=jetstream-test",
 		"JETSTREAM_AAA=value=with=equals",
 	})

--- a/cmd/jetstream/test_app_test.go
+++ b/cmd/jetstream/test_app_test.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/urfave/cli/v3"
+
+func newTestApp() *cli.Command {
+	return newAppWithEnviron(func() []string { return nil })
+}

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -721,6 +721,9 @@ func TestResumeIncomplete_SkipsCheckpointedSegments(t *testing.T) {
 	require.NoError(t, err)
 	<-stopped // segment 0 checkpointed; runner now blocked on ctx
 	cancel()  // simulate shutdown/crash mid-import
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer waitCancel()
+	require.NoError(t, m1.Wait(waitCtx), "first manager must drain its pause write before restart")
 
 	// The paused job stays current + resumable (non-terminal); it is not
 	// cleared like a completed job.

--- a/specs/notes/2026-07-03-maintainability-improvements.md
+++ b/specs/notes/2026-07-03-maintainability-improvements.md
@@ -3,7 +3,8 @@
 Status: **active planning doc.** Split out of
 `2026-07-02-tech-debt-paydown-ideation.md` (§0/§3/§4) after Jim's review; the
 parent doc holds the full exploration evidence and decision trail. This doc is
-the forward-looking plan only. No issues filed yet.
+the forward-looking plan only. Issues are linked on individual items as work is
+split out.
 
 Scope note: oracle/simulator testing work lives in
 `2026-07-03-oracle-testing-improvements.md`. Explicitly out of scope per Jim:
@@ -102,7 +103,7 @@ user-facing documentation, HA mode.
   ENOSPC → clean crash → clean recovery, no corrupt tail (oracle doc, work
   item 3), plus coverage in the advanced tiers (crashpoint/mutation) as they
   apply.
-- **Unrecognized-env-var warning at startup** — a typo'd `JETSTREAM_*` var is
+- **Unrecognized-env-var warning at startup** (#223) — a typo'd `JETSTREAM_*` var is
   silently ignored today; ~30 lines to warn on unknown prefix matches.
 - **Panic posture for long-lived goroutines** — one `recover()` in the whole
   codebase; an ingest/orchestrator panic dies as a bare stderr traceback that

--- a/specs/notes/2026-07-03-maintainability-improvements.md
+++ b/specs/notes/2026-07-03-maintainability-improvements.md
@@ -103,8 +103,8 @@ user-facing documentation, HA mode.
   ENOSPC → clean crash → clean recovery, no corrupt tail (oracle doc, work
   item 3), plus coverage in the advanced tiers (crashpoint/mutation) as they
   apply.
-- **Unrecognized-env-var warning at startup** (#223) — a typo'd `JETSTREAM_*` var is
-  silently ignored today; ~30 lines to warn on unknown prefix matches.
+- **Unrecognized-env-var rejection at startup** (#223) — a typo'd `JETSTREAM_*` var is
+  silently ignored today; reject unknown prefix matches before command execution.
 - **Panic posture for long-lived goroutines** — one `recover()` in the whole
   codebase; an ingest/orchestrator panic dies as a bare stderr traceback that
   log shippers mangle. Top-of-goroutine recover-log-rethrow in


### PR DESCRIPTION
## Summary
- reject command startup when exported `JETSTREAM_*` variables are not recognized by the CLI flag tree
- derive the recognized env-var set from urfave/cli flag sources instead of maintaining a second allowlist
- tolerate simulator-owned `JETSTREAM_SIM_*` vars because the committed `.env` is shared with `cmd/simulator`
- remove stale `JETSTREAM_STATUS_CACHE_TTL` from `.env` because no current flag consumes it
- isolate command tests from the caller's shell environment while preserving production `os.Environ` behavior
- drain the first importer manager in the resume test before constructing its replacement, removing a paused-write/terminal-write race exposed during verification
- update the maintainability note to point at the focused issue

## Tests
- `just lint`
- `just test ./cmd/jetstream`
- `just test ./internal/importer -run TestResumeIncomplete_SkipsCheckpointedSegments -count=20`
- `JETSTREAM_STATUS_CACHE_TTL=1s just test`
- `just test`

Closes #223
Refs #213