### PR TITLE
simulator: note replay fault before writing replayed frames

### DIFF
--- a/internal/simulator/http/relay_subscribe.go
+++ b/internal/simulator/http/relay_subscribe.go
@@ -211,11 +211,17 @@ func (w *subscribeFaultWriter) fireReplay(ctx context.Context) error {
 			cursor += int64(len(page))
 		}
 	}
+	// Note the replay BEFORE writing: once the client has read a replayed
+	// frame there must be a happens-before with the counters, or a test
+	// polling SubscribeReposReplaysFired after draining the frames races
+	// this goroutine. On a mid-replay write failure this overcounts
+	// delivered frames, which keeps replayedFrames a valid upper bound
+	// for the oracle's storage-bloat check.
+	w.faults.noteSubscribeReplay(len(frames))
 	for _, f := range frames {
 		if err := w.conn.Write(ctx, websocket.MessageBinary, f); err != nil {
 			return err
 		}
 	}
-	w.faults.noteSubscribeReplay(len(frames))
 	return nil
 }


### PR DESCRIPTION
## Summary

Fixes the flaky `TestSubscribeRepos_ReplayFaultRegressesToSeq` / `TestSubscribeRepos_ReplayFaultDuplicatesLastFrames` failures (`SubscribeReposReplaysFired()` asserting `expected: 1, actual: 0`).

`subscribeFaultWriter.fireReplay` wrote the replayed frames to the websocket and only then called `noteSubscribeReplay`. `conn.Write` returning means the bytes hit the socket, so the test client could read every replayed frame and reach the counter assertions before the server goroutine incremented them — no happens-before between the client's last read and the note. The fix moves the note ahead of the writes.

Trade-off, made deliberately: on a mid-replay write failure the counter now overcounts *delivered* frames, which preserves the oracle's storage-bloat invariant (archived duplicate rows ≤ `replayedFrames` as an upper bound). Documented at the call site. `TestSubscribeRepos_ReplayAndDisconnectFaultsCompose` was never affected — its counter assertions are gated on the fault-driven close, which happens after the note.

Closes #237

## Verification

- Red-first repro: 4 concurrent `go test ./internal/simulator/http -run TestSubscribeRepos_Replay -count=200` loops on a 32-core box — both replay tests failed with `fired=0` within one round pre-fix.
- Post-fix: 6 concurrent `-count=300` stress loops clean, `-race -count=20` clean.
- Full `just` suite (1996 tests) green, `just lint` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)