### PR TITLE
oracle: cover account status lifecycle

### DIFF
--- a/internal/oracle/account_status_harness_test.go
+++ b/internal/oracle/account_status_harness_test.go
@@ -55,6 +55,16 @@ func configureOracleUnavailableRepos(t *testing.T, w *world.World, cfg Config, t
 	})
 }
 
+// injectOracleAccountStatusLifecycle emits the deterministic #203 lifecycle
+// for the fixture account: a probe create, then every non-deleted inactive
+// status, then an active=true reactivation. It MUST run at the START of the
+// steady window, before the random steady traffic: the m043 mutation gate
+// depends on a later compaction fold covering these rows (a status frame
+// misclassified as a deletion tombstone then drops the probe row and the
+// account's backfilled records), and only rows appended before the steady
+// traffic's tombstone-triggered compaction passes reliably land at or below
+// a pass watermark. assertAccountStatusLifecycleArchived returns the archived
+// row seqs so the harness can assert that coverage (anti-vacuity).
 func injectOracleAccountStatusLifecycle(t *testing.T, w *world.World, cfg Config) string {
 	t.Helper()
 	require.Truef(t, oracleAccountFetchable(t, w, oracleAccountStatusLifecycleIndex),
@@ -73,23 +83,32 @@ func injectOracleAccountStatusLifecycle(t *testing.T, w *world.World, cfg Config
 	return string(acct.DID)
 }
 
-func assertAccountStatusLifecycleArchived(t *testing.T, cfg Config, steady *eventLogRecorder, did string) {
+// assertAccountStatusLifecycleArchived proves the injected lifecycle archived
+// faithfully and returns the highest archived seq among the lifecycle rows.
+// The caller asserts the final compaction watermark reached that seq: without
+// that coverage the m043 tombstone-exactness gate is vacuous (a fold that
+// misclassifies these statuses as deletions only drops rows at or below a
+// pass watermark).
+func assertAccountStatusLifecycleArchived(t *testing.T, cfg Config, steady *eventLogRecorder, did string) uint64 {
 	t.Helper()
 
 	statusCounts := make(map[string]int, len(oracleNonDeletedAccountStatuses))
 	var sawProbeCreate bool
 	var sawReactivation bool
+	var maxSeq uint64
 	for _, ev := range steady.snapshotEvents() {
 		if ev.DID != did {
 			continue
 		}
 		if ev.Kind == segment.KindCreate && ev.Collection == "app.bsky.feed.post" && ev.Rkey == oracleAccountStatusRkey {
 			sawProbeCreate = true
+			maxSeq = max(maxSeq, ev.Seq)
 			continue
 		}
 		if ev.Kind != segment.KindAccount {
 			continue
 		}
+		maxSeq = max(maxSeq, ev.Seq)
 		var acc comatproto.SyncSubscribeRepos_Account
 		require.NoErrorf(t, acc.UnmarshalCBOR(ev.Payload),
 			"decode archived account status did=%s seq=%d mode=%s seed=%d", did, ev.Seq, cfg.Mode, cfg.Seed)
@@ -117,6 +136,7 @@ func assertAccountStatusLifecycleArchived(t *testing.T, cfg Config, steady *even
 	require.Truef(t, sawReactivation,
 		"account-status lifecycle active=true reactivation did=%s was not archived: mode=%s seed=%d",
 		did, cfg.Mode, cfg.Seed)
+	return maxSeq
 }
 
 func assertUnavailableRepoStatuses(t *testing.T, dataDir string, w *world.World, cfg Config) {

--- a/internal/oracle/account_status_harness_test.go
+++ b/internal/oracle/account_status_harness_test.go
@@ -1,0 +1,171 @@
+package oracle
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bluesky-social/jetstream/internal/ingest/backfill"
+	"github.com/bluesky-social/jetstream/internal/simulator/world"
+	metastore "github.com/bluesky-social/jetstream/internal/store"
+	"github.com/bluesky-social/jetstream/segment"
+	"github.com/jcalabro/atmos"
+	"github.com/jcalabro/atmos/api/comatproto"
+	atmosbackfill "github.com/jcalabro/atmos/backfill"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	oracleAccountStatusLifecycleIndex = 7
+	oracleAccountStatusRkey           = "account-status-probe"
+)
+
+type oracleUnavailableRepo struct {
+	accountIdx int
+	status     string
+}
+
+var oracleUnavailableRepos = []oracleUnavailableRepo{
+	{accountIdx: 4, status: "takendown"},
+	{accountIdx: 5, status: "suspended"},
+	{accountIdx: 6, status: "deactivated"},
+}
+
+var oracleNonDeletedAccountStatuses = []string{
+	"takendown",
+	"suspended",
+	"deactivated",
+	"unknown",
+}
+
+func configureOracleUnavailableRepos(t *testing.T, w *world.World, cfg Config, trace *Trace) {
+	t.Helper()
+	require.Greaterf(t, cfg.Accounts, oracleAccountStatusLifecycleIndex,
+		"oracle account-status fixtures require at least %d accounts; mode=%s has %d",
+		oracleAccountStatusLifecycleIndex+1, cfg.Mode, cfg.Accounts)
+
+	configured := make(map[int]string, len(oracleUnavailableRepos))
+	for _, tc := range oracleUnavailableRepos {
+		require.NoErrorf(t, w.SetRepoUnavailableForTest(tc.accountIdx, tc.status),
+			"configure unavailable repo account=%d status=%s mode=%s seed=%d",
+			tc.accountIdx, tc.status, cfg.Mode, cfg.Seed)
+		configured[tc.accountIdx] = tc.status
+	}
+	recordTraceOrError(t, trace, "repo_unavailable_config", map[string]any{
+		"accounts": configured,
+	})
+}
+
+func injectOracleAccountStatusLifecycle(t *testing.T, w *world.World, cfg Config) string {
+	t.Helper()
+	require.Truef(t, oracleAccountFetchable(t, w, oracleAccountStatusLifecycleIndex),
+		"account-status lifecycle fixture account %d must stay fetchable", oracleAccountStatusLifecycleIndex)
+
+	acct, err := w.LoadAccount(oracleAccountStatusLifecycleIndex)
+	require.NoError(t, err)
+	_, _, err = w.GenerateRecordOpForTest(t.Context(), oracleAccountStatusLifecycleIndex, "create", "app.bsky.feed.post", oracleAccountStatusRkey)
+	require.NoErrorf(t, err, "account-status lifecycle create: mode=%s seed=%d", cfg.Mode, cfg.Seed)
+	for _, status := range oracleNonDeletedAccountStatuses {
+		_, err := w.GenerateAccountStatusForTest(t.Context(), oracleAccountStatusLifecycleIndex, false, status)
+		require.NoErrorf(t, err, "account-status lifecycle status=%s mode=%s seed=%d", status, cfg.Mode, cfg.Seed)
+	}
+	_, err = w.GenerateAccountStatusForTest(t.Context(), oracleAccountStatusLifecycleIndex, true, "")
+	require.NoErrorf(t, err, "account-status lifecycle reactivation: mode=%s seed=%d", cfg.Mode, cfg.Seed)
+	return string(acct.DID)
+}
+
+func assertAccountStatusLifecycleArchived(t *testing.T, cfg Config, steady *eventLogRecorder, did string) {
+	t.Helper()
+
+	statusCounts := make(map[string]int, len(oracleNonDeletedAccountStatuses))
+	var sawProbeCreate bool
+	var sawReactivation bool
+	for _, ev := range steady.snapshotEvents() {
+		if ev.DID != did {
+			continue
+		}
+		if ev.Kind == segment.KindCreate && ev.Collection == "app.bsky.feed.post" && ev.Rkey == oracleAccountStatusRkey {
+			sawProbeCreate = true
+			continue
+		}
+		if ev.Kind != segment.KindAccount {
+			continue
+		}
+		var acc comatproto.SyncSubscribeRepos_Account
+		require.NoErrorf(t, acc.UnmarshalCBOR(ev.Payload),
+			"decode archived account status did=%s seq=%d mode=%s seed=%d", did, ev.Seq, cfg.Mode, cfg.Seed)
+		deleted, err := oracleAccountDeleted(ev.Payload)
+		require.NoError(t, err)
+		require.Falsef(t, deleted,
+			"non-deleted account status archived as tombstone: did=%s status=%v mode=%s seed=%d",
+			did, acc.Status, cfg.Mode, cfg.Seed)
+		if acc.Active && !acc.Status.HasVal() {
+			sawReactivation = true
+			continue
+		}
+		if !acc.Active && acc.Status.HasVal() {
+			statusCounts[acc.Status.Val()]++
+		}
+	}
+
+	require.Truef(t, sawProbeCreate,
+		"account-status lifecycle probe create did=%s was not archived: mode=%s seed=%d", did, cfg.Mode, cfg.Seed)
+	for _, status := range oracleNonDeletedAccountStatuses {
+		require.Positivef(t, statusCounts[status],
+			"account-status lifecycle status=%s did=%s was not archived: mode=%s seed=%d",
+			status, did, cfg.Mode, cfg.Seed)
+	}
+	require.Truef(t, sawReactivation,
+		"account-status lifecycle active=true reactivation did=%s was not archived: mode=%s seed=%d",
+		did, cfg.Mode, cfg.Seed)
+}
+
+func assertUnavailableRepoStatuses(t *testing.T, dataDir string, w *world.World, cfg Config) {
+	t.Helper()
+
+	st, err := metastore.Open(dataDir, nil)
+	require.NoErrorf(t, err, "open metadata store for unavailable repo assertions: mode=%s seed=%d", cfg.Mode, cfg.Seed)
+	defer func() { require.NoError(t, st.Close()) }()
+
+	bs := backfill.NewStore(st, nil)
+	for _, tc := range oracleUnavailableRepos {
+		acct, err := w.LoadAccount(tc.accountIdx)
+		require.NoError(t, err)
+		did := atmos.DID(acct.DID)
+		rs, ok, err := backfill.LoadRepoStatus(st, did)
+		require.NoErrorf(t, err, "load repo status for unavailable DID %s", did)
+		require.Truef(t, ok, "missing repo status for unavailable DID %s", did)
+		require.Equalf(t, backfill.StatusUnavailable, rs.Backfill.Status,
+			"unavailable DID %s status=%s must persist as StatusUnavailable", did, tc.status)
+		require.Truef(t, rs.Active, "unavailable DID %s must retain listRepos active=true so getRepo owns terminal classification", did)
+		require.Emptyf(t, rs.Backfill.LastError, "unavailable DID %s must not retain a stale failure error", did)
+		require.Zerof(t, rs.Backfill.Attempts, "unavailable DID %s must not count as retry-consuming failure", did)
+		require.Zerof(t, rs.Backfill.RetryCount, "unavailable DID %s must not be retry-eligible", did)
+		require.Truef(t, rs.Backfill.NextAttemptAt.IsZero(), "unavailable DID %s must not schedule retry", did)
+
+		got, err := bs.Lookup(context.Background(), did)
+		require.NoError(t, err)
+		require.Equalf(t, atmosbackfill.StateComplete, got.State,
+			"unavailable DID %s must project to complete so atmos does not retry", did)
+		require.Truef(t, got.Active, "unavailable DID %s lookup must preserve active=true", did)
+	}
+
+	counts, ok, err := backfill.LoadCounts(st)
+	require.NoError(t, err)
+	require.True(t, ok, "backfill counts row missing")
+	require.Equalf(t, uint64(len(oracleUnavailableRepos)), counts.Unavailable,
+		"unavailable aggregate count mismatch: mode=%s seed=%d", cfg.Mode, cfg.Seed)
+
+	hosts, err := backfill.ListHostStatuses(st)
+	require.NoError(t, err)
+	var hostUnavailable uint64
+	for _, hs := range hosts {
+		hostUnavailable += hs.Unavailable
+		if hs.Unavailable == 0 {
+			continue
+		}
+		require.Emptyf(t, hs.LatestError, "unavailable host %s must not retain latest failure error", hs.Host)
+		require.Emptyf(t, hs.RecentErrors, "unavailable host %s must not retain recent failure samples", hs.Host)
+	}
+	require.Equalf(t, uint64(len(oracleUnavailableRepos)), hostUnavailable,
+		"host unavailable aggregate mismatch: mode=%s seed=%d", cfg.Mode, cfg.Seed)
+}

--- a/internal/oracle/adversarial_harness_test.go
+++ b/internal/oracle/adversarial_harness_test.go
@@ -78,22 +78,32 @@ var adversarialGateReasonMatrix = map[string][]string{
 	"backfill": {"invalid_collection", "invalid_rkey", "field_too_long"},
 }
 
-// pickAdversarialAccounts returns three distinct active accounts
-// (acctOp, acctSyncLie, acctVerifier). Fast mode has exactly three
-// active accounts (of four; bootstrap deletes account 0), so every
-// mode can host the full lie set.
+// pickAdversarialAccounts returns three distinct fetchable, active accounts
+// (acctOp, acctSyncLie, acctVerifier). Fast mode keeps accounts 1-3 in that
+// set after bootstrap deletes account 0; later deterministic fixtures use
+// higher account indexes so they do not steal an adversarial role.
 func pickAdversarialAccounts(t *testing.T, w *world.World, cfg Config) (acctOp, acctSyncLie, acctVerifier int) {
 	t.Helper()
 	var picked []int
 	for idx := 0; idx < cfg.Accounts && len(picked) < 3; idx++ {
-		deleted, err := w.IsAccountDeleted(idx)
-		require.NoError(t, err)
-		if !deleted {
+		if oracleAccountFetchable(t, w, idx) {
 			picked = append(picked, idx)
 		}
 	}
-	require.Lenf(t, picked, 3, "adversarial phase needs 3 active accounts, mode=%s has fewer", cfg.Mode)
+	require.Lenf(t, picked, 3, "adversarial phase needs 3 fetchable active accounts, mode=%s has fewer", cfg.Mode)
 	return picked[0], picked[1], picked[2]
+}
+
+func oracleAccountFetchable(t *testing.T, w *world.World, idx int) bool {
+	t.Helper()
+	deleted, err := w.IsAccountDeleted(idx)
+	require.NoError(t, err)
+	if deleted {
+		return false
+	}
+	_, unavailable, err := w.RepoUnavailableStatus(idx)
+	require.NoError(t, err)
+	return !unavailable
 }
 
 // injectAdversarialBackfillLies commits the backfill lie set into

--- a/internal/oracle/config.go
+++ b/internal/oracle/config.go
@@ -75,7 +75,7 @@ func parseConfigFromLookupEnv(lookupenv func(string) (string, bool)) (Config, er
 	switch mode {
 	case "default":
 	case "fast":
-		cfg.Accounts = 4
+		cfg.Accounts = 8
 		cfg.MaxInitialRecords = 10
 		cfg.LiveEventsBootstrap = 12
 		cfg.LiveEventsSteady = 12

--- a/internal/oracle/config_test.go
+++ b/internal/oracle/config_test.go
@@ -31,7 +31,7 @@ func TestDefaultLifecycleConfigUsesFastModeUnderShort(t *testing.T) {
 	cfg, err := defaultLifecycleConfig(lookupEnvMap(nil), true)
 	require.NoError(t, err)
 	require.Equal(t, "fast", cfg.Mode)
-	require.Equal(t, 4, cfg.Accounts)
+	require.Equal(t, 8, cfg.Accounts)
 	require.Equal(t, 10, cfg.MaxInitialRecords)
 }
 

--- a/internal/oracle/faults.go
+++ b/internal/oracle/faults.go
@@ -268,6 +268,20 @@ func worldDIDs(w *world.World) ([]string, error) {
 	}
 	dids := make([]string, 0, len(page))
 	for _, entry := range page {
+		acct, ok, err := w.FindAccountByDID(entry.DID)
+		if err != nil {
+			return nil, fmt.Errorf("oracle: resolve fault-plan DID %s: %w", entry.DID, err)
+		}
+		if !ok {
+			return nil, fmt.Errorf("oracle: fault-plan DID %s missing from simulator world", entry.DID)
+		}
+		_, unavailable, err := w.RepoUnavailableStatus(acct.Index)
+		if err != nil {
+			return nil, fmt.Errorf("oracle: inspect fault-plan DID %s availability: %w", entry.DID, err)
+		}
+		if unavailable {
+			continue
+		}
 		dids = append(dids, string(entry.DID))
 	}
 	return dids, nil

--- a/internal/oracle/faults_test.go
+++ b/internal/oracle/faults_test.go
@@ -227,6 +227,28 @@ func TestBuildSwarmFaultPlanSingleDIDWorld(t *testing.T) {
 	require.Equal(t, 1, plan.TotalGetRepoCARTruncations())
 }
 
+func TestBuildSwarmFaultPlanSkipsRepoUnavailableDIDs(t *testing.T) {
+	t.Parallel()
+
+	w := newFaultPlanWorld(t, 8)
+	for idx := range 7 {
+		require.NoError(t, w.SetRepoUnavailableForTest(idx, "suspended"))
+	}
+	acct, err := w.LoadAccount(7)
+	require.NoError(t, err)
+
+	cfg := Config{
+		Seed:             123,
+		Accounts:         8,
+		LiveEventsSteady: 25,
+		FaultMode:        FaultModeSwarm,
+	}
+	plan, err := BuildSwarmFaultPlan(w, cfg)
+	require.NoError(t, err)
+	require.Equal(t, map[string]int{string(acct.DID): 2}, plan.GetRepoHTTPFailures)
+	require.Equal(t, map[string]int{string(acct.DID): 1}, plan.GetRepoCARTruncations)
+}
+
 func TestBuildSwarmFaultPlanNoopsWhenFaultModeNone(t *testing.T) {
 	t.Parallel()
 

--- a/internal/oracle/groundtruth.go
+++ b/internal/oracle/groundtruth.go
@@ -29,6 +29,13 @@ func GroundTruthFromWorld(w *world.World) (*Model, error) {
 		if deleted {
 			continue
 		}
+		_, unavailable, err := w.RepoUnavailableStatus(idx)
+		if err != nil {
+			return nil, err
+		}
+		if unavailable {
+			continue
+		}
 		rp, _, err := w.LoadRepo(idx)
 		if err != nil {
 			return nil, err

--- a/internal/oracle/harness_test.go
+++ b/internal/oracle/harness_test.go
@@ -408,6 +408,14 @@ func testOracleDefaultLifecycle(t *testing.T) {
 	// lost, exactly as the ledger asserts.
 	acctOp, acctSyncLie, acctVerifier := pickAdversarialAccounts(t, w, cfg)
 	steadyStartSeq := w.CurrentSeq()
+	// #203 account-status lifecycle FIRST, before the random steady traffic:
+	// the m043 mutation gate needs these rows at or below a steady compaction
+	// watermark, and the pass that provides it is triggered by the steady
+	// traffic's first tombstone (CompactionTombstoneCap=1). Injecting before
+	// generateN guarantees the lifecycle rows are already archived when that
+	// pass force-rotates, so its watermark covers them. The shutdown-flush
+	// anti-vacuity assertion below enforces this coverage.
+	accountStatusDID := injectOracleAccountStatusLifecycle(t, w, cfg)
 	generateN(t, w, cfg.LiveEventsSteady)
 	// Deterministic #202 identity injections, independent of the random
 	// mix: a handle-change payload (the optional-field shape) and a
@@ -426,7 +434,6 @@ func testOracleDefaultLifecycle(t *testing.T) {
 	injectAdversarialLiveOpLies(t, w, cfg, acctOp)
 	_, err = w.GenerateSilentMutationThenSyncForTest(t.Context(), syncIdx)
 	require.NoError(t, err)
-	accountStatusDID := injectOracleAccountStatusLifecycle(t, w, cfg)
 	_, err = w.GenerateAdversarialSyncForTest(t.Context(), acctSyncLie, "not-a-tid")
 	require.NoErrorf(t, err, "adversarial sync lie: mode=%s seed=%d", cfg.Mode, cfg.Seed)
 	exemptWholeEventSeqs(steadyAck, w.AdversarialLedger().Entries())
@@ -442,7 +449,7 @@ func testOracleDefaultLifecycle(t *testing.T) {
 	assertNoPermanentCursorGapExcept(t, steadyEventLog, steadyStartSeq, targetSeq, cfg, "steady-state",
 		newAdversarialFilter(w.AdversarialLedger().Entries()))
 	assertIdentityArchived(t, cfg, bootstrapEventLog, steadyEventLog, identityDID(t, w, identityIdx))
-	assertAccountStatusLifecycleArchived(t, cfg, steadyEventLog, accountStatusDID)
+	accountStatusMaxSeq := assertAccountStatusLifecycleArchived(t, cfg, steadyEventLog, accountStatusDID)
 	// The malformed-DID identity must be rejected by the net-new
 	// enqueuer's validation gate (metric via the debug /metrics surface,
 	// scraped while the runtime is still serving), and at least one VALID
@@ -529,6 +536,14 @@ func testOracleDefaultLifecycle(t *testing.T) {
 	assertSubscribeReposFaultPlanFired(t, cfg, faultPlan)
 	assertUnavailableRepoStatuses(t, dataDir, w, cfg)
 	assertOracleMatches(t, dataDir, w, cfg, "steady-state-shutdown-flush")
+	// Anti-vacuity for the #203 / m043 gate: the tombstone-exactness fold only
+	// touches rows at or below a pass watermark, so the lifecycle's account
+	// rows must be covered by the final watermark or the "non-deleted statuses
+	// never fold as tombstones" property was never actually exercised
+	// end-to-end this run.
+	require.GreaterOrEqualf(t, compaction.Last(t).Watermark, accountStatusMaxSeq,
+		"final compaction watermark did not cover the #203 account-status lifecycle rows (mode=%s seed=%d): the tombstone-exactness fold never saw them, so the m043 gate is vacuous — inject earlier or ensure a later pass",
+		cfg.Mode, cfg.Seed)
 	assertCompacted(t, dataDir, compaction.Last(t).Watermark, cfg, "steady-state-shutdown-flush")
 	// Compaction over-drop / data-loss check (#100): every compaction pass
 	// must have preserved each row the documented filter says survives at its

--- a/internal/oracle/harness_test.go
+++ b/internal/oracle/harness_test.go
@@ -104,6 +104,7 @@ func testOracleDefaultLifecycle(t *testing.T) {
 	_, err = w.EnsureSeed()
 	require.NoError(t, err)
 	require.NoError(t, w.Bootstrap(t.Context(), slog.Default()))
+	configureOracleUnavailableRepos(t, w, cfg, trace)
 	// Size the firehose fanout buffer to comfortably exceed the run's total
 	// event volume. The simulator fanout drops frames on a full per-subscriber
 	// buffer (it models a lossy relay), and in the bubble a dropped frame is
@@ -425,6 +426,7 @@ func testOracleDefaultLifecycle(t *testing.T) {
 	injectAdversarialLiveOpLies(t, w, cfg, acctOp)
 	_, err = w.GenerateSilentMutationThenSyncForTest(t.Context(), syncIdx)
 	require.NoError(t, err)
+	accountStatusDID := injectOracleAccountStatusLifecycle(t, w, cfg)
 	_, err = w.GenerateAdversarialSyncForTest(t.Context(), acctSyncLie, "not-a-tid")
 	require.NoErrorf(t, err, "adversarial sync lie: mode=%s seed=%d", cfg.Mode, cfg.Seed)
 	exemptWholeEventSeqs(steadyAck, w.AdversarialLedger().Entries())
@@ -440,6 +442,7 @@ func testOracleDefaultLifecycle(t *testing.T) {
 	assertNoPermanentCursorGapExcept(t, steadyEventLog, steadyStartSeq, targetSeq, cfg, "steady-state",
 		newAdversarialFilter(w.AdversarialLedger().Entries()))
 	assertIdentityArchived(t, cfg, bootstrapEventLog, steadyEventLog, identityDID(t, w, identityIdx))
+	assertAccountStatusLifecycleArchived(t, cfg, steadyEventLog, accountStatusDID)
 	// The malformed-DID identity must be rejected by the net-new
 	// enqueuer's validation gate (metric via the debug /metrics surface,
 	// scraped while the runtime is still serving), and at least one VALID
@@ -505,6 +508,9 @@ func testOracleDefaultLifecycle(t *testing.T) {
 		"err":   traceErr(run.err),
 	})
 	runDone = true
+	closeCtx, closeCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	require.NoError(t, rt.Close(closeCtx))
+	closeCancel()
 	recordTraceOrError(t, trace, "phase", map[string]any{"phase": "final-assertions", "marker": "begin"})
 	// Anti-vacuity: the fanout models a lossy relay (drop-on-full per
 	// subscriber, fanout.go Publish), and in the bubble a dropped frame is
@@ -521,6 +527,7 @@ func testOracleDefaultLifecycle(t *testing.T) {
 		cfg.Mode, cfg.Seed, fan.TotalDrops())
 	recordSubscribeReposFaults(t, trace, "steady-state-shutdown-flush", faultPlan)
 	assertSubscribeReposFaultPlanFired(t, cfg, faultPlan)
+	assertUnavailableRepoStatuses(t, dataDir, w, cfg)
 	assertOracleMatches(t, dataDir, w, cfg, "steady-state-shutdown-flush")
 	assertCompacted(t, dataDir, compaction.Last(t).Watermark, cfg, "steady-state-shutdown-flush")
 	// Compaction over-drop / data-loss check (#100): every compaction pass
@@ -1347,13 +1354,11 @@ func generateN(t *testing.T, w *world.World, n int) {
 func pickActiveOracleAccount(t *testing.T, w *world.World, cfg Config) int {
 	t.Helper()
 	for idx := range cfg.Accounts {
-		deleted, err := w.IsAccountDeleted(idx)
-		require.NoError(t, err)
-		if !deleted {
+		if oracleAccountFetchable(t, w, idx) {
 			return idx
 		}
 	}
-	t.Fatal("oracle requires at least one active account for sync divergence")
+	t.Fatal("oracle requires at least one fetchable active account for sync divergence")
 	return 0
 }
 

--- a/internal/simulator/http/pds.go
+++ b/internal/simulator/http/pds.go
@@ -2,6 +2,8 @@ package http
 
 import (
 	"bytes"
+	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/bluesky-social/jetstream/internal/simulator/world"
@@ -37,6 +39,14 @@ func newPDSGetRepoHandler(w *world.World, faults *FaultPlan, onServed func(did s
 		}
 		if !ok {
 			http.NotFound(rw, r)
+			return
+		}
+		if status, unavailable, err := w.RepoUnavailableStatus(acct.Index); err != nil {
+			http.Error(rw, err.Error(), http.StatusInternalServerError)
+			return
+		} else if unavailable {
+			writeXRPCError(rw, http.StatusBadRequest, unavailableGetRepoErrorName(status),
+				fmt.Sprintf("repo %s is %s", did, status))
 			return
 		}
 		rw.Header().Set("Content-Type", "application/vnd.ipld.car")
@@ -79,5 +89,30 @@ func newPDSGetRepoHandler(w *world.World, faults *FaultPlan, onServed func(did s
 		if onServed != nil {
 			onServed(string(did))
 		}
+	})
+}
+
+func unavailableGetRepoErrorName(status string) string {
+	switch status {
+	case "takendown":
+		return "RepoTakendown"
+	case "suspended":
+		return "RepoSuspended"
+	case "deactivated":
+		return "RepoDeactivated"
+	default:
+		return "InvalidRequest"
+	}
+}
+
+func writeXRPCError(rw http.ResponseWriter, status int, name, message string) {
+	rw.Header().Set("Content-Type", "application/json")
+	rw.WriteHeader(status)
+	_ = json.NewEncoder(rw).Encode(struct {
+		Error   string `json:"error"`
+		Message string `json:"message,omitempty"`
+	}{
+		Error:   name,
+		Message: message,
 	})
 }

--- a/internal/simulator/http/pds_test.go
+++ b/internal/simulator/http/pds_test.go
@@ -3,6 +3,8 @@ package http_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -202,4 +204,57 @@ func TestPDS_GetRepoFaultHandlerServesTruncatedCARThenCAR(t *testing.T) {
 	require.Equal(t, a.DID, rp.DID)
 	require.NotEmpty(t, commit.Sig)
 	require.Equal(t, 1, faults.GetRepoCARTruncationsFired(string(a.DID)))
+}
+
+func TestPDS_GetRepoUnavailableReturnsXRPCError(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		status string
+		name   string
+	}{
+		{status: "takendown", name: "RepoTakendown"},
+		{status: "suspended", name: "RepoSuspended"},
+		{status: "deactivated", name: "RepoDeactivated"},
+	} {
+		t.Run(tc.status, func(t *testing.T) {
+			t.Parallel()
+			w := newTestWorld(t, 5, 2)
+			a, err := w.LoadAccount(0)
+			require.NoError(t, err)
+			require.NoError(t, w.SetRepoUnavailableForTest(0, tc.status))
+
+			srv := httptest.NewServer(simhttp.NewHandler(w, "http://example.test"))
+			defer srv.Close()
+
+			xc := &xrpc.Client{
+				Host:       srv.URL,
+				HTTPClient: gt.Some(http.DefaultClient),
+				Retry:      gt.Some(xrpc.RetryPolicy{MaxAttempts: gt.Some(1)}),
+			}
+			sc := sync.NewClient(sync.Options{Client: xc})
+
+			body, err := sc.GetRepoStream(context.Background(), a.DID, "")
+			require.Nil(t, body)
+			var xerr *xrpc.Error
+			require.True(t, errors.As(err, &xerr), "getRepo unavailable must parse as *xrpc.Error")
+			require.Equal(t, http.StatusBadRequest, xerr.StatusCode)
+			require.Equal(t, tc.name, xerr.Name)
+
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet,
+				srv.URL+"/xrpc/com.atproto.sync.getRepo?did="+string(a.DID), nil)
+			require.NoError(t, err)
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer func() { _ = resp.Body.Close() }()
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			require.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+			var envelope struct {
+				Error   string `json:"error"`
+				Message string `json:"message"`
+			}
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&envelope))
+			require.Equal(t, tc.name, envelope.Error)
+			require.Contains(t, envelope.Message, tc.status)
+		})
+	}
 }

--- a/internal/simulator/world/account_view.go
+++ b/internal/simulator/world/account_view.go
@@ -149,11 +149,15 @@ func (w *World) ListReposPage(start, limit int) (entries []ListReposEntry, nextS
 		if err != nil {
 			return nil, 0, err
 		}
+		_, unavailable, err := w.repoUnavailableStatus(i)
+		if err != nil {
+			return nil, 0, err
+		}
 		out = append(out, ListReposEntry{
 			DID:    a.DID,
 			Rev:    state.Rev,
 			Head:   state.CommitCID.String(),
-			Active: !deleted,
+			Active: !deleted && !unavailable,
 		})
 	}
 	return out, end, nil
@@ -191,6 +195,17 @@ func (w *World) GenerateAccountReactivateForTest(ctx context.Context, idx int) (
 	return w.generateAccountReactivate(ctx, idx)
 }
 
+// GenerateAccountStatusForTest emits a #account frame with the caller-supplied
+// active/status pair without mutating the world's repo or deleted flag. Oracle
+// tests use this to pin non-deleted hosting statuses end-to-end: only
+// Active:false,status:"deleted" is a tombstone.
+func (w *World) GenerateAccountStatusForTest(ctx context.Context, idx int, active bool, status string) ([]byte, error) {
+	w.mutationMu.Lock()
+	defer w.mutationMu.Unlock()
+
+	return w.generateAccountStatus(ctx, idx, active, status)
+}
+
 // GenerateIdentityForTest emits one polite #identity frame for account
 // idx: handle-absent (the dominant production shape) or, with
 // handleChange, a handle-change payload backed by the account's
@@ -223,4 +238,20 @@ func (w *World) GenerateMalformedIdentityForTest(ctx context.Context) ([]byte, e
 
 func (w *World) IsAccountDeleted(idx int) (bool, error) {
 	return w.isAccountDeleted(idx)
+}
+
+// SetRepoUnavailableForTest makes getRepo for account idx return a terminal
+// unavailable XRPC error. Status must be "takendown", "suspended", or
+// "deactivated".
+func (w *World) SetRepoUnavailableForTest(idx int, status string) error {
+	w.mutationMu.Lock()
+	defer w.mutationMu.Unlock()
+
+	return w.setRepoUnavailableStatus(idx, status)
+}
+
+// RepoUnavailableStatus returns the terminal getRepo-unavailable status for
+// account idx, if one has been configured.
+func (w *World) RepoUnavailableStatus(idx int) (string, bool, error) {
+	return w.repoUnavailableStatus(idx)
 }

--- a/internal/simulator/world/account_view.go
+++ b/internal/simulator/world/account_view.go
@@ -149,15 +149,11 @@ func (w *World) ListReposPage(start, limit int) (entries []ListReposEntry, nextS
 		if err != nil {
 			return nil, 0, err
 		}
-		_, unavailable, err := w.repoUnavailableStatus(i)
-		if err != nil {
-			return nil, 0, err
-		}
 		out = append(out, ListReposEntry{
 			DID:    a.DID,
 			Rev:    state.Rev,
 			Head:   state.CommitCID.String(),
-			Active: !deleted && !unavailable,
+			Active: !deleted,
 		})
 	}
 	return out, end, nil

--- a/internal/simulator/world/accounts.go
+++ b/internal/simulator/world/accounts.go
@@ -157,6 +157,21 @@ func (w *World) setRepoUnavailableStatus(idx int, status string) error {
 	return nil
 }
 
+func (w *World) accountCanAuthor(idx int) (bool, error) {
+	deleted, err := w.isAccountDeleted(idx)
+	if err != nil {
+		return false, err
+	}
+	if deleted {
+		return false, nil
+	}
+	_, unavailable, err := w.repoUnavailableStatus(idx)
+	if err != nil {
+		return false, err
+	}
+	return !unavailable, nil
+}
+
 func (w *World) generateAccountDelete(ctx context.Context, idx int) ([]byte, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err

--- a/internal/simulator/world/accounts.go
+++ b/internal/simulator/world/accounts.go
@@ -124,6 +124,39 @@ func (w *World) isAccountDeleted(idx int) (bool, error) {
 	return len(val) == 1 && val[0] == 1, nil
 }
 
+func (w *World) repoUnavailableStatus(idx int) (string, bool, error) {
+	val, closer, err := w.db.Get(keyAccountRepoUnavailable(idx))
+	if errors.Is(err, pebble.ErrNotFound) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("world: load account %d repo unavailable status: %w", idx, err)
+	}
+	defer func() { _ = closer.Close() }()
+	status := string(val)
+	switch status {
+	case "takendown", "suspended", "deactivated":
+		return status, true, nil
+	default:
+		return "", false, fmt.Errorf("world: account %d has invalid repo unavailable status %q", idx, status)
+	}
+}
+
+func (w *World) setRepoUnavailableStatus(idx int, status string) error {
+	if idx < 0 || idx >= w.cfg.Accounts {
+		return fmt.Errorf("simulator: repo-unavailable account index %d out of range", idx)
+	}
+	switch status {
+	case "takendown", "suspended", "deactivated":
+	default:
+		return fmt.Errorf("simulator: unsupported repo unavailable status %q", status)
+	}
+	if err := w.db.Set(keyAccountRepoUnavailable(idx), []byte(status), pebble.NoSync); err != nil {
+		return fmt.Errorf("world: set account %d repo unavailable status: %w", idx, err)
+	}
+	return nil
+}
+
 func (w *World) generateAccountDelete(ctx context.Context, idx int) ([]byte, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -160,6 +193,51 @@ func (w *World) generateAccountDelete(ctx context.Context, idx int) ([]byte, err
 	}
 	if err := b.Commit(pebble.NoSync); err != nil {
 		return nil, fmt.Errorf("world: commit account delete: %w", err)
+	}
+	if w.fanout != nil {
+		w.fanout.Publish(frame)
+	}
+	return frame, nil
+}
+
+func (w *World) generateAccountStatus(ctx context.Context, idx int, active bool, status string) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if idx < 0 || idx >= w.cfg.Accounts {
+		return nil, fmt.Errorf("simulator: account-status index %d out of range", idx)
+	}
+	a, err := w.loadAccount(idx)
+	if err != nil {
+		return nil, err
+	}
+
+	seq := w.seq.Add(1)
+	b := w.db.NewBatch()
+	defer func() { _ = b.Close() }()
+	eventMicros, err := w.nextLogicalClockMicros(b)
+	if err != nil {
+		return nil, err
+	}
+	envelope := &comatproto.SyncSubscribeRepos_Account{
+		DID:    string(a.DID),
+		Active: active,
+		Seq:    seq,
+		Time:   formatLogicalClockTime(eventMicros),
+	}
+	if status != "" {
+		envelope.Status = gt.Some(status)
+	}
+	frame, err := encodeAccountFrame(envelope)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := stageFirehoseFrame(b, seq, frame, w.cfg.FirehoseHistory); err != nil {
+		return nil, err
+	}
+	if err := b.Commit(pebble.NoSync); err != nil {
+		return nil, fmt.Errorf("world: commit account status: %w", err)
 	}
 	if w.fanout != nil {
 		w.fanout.Publish(frame)

--- a/internal/simulator/world/accounts_test.go
+++ b/internal/simulator/world/accounts_test.go
@@ -172,7 +172,7 @@ func TestGenerateAccountStatusForTest_NonDeletedStatusesDoNotMarkDeleted(t *test
 	require.True(t, entries[0].Active, "non-deleted account statuses must not flip listRepos active")
 }
 
-func TestSetRepoUnavailableForTest_MarksListReposInactive(t *testing.T) {
+func TestSetRepoUnavailableForTest_LeavesListReposActive(t *testing.T) {
 	t.Parallel()
 
 	cfg := DefaultConfig()
@@ -193,7 +193,7 @@ func TestSetRepoUnavailableForTest_MarksListReposInactive(t *testing.T) {
 	entries, _, err := w.ListReposPage(0, 10)
 	require.NoError(t, err)
 	require.True(t, entries[0].Active)
-	require.False(t, entries[1].Active, "unavailable repo must list inactive")
+	require.True(t, entries[1].Active, "unavailable repos must still dispatch to getRepo")
 	require.Error(t, w.SetRepoUnavailableForTest(1, "unknown"))
 }
 

--- a/internal/simulator/world/accounts_test.go
+++ b/internal/simulator/world/accounts_test.go
@@ -136,6 +136,67 @@ func TestGenerateAccountReactivateForTest_ClearsDeletedAndEmitsActiveFrame(t *te
 	require.True(t, entries[0].Active, "reactivated account must list as active")
 }
 
+func TestGenerateAccountStatusForTest_NonDeletedStatusesDoNotMarkDeleted(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultConfig()
+	cfg.DataDir = t.TempDir()
+	cfg.Accounts = 2
+	cfg.InitialRecords = 1
+	w, err := New(context.Background(), cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+	require.NoError(t, w.Bootstrap(context.Background(), slog.Default()))
+	require.NoError(t, w.AttachRuntime(rand.New(rand.NewPCG(1, 2)), fanout.New(16)))
+
+	for _, status := range []string{"takendown", "suspended", "deactivated", "unknown"} {
+		frame, err := w.GenerateAccountStatusForTest(context.Background(), 0, false, status)
+		require.NoError(t, err)
+		acct := decodeAccountFrameForTest(t, frame)
+		require.False(t, acct.Active)
+		require.Equal(t, status, acct.Status.Val())
+
+		deleted, err := w.IsAccountDeleted(0)
+		require.NoError(t, err)
+		require.Falsef(t, deleted, "status %q must not mark the world account deleted", status)
+	}
+
+	frame, err := w.GenerateAccountStatusForTest(context.Background(), 0, true, "")
+	require.NoError(t, err)
+	acct := decodeAccountFrameForTest(t, frame)
+	require.True(t, acct.Active)
+	require.False(t, acct.Status.HasVal())
+
+	entries, _, err := w.ListReposPage(0, 10)
+	require.NoError(t, err)
+	require.True(t, entries[0].Active, "non-deleted account statuses must not flip listRepos active")
+}
+
+func TestSetRepoUnavailableForTest_MarksListReposInactive(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultConfig()
+	cfg.DataDir = t.TempDir()
+	cfg.Accounts = 2
+	cfg.InitialRecords = 1
+	w, err := New(context.Background(), cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+	require.NoError(t, w.Bootstrap(context.Background(), slog.Default()))
+
+	require.NoError(t, w.SetRepoUnavailableForTest(1, "suspended"))
+	status, ok, err := w.RepoUnavailableStatus(1)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "suspended", status)
+
+	entries, _, err := w.ListReposPage(0, 10)
+	require.NoError(t, err)
+	require.True(t, entries[0].Active)
+	require.False(t, entries[1].Active, "unavailable repo must list inactive")
+	require.Error(t, w.SetRepoUnavailableForTest(1, "unknown"))
+}
+
 func TestGenerateAccountDeleteForTestUsesDeterministicTime(t *testing.T) {
 	t.Parallel()
 

--- a/internal/simulator/world/keys.go
+++ b/internal/simulator/world/keys.go
@@ -35,6 +35,14 @@ func keyAccountDeleted(idx int) []byte {
 	return fmt.Appendf(nil, "sim/account/%010d/deleted", idx)
 }
 
+// keyAccountRepoUnavailable builds "sim/account/<idx>/repo_unavailable".
+// Absence means getRepo serves the repo normally. Presence is one of
+// "takendown", "suspended", or "deactivated" and makes getRepo return the
+// matching terminal XRPC error.
+func keyAccountRepoUnavailable(idx int) []byte {
+	return fmt.Appendf(nil, "sim/account/%010d/repo_unavailable", idx)
+}
+
 // keyAccountHandleChanges builds "sim/account/<idx>/handle_changes": a
 // big-endian uint64 counter of #identity handle changes emitted for
 // this account. Absence means zero.

--- a/internal/simulator/world/traffic.go
+++ b/internal/simulator/world/traffic.go
@@ -109,12 +109,12 @@ func (w *World) generateOneForAccount(ctx context.Context, authorIdx int, action
 	if authorIdx < 0 || authorIdx >= w.cfg.Accounts {
 		return nil, fmt.Errorf("simulator: author index %d out of range", authorIdx)
 	}
-	deleted, err := w.isAccountDeleted(authorIdx)
+	canAuthor, err := w.accountCanAuthor(authorIdx)
 	if err != nil {
 		return nil, err
 	}
-	if deleted {
-		return nil, fmt.Errorf("simulator: author account %d is deleted", authorIdx)
+	if !canAuthor {
+		return nil, fmt.Errorf("simulator: author account %d is unavailable", authorIdx)
 	}
 	author, err := w.loadAccount(authorIdx)
 	if err != nil {
@@ -381,12 +381,12 @@ func (w *World) GenerateMultiOpCommitForTest(ctx context.Context, idx int, specs
 	if idx < 0 || idx >= w.cfg.Accounts {
 		return nil, nil, fmt.Errorf("simulator: chain account index %d out of range", idx)
 	}
-	deleted, err := w.isAccountDeleted(idx)
+	canAuthor, err := w.accountCanAuthor(idx)
 	if err != nil {
 		return nil, nil, err
 	}
-	if deleted {
-		return nil, nil, fmt.Errorf("simulator: chain account %d is deleted", idx)
+	if !canAuthor {
+		return nil, nil, fmt.Errorf("simulator: chain account %d is unavailable", idx)
 	}
 	author, err := w.loadAccount(idx)
 	if err != nil {
@@ -542,12 +542,12 @@ func (w *World) loadRepoForTargetedCommit(idx int) (account, *repo.Repo, *diffSt
 	if idx < 0 || idx >= w.cfg.Accounts {
 		return account{}, nil, nil, repoState{}, fmt.Errorf("simulator: account index %d out of range", idx)
 	}
-	deleted, err := w.isAccountDeleted(idx)
+	canAuthor, err := w.accountCanAuthor(idx)
 	if err != nil {
 		return account{}, nil, nil, repoState{}, err
 	}
-	if deleted {
-		return account{}, nil, nil, repoState{}, fmt.Errorf("simulator: account %d is deleted", idx)
+	if !canAuthor {
+		return account{}, nil, nil, repoState{}, fmt.Errorf("simulator: account %d is unavailable", idx)
 	}
 	author, err := w.loadAccount(idx)
 	if err != nil {
@@ -630,12 +630,12 @@ func (w *World) silentCreateForAccount(idx int) error {
 	if idx < 0 || idx >= w.cfg.Accounts {
 		return fmt.Errorf("simulator: silent account index %d out of range", idx)
 	}
-	deleted, err := w.isAccountDeleted(idx)
+	canAuthor, err := w.accountCanAuthor(idx)
 	if err != nil {
 		return err
 	}
-	if deleted {
-		return fmt.Errorf("simulator: silent account %d is deleted", idx)
+	if !canAuthor {
+		return fmt.Errorf("simulator: silent account %d is unavailable", idx)
 	}
 	author, err := w.loadAccount(idx)
 	if err != nil {
@@ -686,12 +686,12 @@ func (w *World) emitSyncWithRev(ctx context.Context, idx int, rev, timeStr strin
 	if idx < 0 || idx >= w.cfg.Accounts {
 		return nil, 0, "", fmt.Errorf("simulator: sync account index %d out of range", idx)
 	}
-	deleted, err := w.isAccountDeleted(idx)
+	canAuthor, err := w.accountCanAuthor(idx)
 	if err != nil {
 		return nil, 0, "", err
 	}
-	if deleted {
-		return nil, 0, "", fmt.Errorf("simulator: sync account %d is deleted", idx)
+	if !canAuthor {
+		return nil, 0, "", fmt.Errorf("simulator: sync account %d is unavailable", idx)
 	}
 	author, err := w.loadAccount(idx)
 	if err != nil {
@@ -873,20 +873,20 @@ func (w *World) pickTargetAccount(authorIdx int) (atmos.DID, error) {
 func (w *World) pickActiveAuthor() (int, error) {
 	for attempts := 0; attempts < max(1, w.cfg.Accounts*4); attempts++ {
 		idx := zipfian(w.rng, 1.07, w.cfg.Accounts)
-		deleted, err := w.isAccountDeleted(idx)
+		canAuthor, err := w.accountCanAuthor(idx)
 		if err != nil {
 			return 0, err
 		}
-		if !deleted {
+		if canAuthor {
 			return idx, nil
 		}
 	}
 	for idx := range w.cfg.Accounts {
-		deleted, err := w.isAccountDeleted(idx)
+		canAuthor, err := w.accountCanAuthor(idx)
 		if err != nil {
 			return 0, err
 		}
-		if !deleted {
+		if canAuthor {
 			return idx, nil
 		}
 	}

--- a/testing/mutation/RESULTS.md
+++ b/testing/mutation/RESULTS.md
@@ -5,10 +5,10 @@ oracle's detection power is visible over time. See
 `docs/superpowers/specs/2026-06-12-oracle-mutation-campaign-design.md` for the
 method and `testing/mutation/run.sh` for the driver.
 
-**Current catalog (keep this line current): 34 active mutants on disk
-(m001–m042; m007, m010, m013, m014, m020, m021, m023, m025 retired). Current
-union baseline: **33 killed, 1 survived, zero STALE/BUILD-BROKEN** in
-`testing/mutation/baseline.json` (commit field `fdbfaa7` is
+**Current catalog (keep this line current): 35 active mutants on disk
+(m001–m043; m007, m010, m013, m014, m020, m021, m023, m025 retired). Current
+union baseline: **34 killed, 1 survived, zero STALE/BUILD-BROKEN** in
+`testing/mutation/baseline.json` (commit field `2450fec` is
 provenance-only). The remaining survivor (m015) is a documented escape with
 owning issue #208.
 m042 (the #206 frames-tier mutant) was renumbered from its original m036 id
@@ -75,6 +75,28 @@ remain below so the reasoning is not lost.
 | m021_overlay_record_seq_base_zero | 2026-06-29 | Same — `internal/overlay` deleted in #177. |
 | m023_overlay_drop_record_tombstones | 2026-06-29 | Same — `internal/overlay` deleted in #177. |
 | m025_compaction_overdrop_above_watermark | 2026-06-29 | Mutated `Set.SnapshotRange` (unbounded in-memory snapshot), deleted in #178. The on-disk windowed fold cannot reproduce it: `targetWatermark` is the last sealed segment's MaxSeq, so no decoded event exceeds the fold window. The above-watermark over-drop is unreachable post-#178. #183's re-derivation analysis (2026-07-04 section below) concluded no single-edit replacement exists: the recorder is a regression assertion without a gated mutant. |
+
+## Campaign 2026-07-05 (#203 — account lifecycle statuses and getRepo unavailable)
+
+Full campaign at `2450fec` after adding deterministic simulator/oracle coverage
+for non-deleted account lifecycle statuses (`takendown`, `suspended`,
+`deactivated`, `unknown`), reactivation, and terminal `getRepo`
+`RepoTakendown`/`RepoSuspended`/`RepoDeactivated` classification. **35 active
+mutants: 34 KILLED, 1 SURVIVED, zero STALE/BUILD-BROKEN.** The only survivor is
+the existing documented m015 footer-count escape.
+
+Drivers:
+
+```bash
+testing/mutation/run.sh m043 --json /tmp/m043.json
+testing/mutation/run.sh --json testing/mutation/baseline.json
+```
+
+### Scorecard
+
+| mutant | result | note |
+|---|---|---|
+| m043_account_status_exactness | KILLED@tombstone | `accountDeleted` treating any inactive status as a DID tombstone is killed by the tombstone exactness tier; the default lifecycle also injects archived non-deleted statuses after a probe create. |
 
 ## Campaign 2026-06-29 (step 11 #182 — partb tier; catalog refresh; baseline regen)
 

--- a/testing/mutation/RESULTS.md
+++ b/testing/mutation/RESULTS.md
@@ -8,7 +8,7 @@ method and `testing/mutation/run.sh` for the driver.
 **Current catalog (keep this line current): 35 active mutants on disk
 (m001–m043; m007, m010, m013, m014, m020, m021, m023, m025 retired). Current
 union baseline: **34 killed, 1 survived, zero STALE/BUILD-BROKEN** in
-`testing/mutation/baseline.json` (commit field `2450fec` is
+`testing/mutation/baseline.json` (commit field `4f2c153` is
 provenance-only). The remaining survivor (m015) is a documented escape with
 owning issue #208.
 m042 (the #206 frames-tier mutant) was renumbered from its original m036 id
@@ -85,6 +85,24 @@ for non-deleted account lifecycle statuses (`takendown`, `suspended`,
 mutants: 34 KILLED, 1 SURVIVED, zero STALE/BUILD-BROKEN.** The only survivor is
 the existing documented m015 footer-count escape.
 
+**Re-run at `4f2c153` (same day) after an adversarial-review finding proved the
+`2450fec` result vacuous at the end-to-end tier.** m043 originally declared
+`tiers: tombstone,default`; the driver stops at the first killing tier, so the
+pre-existing tombstone unit matrix killed the mutant and
+`TestOracle_DefaultLifecycle` never gated the new #203 lifecycle coverage —
+confirmed by hand-applying the mutant: the default tier PASSED, because the
+lifecycle was injected at the end of the steady window, above every compaction
+watermark, where the tombstone-exactness fold never touches rows. Fixes: the
+lifecycle injection moved to the start of the steady window (below the
+tombstone-triggered pass watermark), the harness now asserts the final
+watermark covers the lifecycle rows (anti-vacuity), and m043's tiers reordered
+to `default,tombstone` so the end-to-end tier is the recorded killer. The
+mutant's expected-detection block also cited a nonexistent test
+(`TestTombstoneSet_AccountStatusExactness`); corrected to the real unit
+backstops (`TestObserveAccountDeletedOnlyPurgesLiteralDeleted`,
+`TestObserveAccountStatusMatrixRetains`). m001's recorded tier also moved
+stress→default in this regen (tier-order note only; disposition unchanged).
+
 Drivers:
 
 ```bash
@@ -96,7 +114,7 @@ testing/mutation/run.sh --json testing/mutation/baseline.json
 
 | mutant | result | note |
 |---|---|---|
-| m043_account_status_exactness | KILLED@tombstone | `accountDeleted` treating any inactive status as a DID tombstone is killed by the tombstone exactness tier; the default lifecycle also injects archived non-deleted statuses after a probe create. |
+| m043_account_status_exactness | KILLED@default | `oracle: missing did:plc:jqwkem7rbggmxanbfb7e6gbl app.bsky.feed.like/...` — under the mutant the fixture account's inactive statuses fold as DID tombstones and compaction over-drops its records; the tombstone unit matrix remains the fast backstop tier. |
 
 ## Campaign 2026-06-29 (step 11 #182 — partb tier; catalog refresh; baseline regen)
 

--- a/testing/mutation/baseline.json
+++ b/testing/mutation/baseline.json
@@ -1,15 +1,15 @@
 {
-  "commit": "fdbfaa7cc5098dd0566a8b0f97da09ae70afc2e1",
+  "commit": "2450fecb8ab1150b12cd8203f3533918d078fa78",
   "mutants": [
-    {"id":"m001_delete_mapped_to_update","disposition":"KILLED","result":"KILLED@default","note":"see log"},
+    {"id":"m001_delete_mapped_to_update","disposition":"KILLED","result":"KILLED@stress","note":"see log"},
     {"id":"m002_watermark_floor_off_by_one","disposition":"KILLED","result":"KILLED@compaction","note":"oracle: superseded record row survived at/below the first-init watermark: seq=1 watermark=2 (m002 boundary miss is permanent: later fold win"},
     {"id":"m003_merge_cursor_no_advance","disposition":"KILLED","result":"KILLED@restart-multisource","note":"see log"},
     {"id":"m004_rev_filter_inverted","disposition":"KILLED","result":"KILLED@default","note":"oracle: missing did:plc:iv2erqbe5k4ltaawmik4tfeo app.bsky.actor.profile/22bgjqcoc57xt rev="},
-    {"id":"m005_backfill_status_check_inverted","disposition":"KILLED","result":"KILLED@restart","note":"oracle: rev regression for DID did:plc:c6r55vuzviwkyk275qu6x7zp at event 13: seq=16 app.bsky.feed.like/22b7c4ezkohs6 rev="},
+    {"id":"m005_backfill_status_check_inverted","disposition":"KILLED","result":"KILLED@restart","note":"oracle: rev regression for DID did:plc:c6r55vuzviwkyk275qu6x7zp at event 12: seq=15 app.bsky.feed.like/22b7c4ezkohs6 rev="},
     {"id":"m006_merge_commit_error_swallowed","disposition":"KILLED","result":"KILLED@storefault","note":"see log"},
     {"id":"m008_header_offset_byteslice","disposition":"KILLED","result":"KILLED@default","note":"see log"},
     {"id":"m009_checksum_range_off_by_one","disposition":"KILLED","result":"KILLED@corpus","note":"see log"},
-    {"id":"m011_wire_frame_length","disposition":"KILLED","result":"KILLED@default","note":"oracle: walk active segment /tmp/TestOracle_DefaultLifecycle1986083502/003/segments/seg_0000000000.jss: segment: walk active frames: segment"},
+    {"id":"m011_wire_frame_length","disposition":"KILLED","result":"KILLED@default","note":"oracle: walk active segment /tmp/TestOracle_DefaultLifecycle2044367451/003/segments/seg_0000000000.jss: segment: walk active frames: segment"},
     {"id":"m012_block_event_count_off_by_one","disposition":"KILLED","result":"KILLED@default","note":"see log"},
     {"id":"m015_collection_count_double","disposition":"SURVIVED","result":"SURVIVED","note":"escape — analyze and disposition"},
     {"id":"m016_bloom_size_off_by_one","disposition":"KILLED","result":"KILLED@default","note":"see log"},
@@ -26,14 +26,15 @@
     {"id":"m031_plan_truncation_zero_units_unadvanced","disposition":"KILLED","result":"KILLED@partb","note":"see log"},
     {"id":"m032_v2_below_floor_silent_clamp","disposition":"KILLED","result":"KILLED@partb","note":"see log"},
     {"id":"m033_client_too_old_400_not_rebackfilled","disposition":"KILLED","result":"KILLED@partb","note":"see log"},
-    {"id":"m034_overdrop_hook_stale_watermark","disposition":"KILLED","result":"KILLED@default","note":"oracle: over-drop recorder watermark mismatch: pre-pass hook saw 20 but the pass committed 36 (recorder scans bounded at the wrong seq would"},
+    {"id":"m034_overdrop_hook_stale_watermark","disposition":"KILLED","result":"KILLED@default","note":"oracle: over-drop recorder watermark mismatch: pre-pass hook saw 25 but the pass committed 41 (recorder scans bounded at the wrong seq would"},
     {"id":"m035_account_replay_guard_inverted","disposition":"KILLED","result":"KILLED@replay","note":"see log"},
-    {"id":"m036_sync_resync_collection_rkey_swap","disposition":"KILLED","result":"KILLED@default","note":"oracle: event mismatch at index 25: want seq=34 kind=create_resync did=did:plc:iv2erqbe5k4ltaawmik4tfeo key=app.bsky.actor.profile/22aotbzcu"},
-    {"id":"m037_sync_resync_rev_dropped","disposition":"KILLED","result":"KILLED@default","note":"oracle: event mismatch at index 25: want seq=34 kind=create_resync did=did:plc:iv2erqbe5k4ltaawmik4tfeo key=app.bsky.actor.profile/22aotbzcu"},
+    {"id":"m036_sync_resync_collection_rkey_swap","disposition":"KILLED","result":"KILLED@default","note":"oracle: event mismatch at index 21: want seq=34 kind=create_resync did=did:plc:iv2erqbe5k4ltaawmik4tfeo key=app.bsky.actor.profile/22bgd52hp"},
+    {"id":"m037_sync_resync_rev_dropped","disposition":"KILLED","result":"KILLED@default","note":"oracle: event mismatch at index 21: want seq=34 kind=create_resync did=did:plc:iv2erqbe5k4ltaawmik4tfeo key=app.bsky.actor.profile/22bgd52hp"},
     {"id":"m038_live_op_path_gate_skipped","disposition":"KILLED","result":"KILLED@default","note":"see log"},
     {"id":"m039_backfill_rkey_gate_skipped","disposition":"KILLED","result":"KILLED@default","note":"oracle: extra did:plc:iv2erqbe5k4ltaawmik4tfeo app.bsky.feed.post/.."},
     {"id":"m040_live_op_drop_escalated_whole_event","disposition":"KILLED","result":"KILLED@default","note":"see log"},
     {"id":"m041_identity_swallowed","disposition":"KILLED","result":"KILLED@default","note":"see log"},
-    {"id":"m042_missing_block_arm_discards_siblings","disposition":"KILLED","result":"KILLED@frames","note":"see log"}
+    {"id":"m042_missing_block_arm_discards_siblings","disposition":"KILLED","result":"KILLED@frames","note":"see log"},
+    {"id":"m043_account_status_exactness","disposition":"KILLED","result":"KILLED@tombstone","note":"see log"}
   ]
 }

--- a/testing/mutation/baseline.json
+++ b/testing/mutation/baseline.json
@@ -1,7 +1,7 @@
 {
-  "commit": "2450fecb8ab1150b12cd8203f3533918d078fa78",
+  "commit": "4f2c153ec38781923b4d60c0cf787ea3ee5b6789",
   "mutants": [
-    {"id":"m001_delete_mapped_to_update","disposition":"KILLED","result":"KILLED@stress","note":"see log"},
+    {"id":"m001_delete_mapped_to_update","disposition":"KILLED","result":"KILLED@default","note":"see log"},
     {"id":"m002_watermark_floor_off_by_one","disposition":"KILLED","result":"KILLED@compaction","note":"oracle: superseded record row survived at/below the first-init watermark: seq=1 watermark=2 (m002 boundary miss is permanent: later fold win"},
     {"id":"m003_merge_cursor_no_advance","disposition":"KILLED","result":"KILLED@restart-multisource","note":"see log"},
     {"id":"m004_rev_filter_inverted","disposition":"KILLED","result":"KILLED@default","note":"oracle: missing did:plc:iv2erqbe5k4ltaawmik4tfeo app.bsky.actor.profile/22bgjqcoc57xt rev="},
@@ -9,7 +9,7 @@
     {"id":"m006_merge_commit_error_swallowed","disposition":"KILLED","result":"KILLED@storefault","note":"see log"},
     {"id":"m008_header_offset_byteslice","disposition":"KILLED","result":"KILLED@default","note":"see log"},
     {"id":"m009_checksum_range_off_by_one","disposition":"KILLED","result":"KILLED@corpus","note":"see log"},
-    {"id":"m011_wire_frame_length","disposition":"KILLED","result":"KILLED@default","note":"oracle: walk active segment /tmp/TestOracle_DefaultLifecycle2044367451/003/segments/seg_0000000000.jss: segment: walk active frames: segment"},
+    {"id":"m011_wire_frame_length","disposition":"KILLED","result":"KILLED@default","note":"oracle: walk active segment /tmp/TestOracle_DefaultLifecycle3644852033/003/segments/seg_0000000000.jss: segment: walk active frames: segment"},
     {"id":"m012_block_event_count_off_by_one","disposition":"KILLED","result":"KILLED@default","note":"see log"},
     {"id":"m015_collection_count_double","disposition":"SURVIVED","result":"SURVIVED","note":"escape — analyze and disposition"},
     {"id":"m016_bloom_size_off_by_one","disposition":"KILLED","result":"KILLED@default","note":"see log"},
@@ -28,13 +28,13 @@
     {"id":"m033_client_too_old_400_not_rebackfilled","disposition":"KILLED","result":"KILLED@partb","note":"see log"},
     {"id":"m034_overdrop_hook_stale_watermark","disposition":"KILLED","result":"KILLED@default","note":"oracle: over-drop recorder watermark mismatch: pre-pass hook saw 25 but the pass committed 41 (recorder scans bounded at the wrong seq would"},
     {"id":"m035_account_replay_guard_inverted","disposition":"KILLED","result":"KILLED@replay","note":"see log"},
-    {"id":"m036_sync_resync_collection_rkey_swap","disposition":"KILLED","result":"KILLED@default","note":"oracle: event mismatch at index 21: want seq=34 kind=create_resync did=did:plc:iv2erqbe5k4ltaawmik4tfeo key=app.bsky.actor.profile/22bgd52hp"},
-    {"id":"m037_sync_resync_rev_dropped","disposition":"KILLED","result":"KILLED@default","note":"oracle: event mismatch at index 21: want seq=34 kind=create_resync did=did:plc:iv2erqbe5k4ltaawmik4tfeo key=app.bsky.actor.profile/22bgd52hp"},
+    {"id":"m036_sync_resync_collection_rkey_swap","disposition":"KILLED","result":"KILLED@default","note":"oracle: event mismatch at index 35: want seq=40 kind=create_resync did=did:plc:iv2erqbe5k4ltaawmik4tfeo key=app.bsky.actor.profile/22bdpktwj"},
+    {"id":"m037_sync_resync_rev_dropped","disposition":"KILLED","result":"KILLED@default","note":"oracle: event mismatch at index 35: want seq=40 kind=create_resync did=did:plc:iv2erqbe5k4ltaawmik4tfeo key=app.bsky.actor.profile/22bdpktwj"},
     {"id":"m038_live_op_path_gate_skipped","disposition":"KILLED","result":"KILLED@default","note":"see log"},
     {"id":"m039_backfill_rkey_gate_skipped","disposition":"KILLED","result":"KILLED@default","note":"oracle: extra did:plc:iv2erqbe5k4ltaawmik4tfeo app.bsky.feed.post/.."},
     {"id":"m040_live_op_drop_escalated_whole_event","disposition":"KILLED","result":"KILLED@default","note":"see log"},
     {"id":"m041_identity_swallowed","disposition":"KILLED","result":"KILLED@default","note":"see log"},
     {"id":"m042_missing_block_arm_discards_siblings","disposition":"KILLED","result":"KILLED@frames","note":"see log"},
-    {"id":"m043_account_status_exactness","disposition":"KILLED","result":"KILLED@tombstone","note":"see log"}
+    {"id":"m043_account_status_exactness","disposition":"KILLED","result":"KILLED@default","note":"oracle: missing did:plc:jqwkem7rbggmxanbfb7e6gbl app.bsky.feed.like/22an2gcxc6rbz rev="}
   ]
 }

--- a/testing/mutation/mutants/m043_account_status_exactness.patch
+++ b/testing/mutation/mutants/m043_account_status_exactness.patch
@@ -10,15 +10,19 @@ failure-mode: |
   a moderation/unavailability event becomes indistinguishable from account
   deletion at the tombstone layer.
 expected-detection: |
-  tombstone tier: TestTombstoneSet_AccountStatusExactness and the oracle's
-  compaction helpers require exact status=="deleted" semantics, so inactive
-  non-deleted statuses must not produce DID tombstones. The default lifecycle
-  also injects a deterministic account-status sequence with takendown,
-  suspended, deactivated, unknown, and active=true reactivation after a probe
-  create; under this mutant the compaction/final-state checks report the probe
-  row as missing or superseded.
-expected-tier: tombstone
-tiers: tombstone,default
+  default tier: the lifecycle injects a deterministic account-status sequence
+  (takendown, suspended, deactivated, unknown, then active=true reactivation)
+  for a fixture account after a probe create; under this mutant those inactive
+  statuses fold as DID tombstones, so compaction drops the probe row and the
+  compaction/final-state checks report it missing or superseded. The default
+  tier is listed first deliberately: the pre-existing tombstone unit matrix
+  (TestObserveAccountDeletedOnlyPurgesLiteralDeleted,
+  TestObserveAccountStatusMatrixRetains) also kills this mutant, and the
+  driver stops at the first killing tier — tombstone-first would record a kill
+  without ever exercising the #203 end-to-end coverage this mutant gates.
+  tombstone tier remains as the fast unit backstop.
+expected-tier: default
+tiers: default,tombstone
 
 diff --git a/internal/tombstone/tombstone.go b/internal/tombstone/tombstone.go
 index 4d34cf1..b73d0f7 100644

--- a/testing/mutation/mutants/m043_account_status_exactness.patch
+++ b/testing/mutation/mutants/m043_account_status_exactness.patch
@@ -1,0 +1,30 @@
+mutant: m043_account_status_exactness
+target: internal/tombstone/tombstone.go
+failure-mode: |
+  DID tombstone classification treats every inactive #account status
+  as a deletion instead of requiring the exact atproto deletion shape
+  active=false,status=deleted. Real relay/PDS account lifecycle statuses
+  such as takendown, suspended, deactivated, and unknown would then fold as
+  DID tombstones during compaction, allowing the compactor to drop unrelated
+  live records for accounts that still exist. This is permanent data loss:
+  a moderation/unavailability event becomes indistinguishable from account
+  deletion at the tombstone layer.
+expected-detection: |
+  tombstone tier: TestTombstoneSet_AccountStatusExactness and the oracle's
+  compaction helpers require exact status=="deleted" semantics, so inactive
+  non-deleted statuses must not produce DID tombstones. The default lifecycle
+  also injects a deterministic account-status sequence with takendown,
+  suspended, deactivated, unknown, and active=true reactivation after a probe
+  create; under this mutant the compaction/final-state checks report the probe
+  row as missing or superseded.
+expected-tier: tombstone
+tiers: tombstone,default
+
+diff --git a/internal/tombstone/tombstone.go b/internal/tombstone/tombstone.go
+index 4d34cf1..b73d0f7 100644
+--- a/internal/tombstone/tombstone.go
++++ b/internal/tombstone/tombstone.go
+@@ -241 +241 @@ func accountDeleted(payload []byte) (bool, error) {
+-	return !acc.Active && acc.Status.HasVal() && acc.Status.Val() == "deleted", nil
++	return !acc.Active && acc.Status.HasVal(), nil
+ }


### PR DESCRIPTION
## Summary
- model non-deleted account lifecycle statuses and terminal getRepo unavailable states in the simulator
- add deterministic oracle coverage for account-status exactness, reactivation, and StatusUnavailable persistence
- add m043_account_status_exactness and refresh the mutation baseline

## Verification
- just test ./internal/simulator/world ./internal/simulator/http
- just test ./internal/oracle
- go test -count=1 -short ./internal/oracle -run TestOracle_DefaultLifecycle -v
- just test ./internal/tombstone
- testing/mutation/run.sh m043 --json /tmp/m043.json
- testing/mutation/run.sh --json testing/mutation/baseline.json
- go run ./testing/mutation/gate -baseline testing/mutation/baseline.json -result testing/mutation/baseline.json

Closes #203