### PR TITLE
client: drop malformed records without skipping block

### DIFF
--- a/internal/client/downloader.go
+++ b/internal/client/downloader.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -83,9 +84,11 @@ func NewDownloader(xc *xrpc.Client, concurrency int, selector RowSelector) *Down
 // the consumer can emit in order. A single plan entry streams as MULTIPLE
 // EntryResults — one per decoded block — all carrying the same Index/Entry, so
 // the downloader never holds a whole segment's decoded events in memory at
-// once. Err is non-nil if a block could not be downloaded or decoded; Events is
-// then nil, and that entry stops streaming after the error (any earlier blocks
-// of the same entry were already emitted).
+// once. Err is non-nil for recoverable failures. If a whole block could not be
+// downloaded or structurally decoded, Events/Payload are nil and that entry
+// stops streaming after the error. If only individual selected rows were
+// semantically malformed, Err is non-nil alongside the valid decoded rows, so
+// consumers can surface the warning without dropping the rest of the block.
 type EntryResult struct {
 	Index  int // position in the plan's Entries slice
 	Entry  PlanEntry
@@ -94,7 +97,8 @@ type EntryResult struct {
 	// Payload is the opaque output of the Downloader's transform (when one is
 	// set), already computed in parallel on the decode workers and forwarded here
 	// in seq order. nil when no transform is set (legacy []Event path) or for an
-	// error result. The caller that supplied the transform type-asserts it.
+	// error result with no valid decoded rows. The caller that supplied the
+	// transform type-asserts it.
 	Payload any
 }
 
@@ -113,7 +117,9 @@ type decodeJob struct {
 // decodeResult is a decoded block leaving the pool, keyed by the same global
 // seq for reassembly. emit is false for a wholly filtered/suppressed block (no
 // events, no error): the reassembler still consumes its seq to keep the space
-// dense but calls no emit. Exactly one of events/err is meaningful.
+// dense but calls no emit. events/payload may be present with err when one or
+// more selected rows in the block were semantically malformed but other rows
+// decoded cleanly.
 type decodeResult struct {
 	seq      uint64
 	entryIdx int
@@ -372,11 +378,8 @@ func (d *Downloader) runDecodeWorker(ctx context.Context, entries []PlanEntry, j
 			res.emit = true
 		default:
 			events, err := d.decodeFrame(j.frame, entries[j.entryIdx].SegmentName, j.blockIdx)
-			switch {
-			case err != nil:
-				res.err = err
-				res.emit = true
-			case d.transform != nil:
+			res.err = err
+			if len(events) > 0 && d.transform != nil {
 				// Fast path: run the caller's per-block transform HERE, in parallel,
 				// so the expensive per-event work is off the serial reassembler.
 				// The transform is caller-supplied (root) code running on a pool
@@ -384,12 +387,13 @@ func (d *Downloader) runDecodeWorker(ctx context.Context, entries []PlanEntry, j
 				// close(results) hung and wedge the whole Download. Convert a panic
 				// into an in-order recoverable error instead (crash-visible to the
 				// consumer, pipeline still drains) — never a silent hang.
-				res.payload, res.err = d.runTransform(j.entryIdx, events)
-				res.emit = res.payload != nil || res.err != nil
-			default:
+				var transformErr error
+				res.payload, transformErr = d.runTransform(j.entryIdx, events)
+				res.err = errors.Join(res.err, transformErr)
+			} else if len(events) > 0 {
 				res.events = events
-				res.emit = len(events) > 0 // skip wholly filtered/suppressed blocks
 			}
+			res.emit = len(events) > 0 || res.err != nil
 		}
 		select {
 		case results <- res:
@@ -454,7 +458,9 @@ func reassemble(entries []PlanEntry, results <-chan decodeResult, sem chan struc
 
 // decodeFrame decompresses one block frame, applies the row selector before
 // decode (so filtered/suppressed rows are never materialized), and converts
-// the survivors to events.
+// the survivors to events. Malformed selected rows are dropped and returned as a
+// joined recoverable error alongside any valid decoded rows; one bad upstream
+// record must not make the client lose the rest of the block.
 //
 // Commit rows dominate the archive (e.g. app.bsky.feed.like), and each commit's
 // *Commit was one heap allocation. To cut that, the surviving commit rows of a
@@ -485,6 +491,7 @@ func (d *Downloader) decodeFrame(frame []byte, segName string, blockIdx int) ([]
 	// holding an earlier batch can never observe a mutation.
 	commits := make([]Commit, len(rows))
 	out := make([]Event, 0, len(rows))
+	var decodeErrs []error
 	ci := 0
 	for i := range rows {
 		if d.selector != nil {
@@ -499,14 +506,15 @@ func (d *Downloader) decodeFrame(frame []byte, segName string, blockIdx int) ([]
 		}
 		ev, err := decodeSegmentEventInto(&rows[i], commit, d.mode)
 		if err != nil {
-			return nil, err
+			decodeErrs = append(decodeErrs, err)
+			continue
 		}
 		out = append(out, ev)
 	}
 	if len(out) == 0 {
-		return nil, nil
+		return nil, errors.Join(decodeErrs...)
 	}
-	return out, nil
+	return out, errors.Join(decodeErrs...)
 }
 
 // isCommitKind reports whether a segment row kind decodes to a KindCommit event

--- a/internal/client/downloader_test.go
+++ b/internal/client/downloader_test.go
@@ -108,15 +108,21 @@ func writeXRPCError(w http.ResponseWriter, status int, name string) {
 
 func (as *archiveServer) addSegment(t *testing.T, name string, events []segment.Event) {
 	t.Helper()
+	as.addSegmentWithBlockSize(t, name, events, 2)
+}
+
+func (as *archiveServer) addSegmentWithBlockSize(t *testing.T, name string, events []segment.Event, maxEventsPerBlock int) {
+	t.Helper()
 	dir := t.TempDir()
 	path := filepath.Join(dir, name)
-	w, err := segment.New(segment.Config{Path: path, MaxEventsPerBlock: 2})
+	w, err := segment.New(segment.Config{Path: path, MaxEventsPerBlock: maxEventsPerBlock})
 	require.NoError(t, err)
 	for i := range events {
 		_, err := w.Append(events[i])
 		require.NoError(t, err)
-		// Flush block boundaries every 2 events to produce multiple blocks.
-		if (i+1)%2 == 0 && i != len(events)-1 {
+		// Flush block boundaries at the requested size to produce predictable
+		// multi-block fixtures.
+		if (i+1)%maxEventsPerBlock == 0 && i != len(events)-1 {
 			require.NoError(t, w.Flush())
 		}
 	}
@@ -151,6 +157,19 @@ func makeCreate(t *testing.T, seq uint64, did, collection, rkey string) segment.
 	rec := map[string]any{"$type": collection, "text": "hello " + rkey}
 	payload, err := cbor.Marshal(rec)
 	require.NoError(t, err)
+	return segment.Event{
+		Seq:         seq,
+		WitnessedAt: int64(1_730_000_000_000_000 + seq*1_000),
+		Kind:        segment.KindCreate,
+		DID:         did,
+		Collection:  collection,
+		Rkey:        rkey,
+		Rev:         "rev" + strconv.FormatUint(seq, 10),
+		Payload:     payload,
+	}
+}
+
+func makeCreateWithPayload(seq uint64, did, collection, rkey string, payload []byte) segment.Event {
 	return segment.Event{
 		Seq:         seq,
 		WitnessedAt: int64(1_730_000_000_000_000 + seq*1_000),
@@ -237,6 +256,70 @@ func TestDownloadTransformOrdering(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, nSeg*(perSeg/2), count, "one payload per non-empty block")
+}
+
+func TestDownloadDropsMalformedRecordNotWholeBlock(t *testing.T) {
+	t.Parallel()
+	as := newArchiveServer(t)
+	invalidUTF8TextRecord := []byte{
+		0xa1,                     // map(1)
+		0x64, 't', 'e', 'x', 't', // "text"
+		0x63, 0xed, 0xa0, 0xbc, // text(3), invalid UTF-8 surrogate bytes
+	}
+	as.addSegmentWithBlockSize(t, segName(0), []segment.Event{
+		makeCreate(t, 1, "did:plc:a", "app.bsky.feed.post", "good1"),
+		makeCreateWithPayload(2, "did:plc:a", "app.bsky.feed.post", "bad", invalidUTF8TextRecord),
+		makeCreate(t, 3, "did:plc:a", "app.bsky.feed.post", "good2"),
+	}, 4)
+
+	var results []EntryResult
+	err := as.downloader(1).Download(context.Background(), []PlanEntry{{
+		SegmentName: segName(0),
+		Index:       0,
+		Mode:        ModeWholeSegment,
+	}}, func(res EntryResult) bool {
+		results = append(results, res)
+		return true
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Error(t, results[0].Err)
+	require.ErrorContains(t, results[0].Err, "seq=2")
+	require.ErrorContains(t, results[0].Err, "invalid UTF-8")
+	require.Equal(t, []uint64{1, 3}, seqs(results[0].Events))
+}
+
+func TestDownloadTransformKeepsPayloadWithMalformedRecordError(t *testing.T) {
+	t.Parallel()
+	as := newArchiveServer(t)
+	invalidUTF8TextRecord := []byte{
+		0xa1,
+		0x64, 't', 'e', 'x', 't',
+		0x63, 0xed, 0xa0, 0xbc,
+	}
+	as.addSegmentWithBlockSize(t, segName(0), []segment.Event{
+		makeCreate(t, 1, "did:plc:a", "app.bsky.feed.post", "good1"),
+		makeCreateWithPayload(2, "did:plc:a", "app.bsky.feed.post", "bad", invalidUTF8TextRecord),
+		makeCreate(t, 3, "did:plc:a", "app.bsky.feed.post", "good2"),
+	}, 4)
+
+	d := as.downloader(1)
+	d.SetTransform(func(_ int, evs []Event) any {
+		return seqs(evs)
+	})
+	var results []EntryResult
+	err := d.Download(context.Background(), []PlanEntry{{
+		SegmentName: segName(0),
+		Index:       0,
+		Mode:        ModeWholeSegment,
+	}}, func(res EntryResult) bool {
+		results = append(results, res)
+		return true
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Error(t, results[0].Err)
+	require.Equal(t, []uint64{1, 3}, results[0].Payload)
 }
 
 // TestDownloadTransformPanicNoHang guards FIX #1: a transform that panics on one

--- a/internal/client/engine.go
+++ b/internal/client/engine.go
@@ -377,12 +377,11 @@ func (e *Engine) startFlusher(ctx context.Context, b *batcher) func() {
 // backfillEmitFunc builds the Download emit callback shared by both backfill
 // paths, and installs the fast-path transform on dl when bf provides one.
 //
-// Error results ALWAYS route through the batcher's emitError (which flushes any
-// buffered events first, preserving error-after-data ordering) BEFORE the
-// fast-path Emit is consulted — so bf.Emit is only ever called for a non-error
-// result, and the payload it receives is always a real transform output. On the
-// legacy path (bf.Transform == nil) events flow through the per-event batcher
-// exactly as before.
+// Results may carry both decoded rows and a recoverable row-level error: the
+// valid rows are emitted first, then the error is surfaced. Whole-block failures
+// carry no rows and therefore route only through emitError. On the legacy path
+// (bf.Transform == nil) events flow through the per-event batcher exactly as
+// before.
 //
 // The returned stopped() reports whether the consumer asked to stop during the
 // backfill. On the legacy path that is just b.stopped(); on the fast path the
@@ -393,13 +392,13 @@ func (e *Engine) backfillEmitFunc(b *batcher, bf BackfillSink, dl *Downloader) (
 	if bf.Transform == nil {
 		// Legacy path: per-event batching on the serial reassembler goroutine.
 		return func(res EntryResult) bool {
-			if res.Err != nil {
-				return b.emitError(res.Err)
-			}
 			for _, ev := range res.Events {
 				if !b.add(ev) {
 					return false
 				}
+			}
+			if res.Err != nil {
+				return b.emitError(res.Err)
 			}
 			return true
 		}, b.stopped
@@ -410,20 +409,21 @@ func (e *Engine) backfillEmitFunc(b *batcher, bf BackfillSink, dl *Downloader) (
 	dl.SetTransform(bf.Transform)
 	var consumerStopped bool
 	return func(res EntryResult) bool {
+			if res.Payload != nil {
+				if !bf.Emit(res) {
+					consumerStopped = true
+					return false
+				}
+			}
 			if res.Err != nil {
 				// Route errors (incl. a transform panic surfaced as Err) through the
-				// batcher so they stay ordered after any prior events and reuse the
-				// fatal/recoverable plumbing. b holds no backfill events on this path,
-				// so emitError just flushes-nothing then emits the error in order.
+				// batcher so they stay ordered after any valid events from the same
+				// result and reuse the fatal/recoverable plumbing. b holds no backfill
+				// events on this path, so emitError just emits the error in order.
 				if !b.emitError(res.Err) {
 					consumerStopped = true
 					return false
 				}
-				return true
-			}
-			if !bf.Emit(res) {
-				consumerStopped = true
-				return false
 			}
 			return true
 		}, func() bool {


### PR DESCRIPTION
## Summary
- keep valid rows from a segment block when a selected record fails semantic CBOR decode
- surface malformed row decode failures as recoverable errors after valid rows from the same result
- cover both legacy downloader output and worker-side transform output with regression tests

## Investigation
The triggering record was `did:plc:74rmtmjzrm2rgfhojlk7cfkn`, collection `app.bsky.feed.post`, rkey `3mcvk4qrlik2z`, seq `1041542221`. Its payload CID is `bafyreigu6lyowgfei5ihxuhggyrwc5pbrue3kjk7zcrqbtjmpuccfa2mhy`.

The record lives in `seg_000000008g.jss`, block `566`, checksum `dbcfd6e1bbe410ef`. A fresh PDS `getRepo` CAR contains the exact same block bytes for that CID, so this is malformed upstream record data rather than Jetstream segment corruption. The client bug was treating that one row-level decode failure as a whole-block loss.

## Verification
- `just test ./internal/client -run 'TestDownload\\(DropsMalformedRecordNotWholeBlock\\|TransformKeepsPayloadWithMalformedRecordError\\)'`
- `just test ./internal/client`
- `just test ./...`
- Remote repro with `just run-client --host=http://cpu2-pop3:8081 --after-seq=0 --did='did:plc:74rmtmjzrm2rgfhojlk7cfkn' --backfill-only --duration=5s` still reports the malformed row but continues delivering sibling rows from that block.

Closes #259