### PR TITLE
subscribe: make options update tests deterministic

### DIFF
--- a/internal/subscribe/handler_test.go
+++ b/internal/subscribe/handler_test.go
@@ -1485,6 +1485,17 @@ func TestHandler_RequireHello_BlocksUntilOptionsUpdate(t *testing.T) {
 	}
 	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "test done") }()
 
+	// Prove no subscriber registered before hello: an eager (buggy) live
+	// subscriber would park at the empty tip and signal blocked almost
+	// immediately after the dial completes. Without this check, the
+	// publish below could race ahead of an eager subscription and the
+	// NotContains assertion would pass vacuously.
+	select {
+	case <-b.blocked:
+		t.Fatal("subscriber registered before hello")
+	case <-time.After(10 * time.Millisecond):
+	}
+
 	// Append a matching event. The subscriber loop hasn't started yet (it
 	// waits for hello), so it will begin reading at the live tip — which is
 	// already past this event. A pre-hello event is therefore never
@@ -1763,6 +1774,16 @@ func TestHandler_RequireHello_NoLeakOnClientDisconnect(t *testing.T) {
 	require.NoError(t, err)
 	if resp != nil && resp.Body != nil {
 		defer func() { _ = resp.Body.Close() }()
+	}
+
+	// Give serve() time to reach its hello wait, and assert no subscriber
+	// registered while we did: a blocked signal here means requireHello
+	// subscribed eagerly, and the disconnect below would no longer be
+	// exercising the hello-wait path this test exists to cover.
+	select {
+	case <-b.blocked:
+		t.Fatal("requireHello subscribed before hello")
+	case <-time.After(10 * time.Millisecond):
 	}
 
 	// Client closes without sending hello. The handler's reader goroutine

--- a/internal/subscribe/handler_test.go
+++ b/internal/subscribe/handler_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/jcalabro/atmos/api/comatproto"
 	"github.com/jcalabro/gt"
 	"github.com/klauspost/compress/zstd"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,6 +42,26 @@ func waitForTailBlocked(t *testing.T, b *Tail) {
 	case <-b.blocked:
 	case <-time.After(2 * time.Second):
 		t.Fatal("subscriber did not park at live tip")
+	}
+}
+
+func waitForOptionsUpdates(t *testing.T, m *Metrics, want float64) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	tick := time.NewTicker(time.Millisecond)
+	defer tick.Stop()
+	for {
+		if testutil.ToFloat64(m.OptionsUpdates) >= want {
+			return
+		}
+		select {
+		case <-tick.C:
+		case <-deadline:
+			if testutil.ToFloat64(m.OptionsUpdates) >= want {
+				return
+			}
+			t.Fatalf("timed out waiting for options_updates_total >= %v", want)
+		}
 	}
 }
 
@@ -1214,10 +1236,12 @@ func TestHandler_OptionsUpdate_ChangesFilter(t *testing.T) {
 	st := newSteadyStateStore(t)
 	b, err := New(Config{Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}, nil, nil)
 	require.NoError(t, err)
+	metrics := NewMetrics(prometheus.NewRegistry())
 	h := NewHandler(Subscription{
-		Tail:   b,
-		Store:  st,
-		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Tail:    b,
+		Store:   st,
+		Logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Metrics: metrics,
 	})
 	srv := httptest.NewServer(h)
 	defer srv.Close()
@@ -1243,10 +1267,7 @@ func TestHandler_OptionsUpdate_ChangesFilter(t *testing.T) {
 		}),
 	}
 	require.NoError(t, conn.Write(ctx, websocket.MessageText, jsonMust(t, update)))
-
-	// Give the reader goroutine a moment to apply the update.
-	time.Sleep(10 * time.Millisecond)
-
+	waitForOptionsUpdates(t, metrics, 1)
 	var seq uint64
 	publishCommit(t, b, &seq, "did:plc:abc", "app.bsky.feed.post", 1)
 	publishCommit(t, b, &seq, "did:plc:abc", "app.bsky.feed.like", 2)
