### PR TITLE
ingest: ratchet account replay guard on append

### DIFF
--- a/internal/ingest/live/consumer.go
+++ b/internal/ingest/live/consumer.go
@@ -90,14 +90,13 @@ func Open(cfg Config) (*Consumer, error) {
 	// tombstone the set does not yet contain, and the pass would
 	// durably advance the watermark past it, evicting it unapplied.
 	//
-	// The #identity applied-seq ratchet (#234) records here for the
-	// same before-any-flush reason: Append can synchronously flush a
-	// full block, and that flush commits the cursor + StageFlush durable
-	// batch. Recording post-Append (where hosting
-	// promotes) would open a crash window where the identity row and
-	// the cursor batch are durable but the ratchet is not — a restart
-	// redelivery would then re-archive the row as a permanent
-	// duplicate, the exact bug the guard exists to prevent.
+	// The #identity and #account applied-seq ratchets record here for
+	// the same before-any-flush reason: Append can synchronously flush
+	// a full block, and that flush commits the cursor + StageFlush
+	// durable batch. Recording post-Append would open a crash window
+	// where the row and cursor batch are durable but the ratchet is not
+	// — a restart redelivery would then re-archive the row as a
+	// permanent duplicate, the exact bug the guards exist to prevent.
 	var onAppend func(ev *segment.Event) error
 	if cfg.Tombstones != nil || cfg.SyncStateStore != nil {
 		ts := cfg.Tombstones
@@ -108,8 +107,13 @@ func Open(cfg Config) (*Consumer, error) {
 					return err
 				}
 			}
-			if ss != nil && ev.Kind == segment.KindIdentity {
-				ss.RecordIdentitySeq(atmos.DID(ev.DID), ev.UpstreamRelayCursor)
+			if ss != nil {
+				switch ev.Kind {
+				case segment.KindAccount:
+					ss.RecordAccountSeq(atmos.DID(ev.DID), ev.UpstreamRelayCursor)
+				case segment.KindIdentity:
+					ss.RecordIdentitySeq(atmos.DID(ev.DID), ev.UpstreamRelayCursor)
+				}
 			}
 			return nil
 		}
@@ -233,37 +237,42 @@ func (c *Consumer) dropStaleOrderedAsyncResync(ctx context.Context, evt streamin
 }
 
 // dropReplayedAccountEvent guards against relay seq replays of #account
-// events. atmos's verifier replay-drops duplicate #commit/#sync
-// deliveries (rev-replay protection), but OnAccountEvent's seq guard only
-// suppresses verifier STATE updates — the event still flows to the
-// consumer. Without this check a relay regression (e.g. restored from
-// backup) re-archives the #account row at a fresh jetstream seq, and a
-// replayed account-delete landing ABOVE a later reactivate+recreate makes
-// every fold (oracle reconstruct, tombstone set, compaction) erase live
-// records permanently. The comparison uses the APPLIED hosting seq
-// (promoted or pebble-durable, never pending): promotion happens
-// synchronously after this DID's row is appended and per-DID delivery is
-// seq-ordered, so seq <= applied means this exact event's row is already
-// in the archive — a second delivery is a duplicate by construction.
-// Pending state is excluded because a later pipelined event could stage
-// it before its own rows land, and consulting it would drop a legitimate
-// intermediate event.
+// events. atmos's verifier replay-drops duplicate #commit/#sync deliveries
+// (rev-replay protection), but OnAccountEvent's seq guard only suppresses
+// verifier STATE updates — the event still flows to the consumer. Without
+// this check a relay regression (e.g. restored from backup) re-archives the
+// #account row at a fresh jetstream seq, and a replayed account-delete
+// landing ABOVE a later reactivate+recreate makes every fold (oracle
+// reconstruct, tombstone set, compaction) erase live records permanently.
+// The primary comparison uses Jetstream's append-owned applied account seq
+// ratchet, recorded in the writer's OnAppend hook. Applied hosting state is
+// only a backward-compatible fallback: pending hosting state cannot be used
+// because a later pipelined event can stage it before its own rows land, and
+// consulting it would drop a legitimate intermediate event.
 func (c *Consumer) dropReplayedAccountEvent(ctx context.Context, segEvts []segment.Event) (bool, error) {
 	if c.cfg.SyncStateStore == nil || len(segEvts) != 1 || segEvts[0].Kind != segment.KindAccount {
 		return false, nil
 	}
-	state, err := c.cfg.SyncStateStore.LoadAppliedHosting(ctx, atmos.DID(segEvts[0].DID))
+	did := atmos.DID(segEvts[0].DID)
+	appliedSeq, err := c.cfg.SyncStateStore.LoadAppliedAccountSeq(ctx, did)
 	if err != nil {
 		return false, fmt.Errorf("livestream: account replay guard: %w", err)
 	}
-	if state == nil || segEvts[0].UpstreamRelayCursor > state.Seq {
+	state, err := c.cfg.SyncStateStore.LoadAppliedHosting(ctx, did)
+	if err != nil {
+		return false, fmt.Errorf("livestream: account replay guard: %w", err)
+	}
+	if state != nil && state.Seq > appliedSeq {
+		appliedSeq = state.Seq
+	}
+	if appliedSeq == 0 || segEvts[0].UpstreamRelayCursor > appliedSeq {
 		return false, nil
 	}
 	c.cfg.Metrics.incReplayedAccountEventsDropped()
 	c.logger.WarnContext(ctx, "dropped replayed account event",
 		"did", segEvts[0].DID,
 		"seq", segEvts[0].UpstreamRelayCursor,
-		"applied_seq", state.Seq,
+		"applied_seq", appliedSeq,
 	)
 	return true, nil
 }

--- a/internal/ingest/live/replay_guard_test.go
+++ b/internal/ingest/live/replay_guard_test.go
@@ -105,6 +105,93 @@ func TestProcessBatch_ReplayedAccountEventIsDroppedNotReArchived(t *testing.T) {
 		"replay drops must still advance the in-memory upstream watermark")
 }
 
+// TestProcessBatch_ReplayedAccountEventDropsWhenHostingPromotionBlocked
+// reproduces the CI failure mode from #254: atmos can stage newer same-DID
+// hosting state before Jetstream appends an older #account row. The older row
+// must not promote that newer pending state, but its own append still has to
+// arm archive-level replay dedupe so a duplicate older frame does not append.
+func TestProcessBatch_ReplayedAccountEventDropsWhenHostingPromotionBlocked(t *testing.T) {
+	t.Parallel()
+
+	st := newTestStore(t)
+	dir := filepath.Join(t.TempDir(), "live_segments")
+	metrics := NewMetrics(prometheus.NewRegistry())
+	stateStore := syncstate.New(st)
+
+	const did = "did:plc:blockedpromote"
+	atmosDID := atmos.DID(did)
+	require.NoError(t, stateStore.SaveHosting(t.Context(), atmosDID,
+		atmossync.HostingState{Active: true, Seq: 6}))
+
+	c, err := Open(Config{
+		SegmentsDir:    dir,
+		Store:          st,
+		SeqKey:         "live_segments/seq/next",
+		CursorKey:      "relay/cursor",
+		RelayURL:       "https://example.invalid",
+		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Verifier:       newTestVerifier(t),
+		SyncStateStore: stateStore,
+		Metrics:        metrics,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	require.NoError(t, c.processBatch(t.Context(), []streaming.Event{
+		accountEvent(did, 5, false),
+	}))
+	require.NoError(t, c.processBatch(t.Context(), []streaming.Event{
+		accountEvent(did, 5, false),
+	}))
+	require.NoError(t, c.Close())
+
+	got := readAllSegmentEvents(t, dir)
+	require.Len(t, got, 1, "blocked hosting promotion must not let account replay re-archive")
+	require.Equal(t, int64(5), archivedAccountSeq(t, got[0].Payload))
+	require.InDelta(t, 1.0, testutil.ToFloat64(metrics.ReplayedAccountsDrop), 0)
+
+	hosting, err := stateStore.LoadAppliedHosting(t.Context(), atmosDID)
+	require.NoError(t, err)
+	require.Nil(t, hosting, "older row must not promote newer pending hosting state")
+}
+
+// TestProcessBatch_AccountRatchetDurableAtBlockBoundary mirrors the identity
+// crash-window guard for #account rows: a full-block append commits the cursor
+// batch inside Append, so the account replay ratchet must be recorded by
+// OnAppend before that flush.
+func TestProcessBatch_AccountRatchetDurableAtBlockBoundary(t *testing.T) {
+	t.Parallel()
+
+	st := newTestStore(t)
+	dir := filepath.Join(t.TempDir(), "live_segments")
+	stateStore := syncstate.New(st)
+
+	const did = "did:plc:acctblockedge"
+
+	c, err := Open(Config{
+		SegmentsDir:       dir,
+		Store:             st,
+		SeqKey:            "live_segments/seq/next",
+		CursorKey:         "relay/cursor",
+		RelayURL:          "https://example.invalid",
+		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Verifier:          newTestVerifier(t),
+		SyncStateStore:    stateStore,
+		MaxEventsPerBlock: 1,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	require.NoError(t, c.processBatch(t.Context(), []streaming.Event{
+		accountEvent(did, 5, false),
+	}))
+
+	applied, err := syncstate.New(st).LoadAppliedAccountSeq(t.Context(), atmos.DID(did))
+	require.NoError(t, err)
+	require.Equal(t, int64(5), applied,
+		"account ratchet must be durable once the row's block has flushed")
+}
+
 func archivedIdentitySeq(t *testing.T, payload []byte) int64 {
 	t.Helper()
 	var ident comatproto.SyncSubscribeRepos_Identity

--- a/internal/ingest/syncstate/store.go
+++ b/internal/ingest/syncstate/store.go
@@ -17,6 +17,7 @@ const (
 	chainPrefix = "sync/chain/"
 	hostPrefix  = "sync/host/"
 	identPrefix = "sync/ident/"
+	acctPrefix  = "sync/acct/"
 )
 
 // PebbleStateStore implements sync.StateStore against a *store.Store.
@@ -70,6 +71,12 @@ type PebbleStateStore struct {
 	// only ratchet upward.
 	promotedIdent map[atmos.DID]int64
 
+	// promotedAccount is the per-DID applied #account seq ratchet. It is
+	// intentionally separate from verifier hosting state: hosting promotion
+	// is gated by the pending event that produced it, but archival replay
+	// dedupe only needs to know that this account row was appended.
+	promotedAccount map[atmos.DID]int64
+
 	// captured* record exactly which promoted values the most recent
 	// StageFlush wrote into its batch. CommitStaged clears only those,
 	// so a promotion that lands between StageFlush and CommitStaged is
@@ -77,6 +84,7 @@ type PebbleStateStore struct {
 	capturedChain   map[atmos.DID][]byte
 	capturedHosting map[atmos.DID][]byte
 	capturedIdent   map[atmos.DID]int64
+	capturedAccount map[atmos.DID]int64
 }
 
 type pendingChainState struct {
@@ -100,6 +108,7 @@ func New(s *store.Store) *PebbleStateStore {
 		promotedChain:   make(map[atmos.DID][]byte),
 		promotedHosting: make(map[atmos.DID][]byte),
 		promotedIdent:   make(map[atmos.DID]int64),
+		promotedAccount: make(map[atmos.DID]int64),
 	}
 }
 
@@ -113,6 +122,10 @@ func hostKey(did atmos.DID) []byte {
 
 func identKey(did atmos.DID) []byte {
 	return []byte(identPrefix + string(did))
+}
+
+func acctKey(did atmos.DID) []byte {
+	return []byte(acctPrefix + string(did))
 }
 
 func (p *PebbleStateStore) LoadChain(_ context.Context, did atmos.DID) (*atmossync.ChainState, error) {
@@ -266,6 +279,34 @@ func (p *PebbleStateStore) LoadAppliedIdentitySeq(_ context.Context, did atmos.D
 	return got, nil
 }
 
+// LoadAppliedAccountSeq returns the highest #account seq whose row has
+// been appended for did (promoted-but-unflushed first, then pebble), or
+// 0 when the DID has never had an account row. This is Jetstream's
+// archive-owned replay ratchet; it deliberately does not consult verifier
+// hosting state, whose pending/promotion lifecycle has a different contract.
+func (p *PebbleStateStore) LoadAppliedAccountSeq(_ context.Context, did atmos.DID) (int64, error) {
+	p.mu.Lock()
+	seq, ok := p.promotedAccount[did]
+	p.mu.Unlock()
+	if ok {
+		return seq, nil
+	}
+
+	val, closer, err := p.s.Get(acctKey(did))
+	if errors.Is(err, store.ErrNotFound) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("syncstate: load applied account seq %s: %w", did, err)
+	}
+	defer func() { _ = closer.Close() }()
+	got, err := decodeIdentitySeq(val)
+	if err != nil {
+		return 0, fmt.Errorf("syncstate: load applied account seq %s: %w", did, err)
+	}
+	return got, nil
+}
+
 // RecordIdentitySeq stages the applied #identity seq for did, to be
 // flushed by the next StageFlush batch. Ratchet-only: a seq at or
 // below the staged value is ignored, so out-of-order calls can never
@@ -283,6 +324,18 @@ func (p *PebbleStateStore) RecordIdentitySeq(did atmos.DID, seq int64) {
 		return
 	}
 	p.promotedIdent[did] = seq
+}
+
+// RecordAccountSeq stages the applied #account seq for did, to be flushed
+// by the next StageFlush batch. Ratchet-only, with the same append-before-
+// flush ordering requirement as RecordIdentitySeq.
+func (p *PebbleStateStore) RecordAccountSeq(did atmos.DID, seq int64) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if cur, ok := p.promotedAccount[did]; ok && cur >= seq {
+		return
+	}
+	p.promotedAccount[did] = seq
 }
 
 // PromoteChain marks the pending chain entry for did as flushable iff
@@ -328,6 +381,7 @@ func (p *PebbleStateStore) StageFlush(b *pebble.Batch) error {
 	p.capturedChain = make(map[atmos.DID][]byte, len(p.promotedChain))
 	p.capturedHosting = make(map[atmos.DID][]byte, len(p.promotedHosting))
 	p.capturedIdent = make(map[atmos.DID]int64, len(p.promotedIdent))
+	p.capturedAccount = make(map[atmos.DID]int64, len(p.promotedAccount))
 	for did, val := range p.promotedChain {
 		if err := b.Set(chainKey(did), val, nil); err != nil {
 			return fmt.Errorf("syncstate: stage chain %s: %w", did, err)
@@ -345,6 +399,12 @@ func (p *PebbleStateStore) StageFlush(b *pebble.Batch) error {
 			return fmt.Errorf("syncstate: stage identity seq %s: %w", did, err)
 		}
 		p.capturedIdent[did] = seq
+	}
+	for did, seq := range p.promotedAccount {
+		if err := b.Set(acctKey(did), encodeIdentitySeq(seq), nil); err != nil {
+			return fmt.Errorf("syncstate: stage account seq %s: %w", did, err)
+		}
+		p.capturedAccount[did] = seq
 	}
 	return nil
 }
@@ -372,9 +432,15 @@ func (p *PebbleStateStore) CommitStaged() {
 			delete(p.promotedIdent, did)
 		}
 	}
+	for did, captured := range p.capturedAccount {
+		if cur, ok := p.promotedAccount[did]; ok && cur == captured {
+			delete(p.promotedAccount, did)
+		}
+	}
 	p.capturedChain = nil
 	p.capturedHosting = nil
 	p.capturedIdent = nil
+	p.capturedAccount = nil
 }
 
 // Flush commits promoted state by itself, outside the consumer's
@@ -412,9 +478,11 @@ func (p *PebbleStateStore) Delete(_ context.Context, did atmos.DID) error {
 	delete(p.promotedChain, did)
 	delete(p.promotedHosting, did)
 	delete(p.promotedIdent, did)
+	delete(p.promotedAccount, did)
 	delete(p.capturedChain, did)
 	delete(p.capturedHosting, did)
 	delete(p.capturedIdent, did)
+	delete(p.capturedAccount, did)
 	p.mu.Unlock()
 
 	b := p.s.NewBatch()
@@ -428,6 +496,9 @@ func (p *PebbleStateStore) Delete(_ context.Context, did atmos.DID) error {
 	}
 	if err := b.Delete(identKey(did), nil); err != nil {
 		return fmt.Errorf("syncstate: delete identity seq %s: %w", did, err)
+	}
+	if err := b.Delete(acctKey(did), nil); err != nil {
+		return fmt.Errorf("syncstate: delete account seq %s: %w", did, err)
 	}
 	if err := p.s.Commit(b, store.SyncWrites); err != nil {
 		return fmt.Errorf("syncstate: delete %s: %w", did, err)

--- a/internal/ingest/syncstate/store_test.go
+++ b/internal/ingest/syncstate/store_test.go
@@ -280,3 +280,38 @@ func TestStateStore_IdentitySeqRatchet(t *testing.T) {
 	require.NoError(t, err)
 	require.Zero(t, got, "Delete must remove the ratchet")
 }
+
+// TestStateStore_AccountSeqRatchet pins the append-owned #account replay
+// ratchet: absent reads as 0, RecordAccountSeq only ratchets upward, the
+// value survives a Flush + fresh store, and Delete removes it.
+func TestStateStore_AccountSeqRatchet(t *testing.T) {
+	t.Parallel()
+	raw := newTestStore(t)
+	s := New(raw)
+	did := parseDID(t, "did:plc:ffffffffffffffffffffffff")
+
+	got, err := s.LoadAppliedAccountSeq(t.Context(), did)
+	require.NoError(t, err)
+	require.Zero(t, got, "absent ratchet must read as 0")
+
+	s.RecordAccountSeq(did, 7)
+	got, err = s.LoadAppliedAccountSeq(t.Context(), did)
+	require.NoError(t, err)
+	require.Equal(t, int64(7), got, "staged ratchet must be visible before flush")
+
+	s.RecordAccountSeq(did, 5)
+	got, err = s.LoadAppliedAccountSeq(t.Context(), did)
+	require.NoError(t, err)
+	require.Equal(t, int64(7), got, "ratchet must not regress")
+
+	require.NoError(t, s.Flush())
+	fresh := New(raw)
+	got, err = fresh.LoadAppliedAccountSeq(t.Context(), did)
+	require.NoError(t, err)
+	require.Equal(t, int64(7), got, "flushed ratchet must survive a restart")
+
+	require.NoError(t, fresh.Delete(t.Context(), did))
+	got, err = fresh.LoadAppliedAccountSeq(t.Context(), did)
+	require.NoError(t, err)
+	require.Zero(t, got, "Delete must remove the ratchet")
+}


### PR DESCRIPTION
## Context
The race CI failure in TestOracle_DefaultLifecycle produced one extra archived #account event at the replay/live overlap. Jetstream's account replay guard depended on applied verifier hosting state; when atmos had newer pending hosting for the same DID, the older account row correctly could not promote it, leaving the duplicate replay unguarded.

## Changes
- Record a Jetstream-owned applied #account seq from the writer OnAppend hook, before block flush can commit cursor state.
- Use that account ratchet as the primary #account replay guard input, with applied hosting as a compatibility fallback.
- Add regression coverage for blocked hosting promotion and block-boundary durability.

## Verification
- just test ./internal/ingest/live -run=TestProcessBatch_ -v
- just test ./internal/ingest/syncstate -run=TestStateStore_ -v
- just test ./internal/ingest/live ./internal/ingest/syncstate
- just test-race ./internal/ingest/live ./internal/ingest/syncstate
- just test-race ./internal/oracle -run TestOracle_DefaultLifecycle -v
- just lint
- just test ./...

Closes #254