### PR TITLE
testing/mutation: make m002 watermark-boundary detection deterministic

### DIFF
--- a/cmd/jetstream/serve_test.go
+++ b/cmd/jetstream/serve_test.go
@@ -117,7 +117,6 @@ func withClearedEnv(t *testing.T) {
 		}
 	}
 	for key := range keys {
-		key := key
 		if prev, ok := os.LookupEnv(key); ok {
 			require.NoError(t, os.Unsetenv(key))
 			t.Cleanup(func() { _ = os.Setenv(key, prev) })

--- a/internal/ingest/orchestrator/compaction_boundary_test.go
+++ b/internal/ingest/orchestrator/compaction_boundary_test.go
@@ -1,0 +1,84 @@
+package orchestrator
+
+import (
+	"io"
+	"log/slog"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/bluesky-social/jetstream/internal/ingest"
+	"github.com/bluesky-social/jetstream/internal/lifecycle"
+	"github.com/bluesky-social/jetstream/segment"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMerge_FirstInitWatermarkFloor_BoundarySeqCompacts pins the
+// watermark-boundary data-loss mode of mutant m002 deterministically (#199):
+// a superseding tombstone landing EXACTLY at the first merged seq.
+//
+// Shape: the destination tree already holds a bootstrap create at seq 1
+// (seq/next = 2), and the live source carries a delete of that same record
+// which the merge appends at seq 2 — the boundary seq.
+//
+//   - Correct floor (nextSeq-1 = 1): the merge-tail pass folds window (1, 2],
+//     sees the delete, and drops the superseded create.
+//   - m002 floor (nextSeq = 2): the pass no-ops (targetWatermark 2 <= floor 2)
+//     and the miss is PERMANENT — every later pass's fold window (W, target]
+//     is exclusive below, so the delete at seq 2 is never folded again and
+//     the superseded create survives forever.
+//
+// The stress tier catches this only when a seed happens to place a tombstone
+// at the boundary (4/5 seeds historically); this scenario places it there by
+// construction, so the mutation campaign's `compaction` tier kills m002 on
+// every run.
+func TestMerge_FirstInitWatermarkFloor_BoundarySeqCompacts(t *testing.T) {
+	t.Parallel()
+
+	// Live source: a delete of the bootstrapped record, rev above the
+	// backfill rev so the merge filter keeps it.
+	del := ev("did:plc:a", "3l6", segment.KindDelete, 2000)
+	del.Rkey = "rkey-boundary"
+	fix := newMergeFixture(t, [][]segment.Event{{del}}, map[string]string{"did:plc:a": "3l5"})
+	fix.cfg.CompactionInterval = time.Hour // enable the merge-tail pass
+
+	// Destination tree: one sealed bootstrap segment with the create at
+	// seq 1, leaving seq/next = 2 so the merged delete lands at the
+	// watermark-floor boundary.
+	bw, err := ingest.Open(ingest.Config{
+		SegmentsDir: filepath.Join(fix.dataDir, "segments"),
+		Store:       fix.store,
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	require.NoError(t, err)
+	create := ev("did:plc:a", "3l5", segment.KindCreate, 1000)
+	create.Rkey = "rkey-boundary"
+	require.NoError(t, bw.Append(t.Context(), &create))
+	require.NoError(t, bw.SealActiveAndClose())
+	require.Equal(t, uint64(1), create.Seq, "precondition: bootstrap create at seq 1")
+
+	require.NoError(t, lifecycle.WritePhase(fix.store, lifecycle.PhaseMerging, time.Now().UTC()))
+	o, err := New(fix.cfg)
+	require.NoError(t, err)
+	require.NoError(t, o.runMerge(t.Context()))
+
+	// The merge-tail pass must have committed the boundary seq.
+	w, ok, err := loadCompactionWatermark(fix.store)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint64(2), w, "merge-tail pass must commit the boundary watermark")
+
+	// Anti-vacuity + contract: the delete merged at seq 2 (the boundary) and
+	// its superseded create at seq 1 was physically dropped.
+	got := readDestEvents(t, fix.dataDir)
+	var sawDelete bool
+	for _, e := range got {
+		if e.Kind == segment.KindDelete && e.Rkey == "rkey-boundary" {
+			sawDelete = true
+			require.Equal(t, uint64(2), e.Seq, "delete must land exactly at the boundary seq")
+		}
+		require.False(t, e.Kind.IsMaterialization() && e.Rkey == "rkey-boundary" && e.Seq <= w,
+			"oracle: superseded record row survived at/below the first-init watermark: seq=%d watermark=%d (m002 boundary miss is permanent: later fold windows are (W, target], exclusive below)", e.Seq, w)
+	}
+	require.True(t, sawDelete, "anti-vacuity: the boundary delete must survive the merge filter")
+}

--- a/internal/ingest/orchestrator/compaction_watermark_test.go
+++ b/internal/ingest/orchestrator/compaction_watermark_test.go
@@ -1,0 +1,53 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// initCompactionWatermarkFloor's first-init contract: the floor sits at
+// nextSeq-1 — the last seq the merge destination has already allocated — so
+// the FIRST event the merge appends (at nextSeq) stays strictly above the
+// watermark and remains compactable. The off-by-one (floor = nextSeq) claims
+// that first seq as already-compacted: a superseding tombstone landing there
+// makes the pass no-op (targetWatermark <= floor) and its victim survives
+// permanently (mutant m002). TestMerge_FirstInitWatermarkFloor_BoundarySeqCompacts
+// proves the data-loss consequence end-to-end; these pin the contract exactly.
+func TestInitCompactionWatermarkFloor_FloorIsNextSeqMinusOne(t *testing.T) {
+	t.Parallel()
+	st := newOrchestratorTestStore(t)
+
+	require.NoError(t, initCompactionWatermarkFloor(st, 5))
+
+	w, ok, err := loadCompactionWatermark(st)
+	require.NoError(t, err)
+	require.True(t, ok, "first init must persist a watermark")
+	require.Equal(t, uint64(4), w,
+		"first-init floor must be nextSeq-1 (the last already-allocated seq), not nextSeq")
+}
+
+func TestInitCompactionWatermarkFloor_ZeroNextSeq(t *testing.T) {
+	t.Parallel()
+	st := newOrchestratorTestStore(t)
+
+	require.NoError(t, initCompactionWatermarkFloor(st, 0))
+
+	w, ok, err := loadCompactionWatermark(st)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint64(0), w, "empty archive floors at 0")
+}
+
+func TestInitCompactionWatermarkFloor_DoesNotOverwriteExisting(t *testing.T) {
+	t.Parallel()
+	st := newOrchestratorTestStore(t)
+
+	require.NoError(t, saveCompactionWatermark(st, 7))
+	require.NoError(t, initCompactionWatermarkFloor(st, 100))
+
+	w, ok, err := loadCompactionWatermark(st)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint64(7), w, "an already-persisted watermark is never re-floored")
+}

--- a/testing/mutation/RESULTS.md
+++ b/testing/mutation/RESULTS.md
@@ -7,22 +7,17 @@ method and `testing/mutation/run.sh` for the driver.
 
 **Current catalog (keep this line current): 27 active mutants on disk
 (m001–m033; m007, m010, m020, m021, m023, m025 retired). Latest full campaign:
-2026-06-30 at `dba121e` (review remediation) — **21 killed, 6 survived, zero
+2026-07-03 at `075fafd` (#199) — **22 killed, 5 survived, zero
 STALE/BUILD-BROKEN**; `testing/mutation/baseline.json` was regenerated from it
-(commit field `dba121e`) and gate-verified self-consistent (`gate: PASS — 27
-mutants match baseline`). This campaign added the `tombstone` tier (runs
-`./internal/tombstone`) and re-banked **m022 as KILLED@tombstone** — closing the
-KILLED→SURVIVED regression #182 introduced when `internal/overlay` (m022's old
-oracle) was deleted in #177. The kill comes from
-`TestSnapshotShouldDropDIDChainsWithSpecificReason`, which asserts
-`Snapshot.ShouldDrop` in BOTH seq directions (a row below the DID tombstone seq
-is dropped; a reactivation row above it survives); m022's patch header declares
-`tiers: tombstone`. No other disposition changed vs the `b9543d9` run and there
-was no catalog drift. The remaining 6 survivors (m002, m003, m009, m013, m014,
-m015) are all pre-existing documented escapes. (#183 still tracks re-deriving a
-#100-recorder mutant to replace the retired m025.) Counts inside older dated
-sections describe the catalog *as of that date* and are intentionally not
-back-edited.**
+(commit field `075fafd`) and gate-verified self-consistent (`gate: PASS — 27
+mutants match baseline`). This campaign added the `compaction` tier and banked
+**m002 SURVIVED→KILLED@compaction** — the watermark-boundary off-by-one is now
+detected deterministically by a boundary-exact scenario instead of 4/5 stress
+seeds. The remaining 5 survivors (m003, m009, m013, m014, m015) are all
+pre-existing documented escapes with owning issues (#209, #208, #204, #204,
+#208). (#183 still tracks re-deriving a #100-recorder mutant to replace the
+retired m025.) Counts inside older dated sections describe the catalog *as of
+that date* and are intentionally not back-edited.**
 
 ## The baseline gate (#108)
 
@@ -984,3 +979,48 @@ path), m015 (footer collection index unread by the oracle — a documented
 footer-index blind spot). See the earlier dated sections for the per-mutant
 analysis; none is a new escape. (#183 still tracks re-deriving a #100-recorder
 mutant to replace the retired m025.)
+
+## Campaign 2026-07-03 — `compaction` tier; m002 SURVIVED→KILLED (#199)
+
+Full campaign at `075fafd`. **27 mutants: 22 KILLED, 5 SURVIVED, zero
+STALE/BUILD-BROKEN.** `testing/mutation/baseline.json` regenerated from this run
+and gate-verified self-consistent (`gate: PASS — 27 mutants match baseline`).
+
+**New `compaction` tier; m002 banked KILLED@compaction.** m002 (first-init
+compaction watermark floor off-by-one, `initCompactionWatermarkFloor` returning
+`nextSeq` instead of `nextSeq-1`) had been a documented seed-dependent escape:
+the fixed-seed campaign recorded SURVIVED and only ~4/5 stress seeds killed it,
+because detection required a seed to place a superseding event exactly at the
+watermark boundary. #199's position: a boundary invariant should be checked
+boundary-exactly, not probabilistically.
+
+The new tier runs two deterministic orchestrator tests
+(`internal/ingest/orchestrator`, <1s, seed-independent):
+
+- `TestMerge_FirstInitWatermarkFloor_BoundarySeqCompacts` constructs the
+  boundary by hand: a sealed bootstrap create at seq 1 leaves `seq/next = 2`;
+  a live-source delete of the same record survives the merge rev-filter and
+  merges at seq 2 — exactly where the first-init floor lands. Correct floor
+  (`nextSeq-1 = 1`): the merge-tail pass folds window (1,2] and physically
+  drops the superseded create. Mutated floor (`nextSeq = 2`): the pass no-ops
+  (`targetWatermark <= watermark`) and the miss is **permanent** — every later
+  pass folds `(W, target]`, exclusive below, so the boundary delete is never
+  folded again and the superseded row survives forever. The test asserts the
+  committed watermark, the survivor contract, and anti-vacuity (the boundary
+  delete itself must survive the merge filter).
+- `TestInitCompactionWatermarkFloor_*` pins the floor contract directly
+  (nextSeq-1; zero-seq floors at 0; an existing watermark is never re-floored).
+
+Red-first verified: both fail under the m002 patch with the modeled failure
+(`oracle: superseded record row survived ... seq=1 watermark=2`) and pass
+clean. m002's header now declares `expected-tier: compaction` with
+`tiers: compaction,default,stress` — the stress tier stays as the end-to-end
+backstop for the same class.
+
+### Survivors (5) — all pre-existing documented escapes with owning issues
+
+m003 (multi-source-segment scenario ceiling, #209), m009 (symmetric checksum
+closed loop; drift pin tracked in #208), m013/m014 (dead paths in this
+simulator config; adversarial-traffic modes in #204 make them live), m015
+(footer-index blind spot, #208). No disposition regressed vs the `dba121e`
+baseline; the only change is m002 SURVIVED→KILLED — a bankable improvement.

--- a/testing/mutation/baseline.json
+++ b/testing/mutation/baseline.json
@@ -1,15 +1,15 @@
 {
-  "commit": "dba121e3ba51c59fdd48d2cfb4b735ee1bf2b13a",
+  "commit": "075fafdbd4379bbf2599c5ae193e94e1de7e5629",
   "mutants": [
     {"id":"m001_delete_mapped_to_update","disposition":"KILLED","result":"KILLED@default","note":"see log"},
-    {"id":"m002_watermark_floor_off_by_one","disposition":"SURVIVED","result":"SURVIVED","note":"escape — analyze and disposition"},
+    {"id":"m002_watermark_floor_off_by_one","disposition":"KILLED","result":"KILLED@compaction","note":"oracle: superseded record row survived at/below the first-init watermark: seq=1 watermark=2 (m002 boundary miss is permanent: later fold win"},
     {"id":"m003_merge_cursor_no_advance","disposition":"SURVIVED","result":"SURVIVED","note":"escape — analyze and disposition"},
     {"id":"m004_rev_filter_inverted","disposition":"KILLED","result":"KILLED@default","note":"oracle: missing did:plc:iv2erqbe5k4ltaawmik4tfeo app.bsky.actor.profile/22auixj3zqj3g rev="},
     {"id":"m005_backfill_status_check_inverted","disposition":"KILLED","result":"KILLED@restart","note":"oracle: rev regression for DID did:plc:xe6kimero4ysp4mpzse6npbs at event 13: seq=20 app.bsky.feed.post/22avhp53lzac4 rev="},
     {"id":"m006_merge_commit_error_swallowed","disposition":"KILLED","result":"KILLED@storefault","note":"see log"},
     {"id":"m008_header_offset_byteslice","disposition":"KILLED","result":"KILLED@default","note":"see log"},
     {"id":"m009_checksum_range_off_by_one","disposition":"SURVIVED","result":"SURVIVED","note":"escape — analyze and disposition"},
-    {"id":"m011_wire_frame_length","disposition":"KILLED","result":"KILLED@default","note":"oracle: walk active segment /tmp/TestOracle_DefaultLifecycle1202675196/003/segments/seg_0000000000.jss: segment: walk active frames: segment"},
+    {"id":"m011_wire_frame_length","disposition":"KILLED","result":"KILLED@default","note":"oracle: walk active segment /tmp/TestOracle_DefaultLifecycle3982613638/003/segments/seg_0000000000.jss: segment: walk active frames: segment"},
     {"id":"m012_block_event_count_off_by_one","disposition":"KILLED","result":"KILLED@default","note":"see log"},
     {"id":"m013_collection_rkey_swap","disposition":"SURVIVED","result":"SURVIVED","note":"escape — analyze and disposition"},
     {"id":"m014_rev_dropped","disposition":"SURVIVED","result":"SURVIVED","note":"escape — analyze and disposition"},

--- a/testing/mutation/mutants/m002_watermark_floor_off_by_one.patch
+++ b/testing/mutation/mutants/m002_watermark_floor_off_by_one.patch
@@ -6,13 +6,15 @@ failure-mode: |
   compacted is below the compaction line. Classic inclusive/exclusive
   boundary mistake when initializing a cursor from a "next" value.
 expected-detection: |
-  assertCompacted should fail: CheckCompacted re-derives which rows must
-  be gone at-or-below the watermark, and a row at the boundary seq can
-  survive uncompacted. Likely seed-dependent — only fires when the
-  boundary seq carries a superseding event. If it survives the default
-  seed, run the seed sweep before recording it as an escape.
-expected-tier: stress
-tiers: default,stress
+  The compaction tier's boundary-exact scenario
+  (TestMerge_FirstInitWatermarkFloor_BoundarySeqCompacts, #199) pins a
+  superseding delete EXACTLY at the first merged seq: the mutated floor
+  claims that seq as already-compacted, the merge-tail pass no-ops, and
+  the superseded create survives permanently — killed deterministically,
+  no seed luck. The stress tier remains as the end-to-end backstop
+  (assertCompacted/CheckCompacted, historically 4/5 seeds).
+expected-tier: compaction
+tiers: compaction,default,stress
 
 diff --git a/internal/ingest/orchestrator/compaction_watermark.go b/internal/ingest/orchestrator/compaction_watermark.go
 index 7403134..b98a633 100644

--- a/testing/mutation/run.sh
+++ b/testing/mutation/run.sh
@@ -282,6 +282,19 @@ for patch in "$MUTANTS_DIR"/*.patch; do
                     # kill the inversion fast and without an end-to-end run.
                     cmd=(go test "${RACE_FLAG[@]}" ./internal/tombstone
                          -count=1 -timeout "$default_timeout") ;;
+                compaction)
+                    # Compaction-boundary tier (#199): kills watermark boundary
+                    # mutants (e.g. m002, the first-init floor off-by-one) with
+                    # deterministic boundary-exact scenarios instead of stress
+                    # seed luck. The orchestrator tests pin a tombstone/survivor
+                    # pair EXACTLY at the first-init watermark: the mutant's
+                    # floor claims that seq as already-compacted, the merge-tail
+                    # pass no-ops, and the superseded row survives permanently
+                    # (fold windows are exclusive below W, so the miss can never
+                    # heal). Fast (<1s) and seed-independent.
+                    cmd=(go test "${RACE_FLAG[@]}" ./internal/ingest/orchestrator
+                         -run 'TestInitCompactionWatermarkFloor|TestMerge_FirstInitWatermarkFloor'
+                         -count=1 -timeout "$default_timeout") ;;
                 *)
                     echo "error: unknown tier '$tier' in $id" >&2
                     exit 1 ;;


### PR DESCRIPTION
## Context

m002 (first-init compaction watermark floor off-by-one, `initCompactionWatermarkFloor` returning `nextSeq` instead of `nextSeq-1`) was a documented seed-dependent escape: killed by only ~4/5 stress seeds, SURVIVED at the fixed seed. Detection required a seed to happen to place a superseding event exactly at the watermark boundary. A boundary invariant should be checked boundary-exactly, not probabilistically.

Closes #199

## What

- **`TestMerge_FirstInitWatermarkFloor_BoundarySeqCompacts`** (orchestrator): constructs the boundary by hand — a sealed bootstrap create at seq 1 leaves `seq/next = 2`; a live-source delete of the same record survives the merge rev-filter and merges at exactly seq 2, where the first-init floor lands.
  - Correct floor (`nextSeq-1 = 1`): merge-tail pass folds window (1,2] and physically drops the superseded create.
  - Mutated floor (`nextSeq = 2`): the pass no-ops (`targetWatermark <= watermark`) and the miss is **permanent** — later fold windows `(W, target]` are exclusive below, so the boundary delete is never folded again and the superseded row survives forever.
  - Asserts committed watermark, survivor contract, and anti-vacuity (the boundary delete must actually survive the merge filter).
- **`TestInitCompactionWatermarkFloor_*`**: unit pins on the floor contract (nextSeq-1; zero floors at 0; existing watermark never re-floored).
- **New `compaction` mutation tier** in `run.sh` (tombstone-tier precedent): runs the boundary tests, <1s, seed-independent. m002 re-headed to `expected-tier: compaction`, `tiers: compaction,default,stress` (stress stays as the end-to-end backstop).
- **Baseline banked**: full campaign at 075fafd — 27 mutants, **22 KILLED / 5 SURVIVED**, zero STALE/BUILD-BROKEN; only change is m002 SURVIVED→KILLED@compaction. Gate self-consistent. RESULTS.md dated section appended.

## Verification

- Red-first: both tests fail under the m002 patch with the modeled failure (`oracle: superseded record row survived ... seq=1 watermark=2`), pass on clean tree.
- `testing/mutation/run.sh m002` → KILLED@compaction.
- Full `just` (1934 tests) green; full campaign green.
- Drive-by: `just modernize` removed a redundant loop-var copy in `cmd/jetstream/serve_test.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)