@@ -1388,10 +1409,12 @@ func TestHandler_OptionsUpdate_UnknownTypeIgnored(t *testing.T) {
 	st := newSteadyStateStore(t)
 	b, err := New(Config{Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}, nil, nil)
 	require.NoError(t, err)
+	metrics := NewMetrics(prometheus.NewRegistry())
 	h := NewHandler(Subscription{
-		Tail:   b,
-		Store:  st,
-		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Tail:    b,
+		Store:   st,
+		Logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Metrics: metrics,
 	})
 	srv := httptest.NewServer(h)
 	defer srv.Close()
@@ -1416,8 +1439,17 @@ func TestHandler_OptionsUpdate_UnknownTypeIgnored(t *testing.T) {
 	}
 	require.NoError(t, conn.Write(ctx, websocket.MessageText, jsonMust(t, unknown)))
 
-	// Subsequent events must still flow.
-	time.Sleep(10 * time.Millisecond)
+	// A following valid update proves the prior unknown frame was read and
+	// ignored before we publish the probe event.
+	update := SubscriberSourcedMessage{
+		Type: SubMessageTypeOptionsUpdate,
+		Payload: jsonMust(t, UpdatePayload{
+			WantedDIDs: []string{"did:plc:still-alive"},
+		}),
+	}
+	require.NoError(t, conn.Write(ctx, websocket.MessageText, jsonMust(t, update)))
+	waitForOptionsUpdates(t, metrics, 1)
+
 	var seq uint64
 	publishIdentity(t, b, &seq, "did:plc:still-alive", 1)
 	frame := readOneFrame(t, ctx, conn)
@@ -1453,21 +1485,12 @@ func TestHandler_RequireHello_BlocksUntilOptionsUpdate(t *testing.T) {
 	}
 	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "test done") }()
 
-	// Give the handler time to start the reader goroutine but NOT
-	// time to subscribe (it shouldn't subscribe until hello).
-	time.Sleep(10 * time.Millisecond)
-
 	// Append a matching event. The subscriber loop hasn't started yet (it
 	// waits for hello), so it will begin reading at the live tip — which is
 	// already past this event. A pre-hello event is therefore never
 	// delivered: live subscribers do not replay history.
 	var seq uint64
 	publishIdentity(t, b, &seq, "did:plc:pre-hello", 1)
-
-	// Wait long enough to ensure that IF the event were going to be
-	// delivered, it would have been (but it won't be, because we
-	// haven't sent hello yet).
-	time.Sleep(10 * time.Millisecond)
 
 	// Send the hello.
 	hello := SubscriberSourcedMessage{
@@ -1741,10 +1764,6 @@ func TestHandler_RequireHello_NoLeakOnClientDisconnect(t *testing.T) {
 	if resp != nil && resp.Body != nil {
 		defer func() { _ = resp.Body.Close() }()
 	}
-
-	// Let the handler get into its hello wait. The reader goroutine
-	// is running; the writer-side serve() body is blocked on helloCh.
-	time.Sleep(10 * time.Millisecond)
 
 	// Client closes without sending hello. The handler's reader goroutine
 	// observes the read error, defer cancel()s the connection context,


### PR DESCRIPTION
## Summary

- replace sleep-based synchronization in subscribe options-update tests with an explicit wait for the handler's successful options update signal
- make the unknown-message and requireHello tests deterministic without fixed sleeps
- keep the regression tied to issue #145's flaky filter-update ordering

## Verification

- just test ./internal/subscribe -run TestHandler_OptionsUpdate_ChangesFilter -race -count=200
- just test ./internal/subscribe -run TestHandler_OptionsUpdate -race -count=20
- just test ./internal/subscribe -run TestHandler_RequireHello -race -count=20
- just test ./internal/subscribe -race
- just test-race ./...
- just lint
- git diff --check

Closes #145