### PR TITLE
oracle: cross-check over-drop recorder watermark against committed pass

### DIFF
--- a/internal/oracle/harness_test.go
+++ b/internal/oracle/harness_test.go
@@ -989,6 +989,24 @@ func (r *compactionOverDropRecorder) ObserveAfter(result jetstreamd.CompactionPa
 		return
 	}
 
+	// Cross-check the scan bound against the watermark the pass actually
+	// committed. A successful watermark-advancing pass commits exactly the
+	// targetWatermark ObserveBefore was handed, so a mismatch means the
+	// OnBeforeCompactionPass hook fed this recorder a stale/wrong bound —
+	// and a stale bound BELOW the pass's drops makes pre == post trivially
+	// true, silently disarming the over-drop check while every other oracle
+	// tier stays green (#226). Fail loud instead of comparing blind.
+	if result.Watermark != pendingW {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		// "oracle:" prefix so the mutation driver's note-grep surfaces this
+		// as the kill reason instead of "see log".
+		r.scanErr = errors.Join(r.scanErr, fmt.Errorf(
+			"oracle: over-drop recorder watermark mismatch: pre-pass hook saw %d but the pass committed %d (recorder scans bounded at the wrong seq would vacuously pass)",
+			pendingW, result.Watermark))
+		return
+	}
+
 	post, err := r.scanSealed(pendingW)
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/testing/mutation/RESULTS.md
+++ b/testing/mutation/RESULTS.md
@@ -5,20 +5,19 @@ oracle's detection power is visible over time. See
 `docs/superpowers/specs/2026-06-12-oracle-mutation-campaign-design.md` for the
 method and `testing/mutation/run.sh` for the driver.
 
-**Current catalog (keep this line current): 27 active mutants on disk
-(m001–m033; m007, m010, m020, m021, m023, m025 retired). Latest full campaign:
-2026-07-03 at `075fafd` (#199) — **22 killed, 5 survived, zero
+**Current catalog (keep this line current): 28 active mutants on disk
+(m001–m034; m007, m010, m020, m021, m023, m025 retired). Latest full campaign:
+2026-07-04 at `40e79cc` (#226) — **23 killed, 5 survived, zero
 STALE/BUILD-BROKEN**; `testing/mutation/baseline.json` was regenerated from it
-(commit field `075fafd`) and gate-verified self-consistent (`gate: PASS — 27
-mutants match baseline`). This campaign added the `compaction` tier and banked
-**m002 SURVIVED→KILLED@compaction** — the watermark-boundary off-by-one is now
-detected deterministically by a boundary-exact scenario instead of 4/5 stress
-seeds. The remaining 5 survivors (m003, m009, m013, m014, m015) are all
-pre-existing documented escapes with owning issues (#209, #208, #204, #204,
-#208). (#183 closed 2026-07-04: no recorder-unique replacement for the retired
-m025 exists post-#178 — see the dated analysis section; the #100 over-drop
-recorder is a regression assertion without a gated mutant.) Counts inside older
-dated sections describe the catalog *as of that date* and are intentionally not
+(commit field `40e79cc`) and gate-verified self-consistent. This campaign added
+**m034 (over-drop recorder disarmed via a stale hook watermark),
+KILLED@default** by the recorder's new watermark cross-check. The 5 survivors
+(m003, m009, m013, m014, m015) are all pre-existing documented escapes with
+owning issues (#209, #208, #204, #204, #208). (#183 closed 2026-07-04: no
+recorder-unique replacement for the retired m025 exists post-#178 — see the
+dated analysis section; the #100 over-drop recorder's gated mutant m034 guards
+its hook integrity, not its drop logic.) Counts inside older dated sections
+describe the catalog *as of that date* and are intentionally not
 back-edited.**
 
 ## The baseline gate (#108)
@@ -1108,3 +1107,35 @@ than scope-crept here:**
 - `ShouldDrop`'s DID branch `ts.Seq > ev.Seq` → `>=` survives every tier
   entirely (a same-seq DID-tombstone/materialization pair cannot exist, so
   the edit is a no-op — an equivalent mutant, not an escape).
+
+## Campaign 2026-07-04 — m034 recorder hook-integrity mutant (#226)
+
+Full campaign at `40e79cc`. **28 mutants: 23 KILLED, 5 SURVIVED, zero
+STALE/BUILD-BROKEN.** `testing/mutation/baseline.json` regenerated from this
+run and gate-verified self-consistent.
+
+**New m034_overdrop_hook_stale_watermark, KILLED@default.** The #183
+adversarial re-derivation analysis (previous section) surfaced this as
+candidate C9: a single edit passing the stale committed `watermark` instead of
+`targetWatermark` to `OnBeforeCompactionPass` (`compact_deletes.go:136`) bounds
+both of the #100 over-drop recorder's scans BELOW every drop the pass makes,
+so pre == post trivially and the recorder passes vacuously — anti-vacuity
+guards included (older survivors keep `survivorsChecked` positive), with every
+other tier legitimately green (the pass still compacts correctly). A watchdog
+that can be blinded by a one-token production edit with zero red tests is not
+a trustworthy watchdog.
+
+The detecting check: `compactionOverDropRecorder.ObserveAfter` now cross-checks
+its pending scan bound against the watermark the pass actually committed
+(`result.Watermark != pendingW` → scan error surfaced by `Assert`). A
+successful watermark-advancing pass commits exactly the targetWatermark
+`ObserveBefore` was handed, so any divergence means the hook fed the recorder a
+wrong bound. Red-first verified: with the m034 edit applied, -short
+`TestOracle_DefaultLifecycle` fails with `oracle: over-drop recorder watermark
+mismatch: pre-pass hook saw 20 but the pass committed 33`; the clean tree is
+green. Kills in the default tier (the merge-tail pass already exposes the
+mismatch), no stress needed.
+
+No other disposition changed vs the `075fafd` baseline; the 5 survivors remain
+the documented escapes with owning issues (m003→#209, m009/m015→#208,
+m013/m014→#204).

--- a/testing/mutation/baseline.json
+++ b/testing/mutation/baseline.json
@@ -1,15 +1,15 @@
 {
-  "commit": "075fafdbd4379bbf2599c5ae193e94e1de7e5629",
+  "commit": "40e79cc26e21ecf1a4bbd1cad17b49e8f10e0b6a",
   "mutants": [
     {"id":"m001_delete_mapped_to_update","disposition":"KILLED","result":"KILLED@default","note":"see log"},
     {"id":"m002_watermark_floor_off_by_one","disposition":"KILLED","result":"KILLED@compaction","note":"oracle: superseded record row survived at/below the first-init watermark: seq=1 watermark=2 (m002 boundary miss is permanent: later fold win"},
     {"id":"m003_merge_cursor_no_advance","disposition":"SURVIVED","result":"SURVIVED","note":"escape — analyze and disposition"},
     {"id":"m004_rev_filter_inverted","disposition":"KILLED","result":"KILLED@default","note":"oracle: missing did:plc:iv2erqbe5k4ltaawmik4tfeo app.bsky.actor.profile/22auixj3zqj3g rev="},
-    {"id":"m005_backfill_status_check_inverted","disposition":"KILLED","result":"KILLED@restart","note":"oracle: rev regression for DID did:plc:xe6kimero4ysp4mpzse6npbs at event 13: seq=20 app.bsky.feed.post/22avhp53lzac4 rev="},
+    {"id":"m005_backfill_status_check_inverted","disposition":"KILLED","result":"KILLED@restart","note":"oracle: rev regression for DID did:plc:xe6kimero4ysp4mpzse6npbs at event 16: seq=23 app.bsky.feed.post/22avhp53lzac4 rev="},
     {"id":"m006_merge_commit_error_swallowed","disposition":"KILLED","result":"KILLED@storefault","note":"see log"},
     {"id":"m008_header_offset_byteslice","disposition":"KILLED","result":"KILLED@default","note":"see log"},
     {"id":"m009_checksum_range_off_by_one","disposition":"SURVIVED","result":"SURVIVED","note":"escape — analyze and disposition"},
-    {"id":"m011_wire_frame_length","disposition":"KILLED","result":"KILLED@default","note":"oracle: walk active segment /tmp/TestOracle_DefaultLifecycle3982613638/003/segments/seg_0000000000.jss: segment: walk active frames: segment"},
+    {"id":"m011_wire_frame_length","disposition":"KILLED","result":"KILLED@default","note":"oracle: walk active segment /tmp/TestOracle_DefaultLifecycle4015434081/003/segments/seg_0000000000.jss: segment: walk active frames: segment"},
     {"id":"m012_block_event_count_off_by_one","disposition":"KILLED","result":"KILLED@default","note":"see log"},
     {"id":"m013_collection_rkey_swap","disposition":"SURVIVED","result":"SURVIVED","note":"escape — analyze and disposition"},
     {"id":"m014_rev_dropped","disposition":"SURVIVED","result":"SURVIVED","note":"escape — analyze and disposition"},
@@ -27,6 +27,7 @@
     {"id":"m030_plan_midsegment_cut_reports_segment_maxseq","disposition":"KILLED","result":"KILLED@partb","note":"see log"},
     {"id":"m031_plan_truncation_zero_units_unadvanced","disposition":"KILLED","result":"KILLED@partb","note":"see log"},
     {"id":"m032_v2_below_floor_silent_clamp","disposition":"KILLED","result":"KILLED@partb","note":"see log"},
-    {"id":"m033_client_too_old_400_not_rebackfilled","disposition":"KILLED","result":"KILLED@partb","note":"see log"}
+    {"id":"m033_client_too_old_400_not_rebackfilled","disposition":"KILLED","result":"KILLED@partb","note":"see log"},
+    {"id":"m034_overdrop_hook_stale_watermark","disposition":"KILLED","result":"KILLED@default","note":"oracle: over-drop recorder watermark mismatch: pre-pass hook saw 20 but the pass committed 33 (recorder scans bounded at the wrong seq would"}
   ]
 }

--- a/testing/mutation/mutants/m034_overdrop_hook_stale_watermark.patch
+++ b/testing/mutation/mutants/m034_overdrop_hook_stale_watermark.patch
@@ -1,0 +1,30 @@
+mutant: m034_overdrop_hook_stale_watermark
+target: internal/ingest/orchestrator/compact_deletes.go
+failure-mode: |
+  runDeleteCompaction passes the stale committed watermark to
+  OnBeforeCompactionPass instead of the pass's targetWatermark. Both of the
+  #100 over-drop recorder's scans then bound BELOW every drop the pass makes,
+  so pre == post trivially and the recorder passes vacuously — including its
+  anti-vacuity guards (older survivors keep survivorsChecked positive). The
+  pass itself still compacts correctly, so no other oracle tier goes red: a
+  single edit that silently disarms the over-drop watchdog rather than
+  corrupting data. Found by the #183 adversarial re-derivation analysis
+  (RESULTS.md 2026-07-04 section, candidate C9); tracked as #226.
+expected-detection: |
+  Killed by the recorder's watermark cross-check in ObserveAfter
+  (internal/oracle/harness_test.go): a successful watermark-advancing pass
+  commits exactly the targetWatermark ObserveBefore was handed, so the stale
+  bound surfaces as "over-drop recorder watermark mismatch: pre-pass hook saw
+  W_old but the pass committed W_new" at overDrop.Assert
+  (steady-state-shutdown-flush). Fires in -short mode on the merge-tail pass
+  already (hook sees the stale 0/bootstrap watermark, pass commits the merge
+  target), so the default tier kills it deterministically.
+expected-tier: default
+tiers: default
+
+diff --git a/internal/ingest/orchestrator/compact_deletes.go b/internal/ingest/orchestrator/compact_deletes.go
+--- a/internal/ingest/orchestrator/compact_deletes.go
++++ b/internal/ingest/orchestrator/compact_deletes.go
+@@ -136 +136 @@ func (o *Orchestrator) runDeleteCompaction(ctx context.Context, mode compaction
+-			o.cfg.OnBeforeCompactionPass(targetWatermark)
++			o.cfg.OnBeforeCompactionPass(watermark)


### PR DESCRIPTION
## Summary

The #183 adversarial re-derivation analysis (PR #227) surfaced a residual gap, filed as #226: a single production edit — passing the stale committed `watermark` instead of `targetWatermark` to `OnBeforeCompactionPass` (`compact_deletes.go:136`) — bounds both of the #100 over-drop recorder's disk scans **below every drop the pass makes**. Pre == post trivially, the recorder passes vacuously (anti-vacuity guards stay satisfied via older survivors), and every other oracle tier is legitimately green because the pass still compacts correctly. A watchdog that can be blinded by a one-token edit with zero red tests is not a trustworthy watchdog.

## Changes

- **Recorder cross-check** (`internal/oracle/harness_test.go`): a successful watermark-advancing pass commits exactly the targetWatermark `ObserveBefore` was handed, so `ObserveAfter` now records a loud scan error when `result.Watermark != pendingW`. The message carries the `oracle:` prefix so the campaign driver's note-grep surfaces the real kill reason.
- **New mutant** `m034_overdrop_hook_stale_watermark` capturing the edit (default tier — the merge-tail pass already exposes the mismatch in `-short`, no stress needed).
- **Baseline banked**: full campaign — 28 mutants, 23 KILLED / 5 SURVIVED, zero STALE/BUILD-BROKEN; only change vs the 075fafd baseline is the new m034. Gate PASS (28 match). RESULTS.md catalog header + dated 2026-07-04 section updated.

## Verification

- Red-first: with the m034 edit applied, `-short TestOracle_DefaultLifecycle` fails with `oracle: over-drop recorder watermark mismatch: pre-pass hook saw 20 but the pass committed 33` (both the merge-tail and steady passes flagged); clean tree green.
- `testing/mutation/run.sh m034` → KILLED@default; full campaign + `just mutation-gate` → PASS.
- `just lint` 0 issues; full suite 1934 tests green.

Note: the baseline's provenance-only `commit` field records `40e79cc`, the pre-rebase hash of the commit the campaign ran against (this branch was rebased onto main after #227 merged; content identical, hashes changed). The gate diffs dispositions, not commits, and scheduled CI re-runs the campaign fresh at HEAD.

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)