### PR TITLE
docs: agent-facing docs bundle (specs, glossary, package docs, reference cleanup)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,8 @@ Agent-facing living docs, in a good reading order for getting oriented:
 - `specs/invariants.md` — the short list of rules that must never break. Read before changing anything on the ingest, storage, or serve paths.
 - `specs/glossary.md` — one-line definitions of the terms that show up everywhere.
 - `specs/gotchas.md` — accepted limitations and hard-won lessons: things that look like bugs but are deliberate, and mistakes not worth making twice.
-- `specs/oracle.md` — the source of truth for the oracle/simulator/mutation testing rig.
+- `specs/oracle.md` — the source of truth for the oracle/simulator testing rig.
+- `specs/mutation.md` — how the mutation campaign measures the oracle's bug-detection power.
 
 These summarize and route; `docs/README.md` and each package's `doc.go` remain authoritative. When a living doc disagrees with them, fix the living doc.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,24 +11,52 @@ Jetstream is a full-network archive and live-streaming service for atproto. Back
 - `specs/*` is documentation intended to be read only by agents
 - `specs/notes/*` are specs and plans documentation that catalogs our train of thought while working on tasks as we go
 
+Agent-facing living docs, in a good reading order for getting oriented:
+
+- `specs/architecture.md` — the high-level map: the big subsystems, how they fit, and a "where to look" table routing each topic to its authoritative source. Start here.
+- `specs/invariants.md` — the short list of rules that must never break. Read before changing anything on the ingest, storage, or serve paths.
+- `specs/glossary.md` — one-line definitions of the terms that show up everywhere.
+- `specs/gotchas.md` — accepted limitations and hard-won lessons: things that look like bugs but are deliberate, and mistakes not worth making twice.
+- `specs/oracle.md` — the source of truth for the oracle/simulator/mutation testing rig.
+
+These summarize and route; `docs/README.md` and each package's `doc.go` remain authoritative. When a living doc disagrees with them, fix the living doc.
+
 ## Repo layout
 
 ```
 cmd/
-  jetstream/      main binary: `serve`, `inspect-segment`
+  jetstream/      main binary: serve, inspect-segment, timestamp import, version
   simulator/      local PLC + PDS + Relay on :7777
-segment/          on-disk segment file format (header, blocks, footer, reader, writer, sealer)
+segment/          on-disk segment file format (header, blocks, footer, reader, writer, sealer); public API
 internal/
-  ingest/         backfill + live firehose + orchestrator that merges them
-  subscribe/      websocket /subscribe endpoint (v1 protocol parity)
+  ingest/         the segment Writer (append/flush/seal, seq, readable log)
+    backfill/     initial full-network backfill (listRepos + getRepo)
+    live/         live firehose consumer (subscribeRepos)
+    orchestrator/ ingestion lifecycle state machine + merge/cutover
+    syncstate/    sync 1.1 resync bookkeeping
+  subscribe/      websocket /subscribe endpoint (v1 protocol parity) + cold reader
+  xrpcapi/        archive download over HTTP/XRPC (planBackfill, getSegment, getBlock)
+  client/         thick Go client: archive negotiation, fold, cutover to live
   server/         HTTP listeners (public :8080, debug :6060) and middleware
   store/          pebble-backed cursor + metadata store
-  simulator/      simulator internals (world, traffic, http handlers)
+  manifest/       segment manifest (directory scan + self-describing headers)
+  tombstone/      delete/update/account tombstone set for compaction
+  timestamp/      operator timestamp-import pipeline
+  importer/       import job manager
+  repoexport/     reconstruct a repo CAR/MST from archived events
   identity/       DID resolution
   status/         /status endpoint collector
+  diskspace/      data-dir free-space accounting
+  crashpoint/     deterministic crash-injection seams (test-gated)
+  simulator/      fake atproto network: world (traffic), http (PLC/PDS/relay), fanout
+  oracle/         end-to-end correctness harness (see specs/oracle.md)
+  corpus/         real-data corpus tests (independent of the lifecycle oracle)
+  format/         shared wire/format helpers
   obs/            metrics, tracing, slog setup
   lifecycle/      graceful start/stop helpers
-  web/            static UI assets
+  jetstreamd/     process runtime wiring (options, startup, shutdown)
+  version/        build version stamp
+  web/            static debug UI assets
 ```
 
 Atproto lexicon JSON (authoritative for XRPC and record schemas) lives at `~/go/src/github.com/bluesky-social/atproto/lexicons` on dev machines.
@@ -141,3 +169,30 @@ gh issue view <N> --comments                # full history of one unit
     - Treat all upstream relay/firehose/backfill data as user input. Invalid external records must not abort, stop, exit, or crash the server.
     - If upstream record data cannot be represented safely in Jetstream's internal format (for example a field exceeds a segment column width), drop that record or event, increment a warning/error metric, and log bounded diagnostic fields. Do not silently truncate or coerce it.
     - Preserve crash-loud behavior for invalid internal state, persistence corruption, fsync/store failures, and other conditions where continuing could corrupt Jetstream-owned data.
+
+## Which checks to run for which change
+
+`just` is the source of truth for build/test/lint (see "Working in the codebase" above for the less-obvious recipes). Beyond the default `just` (lint + short tests), match the change to the extra coverage it needs:
+
+| If you changed… | Also run |
+|---|---|
+| anything | `just` (lint + short tests) — always |
+| segment format, ingest, orchestrator, cursor, or restart/recovery | `just test-long ./internal/oracle`, `just oracle-sweep`, and the relevant fuzz targets (`just fuzz 30s ./segment`) — short tests skip the crash/restart and stress oracle coverage |
+| the oracle, simulator, or mutation catalog | `just test ./internal/oracle`, then re-run the mutation campaign (`just mutation-campaign`) and check the scorecard didn't regress |
+| anything that could move a mutant's target code | `just mutation-gate` — but on a **clean working tree**: the driver applies/reverts patches with git and aborts on a dirty tree (see `specs/gotchas.md`) |
+| parsing of untrusted input (frames, CARs, CSV) | the matching fuzz target (`just fuzz`), plus a corpus check if `internal/corpus` is affected |
+| lexicon-derived code | `just lexgen` and confirm no drift |
+| hot-path code (segment writer/sealer) | `just bench ./segment` and compare against the baseline |
+
+When in doubt, `specs/oracle.md` explains which tier catches which class of bug.
+
+## Memory promotion
+
+Any per-session or per-machine memory (an agent's private scratchpad) is exactly that — a scratchpad. It is invisible to the next agent and to Jim. **If a fact is worth knowing in a second session, promote it to a durable, checked-in home in the same PR that discovered it:**
+
+- an accepted limitation or a "we tried X, don't do it again" lesson → `specs/gotchas.md`
+- an oracle failure you root-caused → a `specs/oracle/` diary entry
+- a rule others must follow → this file
+- behavior of the system → the relevant `doc.go` (or note it for `docs/README.md`, which Jim owns)
+
+The test: if forgetting it would let a future agent re-introduce a bug or re-litigate a settled decision, it doesn't belong only in memory.

--- a/internal/ingest/async_flush.go
+++ b/internal/ingest/async_flush.go
@@ -236,7 +236,7 @@ func (w *Writer) rotateIfFull(ctx context.Context) error {
 
 		// Flush any trailing sub-block remainder durably first. flushBlockLocked
 		// fsyncs the block, then commits seq/next — the same fsync-before-seq
-		// ordering the sync rotation path uses (DESIGN.md §3.1.1). At full
+		// ordering the sync rotation path uses (docs/README.md §3.1.1). At full
 		// drain w.nextSeq equals this block's max seq + 1, so the committed
 		// seq never leads durable data.
 		if w.active.Pending() > 0 {

--- a/internal/ingest/backfill/completion_batcher.go
+++ b/internal/ingest/backfill/completion_batcher.go
@@ -104,7 +104,7 @@ func (b *completionBatcher) StageDurable(ctx context.Context, batch *pebble.Batc
 		// completion excluded here means its final event is not durable at
 		// a forced checkpoint — which would let saveBatchCursor advance the
 		// listRepos cursor past a non-durable completion (silent data loss).
-		// Crash rather than corrupt (AGENTS.md / DESIGN.md §3.1.1 ordering).
+		// Crash rather than corrupt (AGENTS.md / docs/README.md §3.1.1 ordering).
 		if force {
 			b.mu.Unlock()
 			b.metrics.incCompletionStageErrors()

--- a/internal/ingest/backfill/cursor.go
+++ b/internal/ingest/backfill/cursor.go
@@ -1,4 +1,4 @@
-// Package backfill: cursor.go persists the relay's listRepos resume
+// cursor.go persists the relay's listRepos resume
 // cursor in pebble so a process restart can skip listRepos pages
 // already fully processed in a prior Run.
 //
@@ -17,6 +17,7 @@
 // queued repo completions and their segment data are durably visible.
 // The checkpoint uses pebble.Sync, so a successful callback means the
 // cursor advance is durable too.
+
 package backfill
 
 import (
@@ -89,7 +90,7 @@ func SaveListReposCheckpoint(db *store.Store, relayCursor, bootstrapCursor strin
 // phase. The merge phase reads this to resume listRepos against
 // the relay and discover DIDs born during the bootstrap window
 // (merge-phase spec §4.7,
-// docs/superpowers/specs/2026-05-27-merge-phase-design.md).
+// specs/notes/2026-05-27-merge-phase-design.md).
 //
 // We need a separate key from listReposCursorKey because the
 // existing cursor is allowed (correctly) to drain to "" when

--- a/internal/ingest/backfill/doc.go
+++ b/internal/ingest/backfill/doc.go
@@ -1,7 +1,7 @@
 // Package backfill drives the initial atproto network backfill phase
-// for jetstream (DESIGN.md §4.1). It wraps the atmos backfill engine,
+// for jetstream (docs/README.md §4.1). It wraps the atmos backfill engine,
 // persists per-DID lifecycle state into pebble at repo/<did> per
-// DESIGN.md §3.5, and is invoked once per process start from
+// docs/README.md §3.5, and is invoked once per process start from
 // cmd/jetstream.
 //
 // The package is single-shot per Run: each call paginates listRepos

--- a/internal/ingest/backfill/enqueue.go
+++ b/internal/ingest/backfill/enqueue.go
@@ -1,4 +1,4 @@
-// Package backfill: enqueue.go implements LiveEnqueuer, the steady-state
+// enqueue.go implements LiveEnqueuer, the steady-state
 // firehose hook that detects net-new DIDs and schedules a full repo backfill
 // for them (issue #188).
 //
@@ -42,6 +42,7 @@
 // failure precisely so a later event retries). We accept this rather than make
 // the per-event hot path take a synchronous pebble write at firehose rate; a
 // genuinely active repo that we missed will almost always emit again.
+
 package backfill
 
 import (

--- a/internal/ingest/backfill/handler.go
+++ b/internal/ingest/backfill/handler.go
@@ -1,7 +1,8 @@
-// Package backfill: handler.go provides SegmentHandler, the atmos
+// handler.go provides SegmentHandler, the atmos
 // backfill.Handler that walks each downloaded repo's MST and emits
 // one segment.KindCreate event per record into the shared
 // ingest.Writer.
+
 package backfill
 
 import (

--- a/internal/ingest/backfill/run.go
+++ b/internal/ingest/backfill/run.go
@@ -1,8 +1,9 @@
-// Package backfill: run.go is the entrypoint cmd/jetstream calls
+// run.go is the entrypoint cmd/jetstream calls
 // from its errgroup. Run constructs the atmos engine and drives it
 // to completion. Returns nil on clean drain (every DID either skipped
 // at Complete or downloaded + recorded), the engine's error
 // otherwise.
+
 package backfill
 
 import (

--- a/internal/ingest/backfill/status.go
+++ b/internal/ingest/backfill/status.go
@@ -8,7 +8,7 @@ import (
 	"github.com/jcalabro/atmos"
 )
 
-// repoKeyPrefix is the pebble key prefix for per-DID rows. DESIGN.md
+// repoKeyPrefix is the pebble key prefix for per-DID rows. docs/README.md
 // §3.5 pins this layout so the on-disk format is stable across
 // replicas.
 const repoKeyPrefix = "repo/"
@@ -19,7 +19,7 @@ func repoKey(did atmos.DID) []byte {
 }
 
 // Status is the lifecycle state of a single DID's initial backfill.
-// Values match DESIGN.md §3.5; the StatusNotStarted value is what
+// Values match docs/README.md §3.5; the StatusNotStarted value is what
 // OnDiscover writes — a row's mere existence at not_started indicates
 // the engine has seen it but not yet downloaded it.
 type Status string
@@ -50,7 +50,7 @@ const (
 	StatusUnavailable Status = "unavailable"
 )
 
-// RepoBackfillStatus tracks initial-backfill state per DESIGN.md §3.5.
+// RepoBackfillStatus tracks initial-backfill state per docs/README.md §3.5.
 type RepoBackfillStatus struct {
 	Status        Status    `json:"status"`
 	Rev           string    `json:"rev,omitempty"`
@@ -63,7 +63,7 @@ type RepoBackfillStatus struct {
 }
 
 // RepoStatus is the JSON value stored at repo/<did>. The shape matches
-// DESIGN.md §3.5; this PR only populates Backfill and Active. The
+// docs/README.md §3.5; this PR only populates Backfill and Active. The
 // other fields (PDS, Host, Handle, Rev, UpdatedAt, LastAttemptedAt,
 // RecordCount, TotalBytes) are reserved for steady-state ingest and
 // diagnostics and remain zero here so we don't force a future schema
@@ -71,7 +71,7 @@ type RepoBackfillStatus struct {
 //
 // Active records the last-observed listRepos.Active value. atmos
 // requires it on every row to detect liveness flips without an extra
-// round-trip; DESIGN.md §3.5 doesn't pin a JSON tag for it (the
+// round-trip; docs/README.md §3.5 doesn't pin a JSON tag for it (the
 // original draft predated atmos's active-flip callback) so we add one
 // here.
 type RepoStatus struct {

--- a/internal/ingest/backfill/store.go
+++ b/internal/ingest/backfill/store.go
@@ -1,4 +1,4 @@
-// Package backfill: store.go implements the atmos backfill.Store
+// store.go implements the atmos backfill.Store
 // interface against pebble. Keys live at repo/<did>; values are the
 // JSON-encoded RepoStatus from status.go.
 //
@@ -10,6 +10,7 @@
 // add to RepoStatus (e.g. RecordCount). They serialize through countsMu
 // with aggregate writes and deferred completion staging so a stale
 // callback cannot overwrite a just-committed completion row.
+
 package backfill
 
 import (
@@ -788,7 +789,7 @@ func (s *Store) OnUpdate(_ context.Context, entry atmossync.ListReposEntry) erro
 
 // OnComplete records a successful repo download. The commit's rev is
 // stored in both Backfill.Rev (the rev at end of initial download
-// per DESIGN.md §3.5) and the top-level Rev (the latest known rev).
+// per docs/README.md §3.5) and the top-level Rev (the latest known rev).
 // They're equal here because initial backfill is the only thing
 // updating Rev in this PR; steady-state ingest will diverge them.
 //
@@ -852,8 +853,8 @@ func (s *Store) simulateCrash(ctx context.Context, point crashpoint.Point) error
 
 // OnFail records a failed repo download. atmos passes the total
 // attempt count for the current Run (initial + retries). We overwrite
-// rather than accumulate across Runs — DESIGN.md §6.3 calls out
-// resetting Attempts on failover as an acceptable cosmetic regression.
+// rather than accumulate across Runs; resetting Attempts on failover
+// is an acceptable cosmetic regression.
 //
 // CompletedAt and Backfill.Rev from a prior successful Run are
 // preserved. This is defensive — within this PR the engine never

--- a/internal/ingest/backfill/store_test.go
+++ b/internal/ingest/backfill/store_test.go
@@ -195,7 +195,7 @@ func TestStore_OnUpdate_MissingRow(t *testing.T) {
 // TestStore_OnComplete_WritesComplete is the success path: a
 // successful download lands the row at Complete with the commit rev
 // recorded both at top-level Rev and in Backfill.Rev (per
-// DESIGN.md §3.5 — both fields exist; Rev is the latest, Backfill.Rev
+// docs/README.md §3.5 — both fields exist; Rev is the latest, Backfill.Rev
 // is the rev at end of initial download).
 func TestStore_OnComplete_WritesComplete(t *testing.T) {
 	t.Parallel()
@@ -347,7 +347,7 @@ func TestStore_OnComplete_PreservesExtraFields(t *testing.T) {
 // TestStore_OnFail_RecordsFailure pins the failure path. attempts is
 // the count for the current Run only — atmos passes initial+retries
 // from processRepo, and we overwrite rather than accumulate across
-// Runs (per DESIGN.md §6.3, this cosmetic regression is intentional).
+// Runs (this cosmetic regression is intentional).
 func TestStore_OnFail_RecordsFailure(t *testing.T) {
 	t.Parallel()
 	s := newTestStore(t)

--- a/internal/ingest/config.go
+++ b/internal/ingest/config.go
@@ -16,7 +16,7 @@ import (
 // the block was detached/flushed.
 type DurableBatchHook func(ctx context.Context, b *pebble.Batch, nextSeq uint64, force bool, prepareValue any) (afterCommit func(), afterDone func(error), err error)
 
-// defaultMaxSegmentBytes is the rotation threshold. DESIGN.md §3.1.1
+// defaultMaxSegmentBytes is the rotation threshold. docs/README.md §3.1.1
 // names ~256MB as the target sealed-segment size. Operator-tunable
 // via Config.MaxSegmentBytes.
 const defaultMaxSegmentBytes int64 = 256 << 20
@@ -82,7 +82,7 @@ type Config struct {
 	// stage metadata whose backing events are not yet durable: a hook that ties
 	// metadata to event durability (e.g. backfill repo completion) must still
 	// gate every staged row on nextSeq, never on force, or it would mark data
-	// durable ahead of its segment fsync (violating DESIGN.md §3.1.1 ordering).
+	// durable ahead of its segment fsync (violating docs/README.md §3.1.1 ordering).
 	OnDurableBatch DurableBatchHook
 
 	// DurableBatchPrepareValue, if non-nil, is sampled while the writer mutex is

--- a/internal/ingest/doc.go
+++ b/internal/ingest/doc.go
@@ -1,7 +1,7 @@
 // Package ingest owns the active-segment writer for jetstream. It
 // allocates monotonic seq numbers, rotates segment files at a
 // configurable byte threshold, and commits the per-block durability
-// batch to pebble (DESIGN.md §3.1.1, §3.4).
+// batch to pebble (docs/README.md §3.1.1, §3.4).
 //
 // One *ingest.Writer is shared across all goroutines that produce
 // events: the bootstrap-phase backfill workers today, the live-tail

--- a/internal/ingest/filename_test.go
+++ b/internal/ingest/filename_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 // TestSegmentFilename_BaseFormat pins the on-disk filename format
-// (DESIGN.md §3.4: 10-digit zero-padded base-36 string).
+// (docs/README.md §3.4: 10-digit zero-padded base-36 string).
 func TestSegmentFilename_BaseFormat(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/ingest/live/cursor.go
+++ b/internal/ingest/live/cursor.go
@@ -1,6 +1,6 @@
 // package live: cursor.go persists the upstream relay firehose
 // cursor in pebble so a process restart resumes from the last
-// durably-flushed block. DESIGN.md §3.1.1: persisted cursor must be
+// durably-flushed block. docs/README.md §3.1.1: persisted cursor must be
 // less than or equal to the latest durable event in the segment file.
 //
 // The on-disk encoding is [1B version][8B LE uint64], delegated to

--- a/internal/ingest/live/doc.go
+++ b/internal/ingest/live/doc.go
@@ -2,16 +2,16 @@
 // relay's com.atproto.sync.subscribeRepos firehose into a
 // directory of segment files. The package is deliberately generic:
 // it is used during the bootstrap phase to populate
-// data/backfill/live_segments (DESIGN.md §4.1 step 1), and the
+// data/backfill/live_segments (docs/README.md §4.1 step 1), and the
 // same Consumer type will be reused after the merge step lands
-// to populate data/segments in steady state (DESIGN.md §4.3).
+// to populate data/segments in steady state (docs/README.md §4.3).
 //
 // The Consumer wraps a dedicated *ingest.Writer. The mapping from
 // upstream firehose events to segment.Events lives in events.go
 // as a pure function so it is straightforward to unit-test
 // against arbitrary input. Cursor durability is delegated to the
 // writer's durable batch hook so persisted cursor ≤ durable events
-// holds in the same synced Pebble commit as seq/next, as DESIGN.md §3.1.1
+// holds in the same synced Pebble commit as seq/next, as docs/README.md §3.1.1
 // requires.
 //
 // Sync 1.1 verification is required: Config.Verifier must be a

--- a/internal/ingest/live/events.go
+++ b/internal/ingest/live/events.go
@@ -6,7 +6,7 @@
 //
 // All segment.Events derived from a single upstream event share the
 // same witnessedAt timestamp. Per-record timestamps would imply false
-// ordering (DESIGN.md §3.4 requires per-DID ingest order is preserved).
+// ordering (docs/README.md §3.4 requires per-DID ingest order is preserved).
 //
 // Seq is left zero on the returned events — ingest.Writer.Append
 // allocates the value at write time.

--- a/internal/ingest/orchestrator/doc.go
+++ b/internal/ingest/orchestrator/doc.go
@@ -1,6 +1,6 @@
 // Package orchestrator owns the ingestion-lifecycle state machine
 // for jetstream. It drives the bootstrap → merging → steady-state
-// transition described in DESIGN.md §4.2 and §4.3.
+// transition described in docs/README.md §4.2 and §4.3.
 //
 // cmd/jetstream constructs cross-cutting primitives (verifier,
 // identity directory, store, HTTP client) and calls Orchestrator.Run.

--- a/internal/ingest/orchestrator/merge.go
+++ b/internal/ingest/orchestrator/merge.go
@@ -1,6 +1,7 @@
-// Package orchestrator: merge.go owns the State 5 cutover step that
+// merge.go owns the State 5 cutover step that
 // drains data/backfill/live_segments/ into data/segments/. Spec:
-// docs/superpowers/specs/2026-05-27-merge-phase-design.md.
+// specs/notes/2026-05-27-merge-phase-design.md.
+
 package orchestrator
 
 import (

--- a/internal/ingest/orchestrator/merge_cursor.go
+++ b/internal/ingest/orchestrator/merge_cursor.go
@@ -1,7 +1,8 @@
-// Package orchestrator: merge_cursor.go owns the merge/next_source_idx
+// merge_cursor.go owns the merge/next_source_idx
 // pebble cursor and the atomic per-source commit batch that advances
 // the cursor alongside per-DID repo/<did>.Rev refreshes. Spec:
-// docs/superpowers/specs/2026-05-27-merge-phase-design.md §4.5–§4.6.
+// specs/notes/2026-05-27-merge-phase-design.md §4.5–§4.6.
+
 package orchestrator
 
 import (

--- a/internal/ingest/orchestrator/merge_discovery.go
+++ b/internal/ingest/orchestrator/merge_discovery.go
@@ -1,7 +1,8 @@
-// Package orchestrator: merge_discovery.go runs the post-merge
+// merge_discovery.go runs the post-merge
 // listRepos resume that picks up DIDs born during the bootstrap
 // window. Spec:
-// docs/superpowers/specs/2026-05-27-merge-phase-design.md §4.7.
+// specs/notes/2026-05-27-merge-phase-design.md §4.7.
+
 package orchestrator
 
 import (

--- a/internal/ingest/orchestrator/merge_filter.go
+++ b/internal/ingest/orchestrator/merge_filter.go
@@ -1,8 +1,9 @@
-// Package orchestrator: merge_filter.go owns the per-event keep/drop
+// merge_filter.go owns the per-event keep/drop
 // predicate that decides whether a live_segments survivor should be
 // promoted into the steady-state segments tree, plus the per-DID
 // repo/<did> lookup cache that backs it. Spec:
-// docs/superpowers/specs/2026-05-27-merge-phase-design.md §4.3–§4.4.
+// specs/notes/2026-05-27-merge-phase-design.md §4.3–§4.4.
+
 package orchestrator
 
 import (
@@ -15,7 +16,7 @@ import (
 )
 
 // isCommitKind reports whether k is one of the three commit-shaped
-// event kinds (DESIGN.md §3.2). Only these carry a per-event Rev
+// event kinds (docs/README.md §3.2). Only these carry a per-event Rev
 // that maps to the repo MST and can therefore be filtered against
 // repo/<did>.Backfill.Rev.
 func isCommitKind(k segment.Kind) bool {

--- a/internal/ingest/orchestrator/merge_runner.go
+++ b/internal/ingest/orchestrator/merge_runner.go
@@ -1,6 +1,7 @@
-// Package orchestrator: merge_runner.go owns the per-source-segment
+// merge_runner.go owns the per-source-segment
 // drain loop. One goroutine, serial, no fan-out. Spec:
-// docs/superpowers/specs/2026-05-27-merge-phase-design.md §4.2.
+// specs/notes/2026-05-27-merge-phase-design.md §4.2.
+
 package orchestrator
 
 import (

--- a/internal/ingest/orchestrator/testfixtures_test.go
+++ b/internal/ingest/orchestrator/testfixtures_test.go
@@ -102,7 +102,7 @@ func readSegFiles(dir string) ([]string, error) {
 }
 
 // isSealed returns true if the segment file at path has been sealed
-// per DESIGN.md §3.1.1. Delegates to segment.Inspect so the
+// per docs/README.md §3.1.1. Delegates to segment.Inspect so the
 // "what does sealed mean on disk" knowledge stays in one place.
 func isSealed(t *testing.T, path string) bool {
 	t.Helper()

--- a/internal/ingest/syncstate/store.go
+++ b/internal/ingest/syncstate/store.go
@@ -25,7 +25,7 @@ const (
 // underlying pebble db is concurrency-safe.
 //
 // Durability is two-phase so verifier state can never run ahead of the
-// archive (DESIGN.md invariant 1 / compaction spec §2.2):
+// archive (docs/README.md invariant 1 / compaction spec §2.2):
 //
 //  1. SaveChain/SaveHosting land in PENDING maps. atmos calls them at
 //     verification time, from its worker goroutines, before the event's

--- a/internal/ingest/writer.go
+++ b/internal/ingest/writer.go
@@ -240,7 +240,7 @@ func Open(cfg Config) (*Writer, error) {
 // closes the active writer file. Idempotent. Does NOT seal — that's
 // a rotation-time concern.
 //
-// Durability ordering matches DESIGN.md §3.1.1: segment.Writer.Close
+// Durability ordering matches docs/README.md §3.1.1: segment.Writer.Close
 // fsyncs any buffered block before we commit the pebble batch. If
 // the pebble write fails after a successful flush, Open's
 // ScanMaxSeq reconciliation will recover the correct nextSeq on
@@ -299,7 +299,7 @@ func (w *Writer) SealActiveAndClose() error {
 	// failure paths leave the file open with stickyErr latched, so we
 	// release the fd ourselves below.
 	//
-	// Durability ordering matches Close (DESIGN.md §3.1.1): the segment
+	// Durability ordering matches Close (docs/README.md §3.1.1): the segment
 	// fsyncs first, then we pebble.Sync nextSeq. A crash between the
 	// two leaves nextSeq lagging at most one block, which Open's
 	// ScanMaxSeq reconciles on next start.
@@ -438,7 +438,7 @@ func (w *Writer) appendLocked(ctx context.Context, ev *segment.Event) (*asyncFlu
 
 // Flush forces any pending block to fsync. Goroutine-safe. Used by
 // the merge phase to order destination-segment durability before
-// its cursor commit (DESIGN.md §3.1.1 / merge spec §5.2). Steady-
+// its cursor commit (docs/README.md §3.1.1 / merge spec §5.2). Steady-
 // state callers do not need to call this — the per-block-fill path
 // inside Append handles ordinary flush + rotation.
 //
@@ -557,7 +557,7 @@ func (w *Writer) commitTerminalDurableBatchLocked() error {
 // flushAndRotateLocked is the post-Append durability commit. The
 // caller MUST hold w.mu.
 //
-// Order matters per DESIGN.md §3.1.1:
+// Order matters per docs/README.md §3.1.1:
 //  1. segment.Writer.Flush fsyncs the block.
 //  2. We pebble.Sync the new seq/next.
 //  3. If activeBytes >= MaxSegmentBytes, seal the current segment

--- a/internal/ingest/writer_test.go
+++ b/internal/ingest/writer_test.go
@@ -522,7 +522,7 @@ func TestClose_PersistsNextSeq(t *testing.T) {
 }
 
 // TestBlockFlush_AdvancesPebbleSeq confirms the durability ordering
-// from DESIGN.md §3.1.1: after a block flush, seq/next in pebble
+// from docs/README.md §3.1.1: after a block flush, seq/next in pebble
 // equals the in-memory nextSeq.
 func TestBlockFlush_AdvancesPebbleSeq(t *testing.T) {
 	t.Parallel()
@@ -707,7 +707,7 @@ func TestResume_SealedSkipsToNext(t *testing.T) {
 }
 
 // TestOpen_ReconcilesDriftedPebble simulates the crash mode from
-// DESIGN.md §3.1.1: block fsynced, pebble batch lost. Open must read
+// docs/README.md §3.1.1: block fsynced, pebble batch lost. Open must read
 // max(seq) from the segment, advance nextSeq to max+1, and rewrite
 // pebble. Otherwise the next Append would reuse a seq.
 func TestOpen_ReconcilesDriftedPebble(t *testing.T) {

--- a/internal/lifecycle/phase.go
+++ b/internal/lifecycle/phase.go
@@ -19,7 +19,7 @@ const (
 	PhaseBootstrap Phase = "bootstrap"
 
 	// PhaseMerging means initial backfill has drained but the merge
-	// step (DESIGN.md §4.2) has not yet completed. A process restart
+	// step (docs/README.md §4.2) has not yet completed. A process restart
 	// in this phase resumes the cutover state machine at the merge
 	// step; backfill and the bootstrap-phase live consumer are not
 	// restarted.

--- a/internal/manifest/doc.go
+++ b/internal/manifest/doc.go
@@ -1,4 +1,4 @@
-// Package manifest materializes DESIGN.md §3.5's "segment manifest"
+// Package manifest materializes docs/README.md §3.5's "segment manifest"
 // concept in memory: an authoritative slice of bounds (MinSeq, MaxSeq,
 // MinWitnessedAt, MaxWitnessedAt) for every sealed segment, plus a small
 // LRU of per-segment block indices for callers that need to seek

--- a/internal/oracle/doc.go
+++ b/internal/oracle/doc.go
@@ -1,0 +1,48 @@
+// Package oracle is jetstream's end-to-end correctness harness. It boots a
+// real jetstream server against a simulated atproto network, drives it through
+// its whole lifecycle, and compares what jetstream durably produced against an
+// independently derived model of what it should have produced. It is a
+// high-value bug detector, not a proof of correctness: a green run means one
+// set of strong contracts held for one scenario. specs/oracle.md is the source
+// of truth for the design; read it before changing anything here.
+//
+// The moving parts, in the vocabulary the tests use:
+//
+//   - driver: the code that starts jetstream (pointed at the simulator's relay,
+//     PDS, and PLC), walks it through bootstrap → merge → steady-state →
+//     compaction → shutdown/restart, and gates each step on durable acks rather
+//     than sleeps.
+//   - observers: the surfaces that collect what jetstream produced — segment
+//     files read straight off disk, the /subscribe websocket replay, downloaded
+//     XRPC archive segments, the real Go client's replay, and durable
+//     store/metrics state. Observers never silently stand in for one another; a
+//     serving bug is not allowed to pass by falling back to a disk read.
+//   - checkers: the code that turns observations into contracts — physical
+//     segment invariants, final-state comparison against simulator world state,
+//     event-log equivalence, the compaction/tombstone drop rules, and
+//     fail-loud fault assertions.
+//
+// "bubble" refers to a testing/synctest bubble: a Go test scope with a fake
+// clock in which the runtime can tell when every goroutine is durably blocked.
+// The default lifecycle tier runs inside one so the whole system quiesces
+// deterministically without wall-clock waits. Only one bubble may exist per
+// process: zstd and other package-global goroutines bind their channels to the
+// first bubble that uses them, and a second bubble in the same process
+// (go test -count=N) makes the runtime abort with "receive on synctest channel
+// from outside bubble". Re-runs and the real-process tiers therefore each get
+// their own process; TestOracle_DefaultLifecycle owns the one bubble.
+//
+// "tier" is a family of checks that share helpers but fail with a distinct
+// explanation (storage/final-state, event-log, client-driven historical,
+// live-tail replay, XRPC egress, crash/restart, store-fault, simulator
+// fidelity, real-data corpus, soak, determinism experiments). Keeping them
+// separate is deliberate: one giant oracle test would be unreadable and
+// undebuggable. specs/oracle.md enumerates the tiers and what each can and
+// cannot prove.
+//
+// The oracle follows the fail-loud-over-corrupt rule in the opposite direction
+// from production: the daemon must never crash on bad upstream input, but the
+// oracle crashes loudly on invalid internal state, persistence corruption, and
+// anti-vacuity failures (a scenario that passed without actually exercising the
+// path it claims to). Every injected fault must be proven to have fired.
+package oracle

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -111,7 +111,7 @@ func New(cfg Config, logger *slog.Logger, metrics *obs.Metrics) *Server {
 	//     The public surface will serve large segment-file downloads (~256 MB
 	//     each) and long-lived websocket streams; a global WriteTimeout would
 	//     kill both. ReadTimeout would similarly cap legitimate streaming
-	//     uploads (e.g. the bulk-timestamp import CSV in DESIGN.md §8).
+	//     uploads (e.g. the bulk-timestamp import CSV in docs/README.md §8).
 	//     Per-handler deadlines via r.Context() are the right tool when an
 	//     individual route needs a bound.
 	//

--- a/internal/simulator/doc.go
+++ b/internal/simulator/doc.go
@@ -1,0 +1,23 @@
+// Package simulator is the parent of jetstream's local atproto network
+// simulator. It has no code of its own; it exists to group and document the
+// three subpackages that together stand in for the upstream network during
+// local runs and oracle tests:
+//
+//   - world: the deterministic, seeded source of truth. It owns the pebble db,
+//     the account roster, repo/MST state, and the traffic generator that
+//     produces real atproto-shaped bytes — signed commits, CAR blocks, CBOR
+//     firehose frames, account and sync events — rather than mocked structs.
+//     It also serves as the independent expected-state model the oracle checks
+//     jetstream against, and includes the adversarial-traffic modes that feed
+//     bad-but-bounded input through the honest pipeline.
+//   - http: the network surface in front of the world — a fake PLC, PDS, and
+//     relay (listRepos, getRepo, the subscribeRepos firehose websocket) plus
+//     the fault-injection knobs (HTTP status, CAR truncation, disconnects).
+//   - fanout: the in-memory pub/sub that delivers the world's generated
+//     firehose events to connected relay-subscribe websocket clients.
+//
+// cmd/simulator wires these together into the standalone dev simulator on
+// :7777; the oracle wires them into an in-process harness. See specs/oracle.md
+// for how the simulator and oracle fit together and why the world is a real
+// byte generator rather than a set of fakes.
+package simulator

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,5 +1,5 @@
 // Package store owns the lifecycle of the metadata pebble database
-// at <data-dir>/meta.pebble (DESIGN.md §3.4 / §3.5).
+// at <data-dir>/meta.pebble (docs/README.md §3.4 / §3.5).
 //
 // The package is deliberately keyspace-agnostic. It knows how to
 // open and close the database, picks pebble configuration that fits
@@ -33,7 +33,7 @@ import (
 )
 
 // PebbleSubdir is the on-disk name of the metadata store relative
-// to the configured data directory. DESIGN.md §3.4 pins this layout
+// to the configured data directory. docs/README.md §3.4 pins this layout
 // so the on-disk format is stable across replicas.
 const PebbleSubdir = "meta.pebble"
 

--- a/internal/store/sync_unix.go
+++ b/internal/store/sync_unix.go
@@ -5,7 +5,7 @@ package store
 import "github.com/cockroachdb/pebble"
 
 // SyncWrites is the *pebble.WriteOptions every metadata write
-// passes when it wants the DESIGN.md §3.1.1 durability anchor.
+// passes when it wants the docs/README.md §3.1.1 durability anchor.
 // On non-darwin platforms pebble.Sync issues a plain fsync(2),
 // which is fast enough that no test-mode override is warranted.
 //

--- a/segment/block.go
+++ b/segment/block.go
@@ -74,7 +74,7 @@ type columns interface {
 }
 
 // encodeBlockInto writes the uncompressed columnar body per
-// DESIGN.md §3.2 by appending to dst, returning the grown buffer.
+// docs/README.md §3.2 by appending to dst, returning the grown buffer.
 // Reusing a scratch dst across flushes is the writer's allocation
 // avoidance strategy.
 func encodeBlockInto(dst []byte, c columns) []byte {

--- a/segment/bloom.go
+++ b/segment/bloom.go
@@ -8,13 +8,13 @@ import (
 )
 
 // Bloom-filter sizing knobs. Both apply to DID blooms (segment-level
-// and per-block) per DESIGN.md §3.1.3 and the project FP-rate guidance
-// in AGENTS.md/DESIGN.md.
+// and per-block) per docs/README.md §3.1.3 and the project FP-rate guidance
+// in AGENTS.md/docs/README.md.
 //
 // The 0.001 (0.1%) false-positive rate balances on-disk size
 // (negligible relative to a ~256 MB segment) against scan-time false
 // positives (each FP costs a full block decompress + column scan,
-// which is meaningfully expensive). AGENTS.md and DESIGN.md
+// which is meaningfully expensive). AGENTS.md and docs/README.md
 // document RAM as cheap on these servers, so we don't penny-pinch.
 const (
 	perBlockBloomFPRate = 0.001
@@ -50,7 +50,7 @@ const (
 const blockBloomsRegionHeaderSize = 8
 
 // encodeBlockBloomsRegion serializes the per-block blooms region
-// (DESIGN.md §3.1.3, spec §5.4). Every filter must marshal to an
+// (docs/README.md §3.1.3, spec §5.4). Every filter must marshal to an
 // identical length; this is the invariant that lets the reader index
 // blooms by multiplication. We assert it here so a violation is loud
 // rather than a silent on-disk corruption.

--- a/segment/collection.go
+++ b/segment/collection.go
@@ -7,7 +7,7 @@ import (
 )
 
 // collectionIndex is the parsed form of the collection block index
-// (DESIGN.md §3.1.4, spec §5.5). stringTable is the unique NSIDs in
+// (docs/README.md §3.1.4, spec §5.5). stringTable is the unique NSIDs in
 // first-seen order; the index of each NSID in stringTable is its
 // "collection ID". eventCounts[i] is the total number of events with
 // collection-id i across the whole segment (parallel-indexed with

--- a/segment/event.go
+++ b/segment/event.go
@@ -1,7 +1,7 @@
 package segment
 
 // Kind discriminates which firehose event type a row represents.
-// Values are the on-disk wire format from DESIGN.md §3.2.
+// Values are the on-disk wire format from docs/README.md §3.2.
 type Kind uint8
 
 const (
@@ -57,7 +57,7 @@ func (k Kind) IsResyncReplacement() bool {
 //	Payload:    up to math.MaxUint32 bytes
 //
 // WitnessedAt and IndexedAt are unix microseconds. IndexedAt == 0
-// means "no operator-supplied timestamp" (DESIGN.md §3.2).
+// means "no operator-supplied timestamp" (docs/README.md §3.2).
 //
 // For non-commit kinds (Identity, Account, Sync), Collection, Rkey,
 // Rev, and Payload are typically empty / nil. The encoder accepts
@@ -89,7 +89,7 @@ type Event struct {
 
 // DisplayTimeUS resolves the timestamp shown to subscribers on the wire
 // (the event's time_us). It applies the sentinel-0 fallback from
-// DESIGN.md §3.2: when an operator has imported an indexed_at value
+// docs/README.md §3.2: when an operator has imported an indexed_at value
 // (IndexedAt != 0) that display value wins; otherwise it falls back to
 // WitnessedAt, the immutable time Jetstream first saw the event.
 //

--- a/segment/event_test.go
+++ b/segment/event_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestEvent_DisplayTimeUS pins the sentinel-0 display resolver (DESIGN.md
+// TestEvent_DisplayTimeUS pins the sentinel-0 display resolver (docs/README.md
 // §3.2): the wire time_us is the imported IndexedAt when one was set
 // (non-zero), otherwise it falls back to WitnessedAt. Absent any import
 // every IndexedAt is 0, so display == witnessed for every event.

--- a/segment/footer.go
+++ b/segment/footer.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-// BlockInfo is one entry of the block index (DESIGN.md §3.1.2). It
+// BlockInfo is one entry of the block index (docs/README.md §3.1.2). It
 // describes a block's location and bounds within a sealed segment
 // file.
 type BlockInfo struct {
@@ -30,7 +30,7 @@ type BlockInfo struct {
 	// MinWitnessedAt, MaxWitnessedAt bound the witnessed_at column in
 	// unix microseconds. MaxWitnessedAt >= MinWitnessedAt. The type
 	// matches Header.MinWitnessedAt/MaxWitnessedAt and the per-event
-	// witnessed_at column in §3.2 of DESIGN.md.
+	// witnessed_at column in §3.2 of docs/README.md.
 	MinWitnessedAt, MaxWitnessedAt int64
 }
 

--- a/segment/header.go
+++ b/segment/header.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Header is the parsed form of the 256-byte fixed header at offset 0
-// of every sealed segment file. See DESIGN.md §3.1.2 for the wire
+// of every sealed segment file. See docs/README.md §3.1.2 for the wire
 // layout, and the spec §5.1 for byte-offset details.
 //
 // All offsets are absolute file offsets.
@@ -122,7 +122,7 @@ func ReadSealedHeader(r io.ReaderAt) (Header, error) {
 }
 
 // xxh3HeaderFooter computes xxh3 over headerBytes[12:] followed by
-// footerBytes — i.e. version through end-of-footer per DESIGN.md
+// footerBytes — i.e. version through end-of-footer per docs/README.md
 // §3.1.2. The magic and the checksum field itself are excluded so a
 // reader can verify the file's integrity without first knowing the
 // checksum value.

--- a/segment/seal.go
+++ b/segment/seal.go
@@ -415,7 +415,7 @@ func walkActiveFrames(f io.ReaderAt, maxOffset int64) (blockWalkResult, error) {
 }
 
 // buildFooter assembles the four footer sections in the layout
-// specified in DESIGN.md §3.1.2 and spec §5.6 and returns them
+// specified in docs/README.md §3.1.2 and spec §5.6 and returns them
 // concatenated, plus the partially-populated Header (Checksum left
 // zero; the caller fills it in after computing xxh3).
 func buildFooter(walk blockWalkResult, maxEventsPerBlock int, footerOffset int64) ([]byte, Header, error) {

--- a/segment/writer.go
+++ b/segment/writer.go
@@ -15,7 +15,7 @@ const (
 	DefaultMaxEventsPerBlock = 4096
 
 	// ReservedHeaderBytes is the size of the fixed header at the start
-	// of every segment file (DESIGN.md §3.1.2). The first len(segmentMagic)
+	// of every segment file (docs/README.md §3.1.2). The first len(segmentMagic)
 	// bytes are the magic; the remainder is zero-filled placeholder until
 	// Seal populates the finalized header. ReservedHeaderBytes is also
 	// the byte offset at which the framed-block region begins.
@@ -283,7 +283,7 @@ func resumeExistingSegment(f *os.File, size int64, path string) error {
 	// Sealed-vs-active detection: bytes 4..11 are zero on an active
 	// file (initializeNewSegment writes only the magic into the
 	// reserved 256-byte header) and non-zero on a sealed file (Seal
-	// patches in the xxh3 checksum). DESIGN.md §3.1.2 names this the
+	// patches in the xxh3 checksum). docs/README.md §3.1.2 names this the
 	// "checksum at offset 4" signal; spec §8 documents the convention.
 	var checksumBuf [8]byte
 	if _, err := f.ReadAt(checksumBuf[:], 4); err != nil {

--- a/segment/zstd.go
+++ b/segment/zstd.go
@@ -18,7 +18,7 @@ var (
 // frame decompress to gigabytes before any of decodeBlock's careful
 // length-validation runs (a classic "zstd bomb"). The cap is
 // generous: a legitimate block is bounded above by the segment
-// file's ~256 MB target (DESIGN.md §3.1.1), so 1 GiB leaves headroom
+// file's ~256 MB target (docs/README.md §3.1.1), so 1 GiB leaves headroom
 // for the segment-size knob without giving an attacker a runway.
 const maxDecodedBlockBytes uint64 = 1 << 30 // 1 GiB
 

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -1,0 +1,77 @@
+# Architecture overview (for agents)
+
+This is a fast orientation map for an agent dropping into the codebase: what the big pieces are, how they fit together, and where to read more. It is deliberately high-level and light on detail so it doesn't rot every time a function moves. `docs/README.md` is the authoritative spec — when this file and that one disagree, that one is right, and you should fix this one. Package `doc.go` files are authoritative for their own package's internals.
+
+If you're here to make a change, the useful reading order is usually: this file (get oriented) → `specs/invariants.md` (the rules you can't break) → the relevant `docs/README.md` section → the package `doc.go`.
+
+## What jetstream is
+
+Jetstream is a full-network archive and live-streaming service for atproto. It ingests every record from every repo on a relay, stores it all in a custom columnar file format on a single machine, and lets clients replay that history and then seamlessly follow the live firehose. It runs as one static binary on one server. High availability is a future goal, not something the current design does.
+
+Two things clients can do:
+
+- **Live tail** — connect to the `/subscribe` websocket and get the same filterable JSON payload as Jetstream v1. Existing v1 consumers work unchanged.
+- **Backfill then cutover** — ask for historical data (e.g. "all likes since 2024"), page through the sealed archive over HTTP, and cut over to the live websocket when caught up. The client libraries hide the seam.
+
+## The three big subsystems
+
+Everything falls into ingest (data in), storage (data on disk), or serve (data out), with a testing rig that wraps the whole thing.
+
+### Ingest — getting data onto disk
+
+Ingest is a lifecycle state machine that walks through three phases. The orchestrator (`internal/ingest/orchestrator`) owns that machine and the durable commit points between phases; a crash mid-cutover recovers by re-entering the machine at the right spot.
+
+- **Bootstrap** (`internal/ingest/backfill` + `internal/ingest/live`): on first start, two things run in parallel — a live consumer captures the firehose into a temporary `backfill/live_segments/` tree so nothing is missed, while the backfill engine paginates listRepos and downloads every repo via getRepo straight into the archive.
+- **Merge** (`internal/ingest/orchestrator`): once backfill drains, the captured live segments are drained into the permanent `segments/` tree, dropping events already covered by each repo's backfilled head, then a tombstone compaction runs so the archive is delete/update-correct before cutover.
+- **Steady state** (`internal/ingest/live` again): one live consumer pumps the firehose into `segments/`. On the side, a retry loop re-downloads repos that failed during bootstrap and backfills net-new DIDs that first appear live (issue #188). Compaction runs periodically.
+
+The live consumer and backfill both write through a shared `ingest.Writer` (`internal/ingest`), which owns segment append/flush/fsync, seq assignment, and the in-memory readable log the live tail reads from. All upstream data is untrusted: a validation gate at each conversion point drops bad revs, bad op paths, and unrepresentable fields with a labeled metric rather than crashing or corrupting (`docs/README.md` §4.4).
+
+### Storage — the segment format and the metadata store
+
+Two places hold state:
+
+- **Segment files** (`segment/`): the columnar, zstd-compressed, append-only logs. An active segment is a file state machine (append → flush → fsync → seal); sealing finalizes it into an immutable file with a footer full of indexes. The `segment` package is pure format code — no goroutines, no timers, no lifecycle — and is intentionally public API. Read `segment/doc.go` and `docs/README.md` §3.1–§3.2.
+- **The metadata store** (`internal/store`, pebble at `data/meta.pebble/`): everything that isn't cheaply re-derivable from segments — the upstream cursor, lifecycle phase, per-DID backfill status, account/sync state, compaction watermark. The manifest is deliberately *not* here; it's just a directory scan plus self-describing file headers. Read `docs/README.md` §3.5.
+
+The durability ordering between these two is the invariant that keeps a crash safe: segment fsync first, pebble commit second. See `specs/invariants.md`.
+
+### Serve — getting data out
+
+- **`/subscribe` websocket** (`internal/subscribe`): pull-based fan-out. Every subscriber runs the same loop and is served from wherever its cursor points — the writer's readable log (the hot tail) for recent events, or the cold reader (a bounded disk walk over sealed segments through a shared block cache) for older cursors. There's no per-client outbound queue, so a slow reader can't blow up server memory. This package carries a lot of deliberate v1 wire-compatibility quirks; `internal/subscribe/doc.go` lists them.
+- **Archive download over HTTP/XRPC** (`internal/xrpcapi`): the paginated `planBackfill` → `getSegment`/`getBlock` path clients use to pull sealed history before cutover.
+- **HTTP plumbing** (`internal/server`): the public (:8080) and debug (:6060) listeners and middleware. Status, health, and metrics live off these (`internal/status`, `internal/obs`).
+- **Client library** (`internal/client` and the module root): the "thick" Go client that negotiates the archive, folds the stream, dedupes by seq, and cuts over to live. `docs/README.md` §5.
+
+### Testing rig — the oracle and simulator
+
+This is unusually central to the project, so it's worth knowing even if you're not touching tests.
+
+- **Simulator** (`internal/simulator`): a fake atproto network — PLC, PDS, relay — that generates *real* atproto-shaped bytes (signed commits, CAR blocks, CBOR frames), not mocked structs. Includes adversarial-traffic modes that feed bad-but-bounded input through the honest pipeline.
+- **Oracle** (`internal/oracle`): boots a real server against the simulator, drives it through its whole lifecycle, and compares durable output against an independently derived model. It's a high-value bug detector organized into tiers (storage, event-log, replay, crash/restart, and more). A green run proves strong contracts held for one scenario, not universal correctness.
+- **Mutation campaign** (`testing/mutation`): curated single-edit bugs that measure the oracle's bug-detection power. `specs/oracle.md` is the source of truth for this whole rig — read it before touching any of it.
+
+## Where to look
+
+| I want to understand… | Start here |
+|---|---|
+| The whole system, authoritatively | `docs/README.md` |
+| The rules I must not break | `specs/invariants.md` |
+| A term I don't recognize | `specs/glossary.md` |
+| Accepted limitations / past mistakes | `specs/gotchas.md` |
+| The on-disk segment format | `segment/doc.go`, `docs/README.md` §3.1–§3.2 |
+| The metadata store keys | `internal/store`, `docs/README.md` §3.5 |
+| The ingest lifecycle / cutover | `internal/ingest/orchestrator/doc.go`, `docs/README.md` §4 |
+| Initial backfill | `internal/ingest/backfill/doc.go`, `docs/README.md` §4.1 |
+| The live firehose consumer | `internal/ingest/live/doc.go`, `docs/README.md` §4.1, §4.3 |
+| The segment writer (append/flush/seal) | `internal/ingest/doc.go` |
+| The `/subscribe` websocket + v1 quirks | `internal/subscribe/doc.go`, `docs/README.md` §5 |
+| Archive download (planBackfill/getSegment) | `internal/xrpcapi`, `docs/README.md` §5 |
+| The Go client | `internal/client`, module root, `docs/README.md` §5 |
+| Compaction / tombstones | `internal/tombstone`, `docs/README.md` §3.3 |
+| Timestamp import | `internal/timestamp`, `docs/README.md` §8 |
+| The oracle / simulator / mutation rig | `specs/oracle.md`, `internal/oracle/doc.go`, `internal/simulator/doc.go` |
+| Coding conventions, workflow, task tracking | `AGENTS.md` |
+| Design history / why a thing is the way it is | `specs/notes/` (dated design + implementation notes) |
+
+`specs/notes/` is a write-once archive of design and implementation notes, one topic per file, dated. It's the record of how we got here — useful for "why did we do it this way," less so for "what does it do now" (some notes predate later rewrites). The living docs above are the current truth.

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -23,7 +23,7 @@ Ingest is a lifecycle state machine that walks through three phases. The orchest
 
 - **Bootstrap** (`internal/ingest/backfill` + `internal/ingest/live`): on first start, two things run in parallel — a live consumer captures the firehose into a temporary `backfill/live_segments/` tree so nothing is missed, while the backfill engine paginates listRepos and downloads every repo via getRepo straight into the archive.
 - **Merge** (`internal/ingest/orchestrator`): once backfill drains, the captured live segments are drained into the permanent `segments/` tree, dropping events already covered by each repo's backfilled head, then a tombstone compaction runs so the archive is delete/update-correct before cutover.
-- **Steady state** (`internal/ingest/live` again): one live consumer pumps the firehose into `segments/`. On the side, a retry loop re-downloads repos that failed during bootstrap and backfills net-new DIDs that first appear live (issue #188). Compaction runs periodically.
+- **Steady state** (`internal/ingest/live` again): one live consumer pumps the firehose into `segments/`. On the side, a retry loop re-downloads repos that failed during bootstrap and backfills net-new DIDs that first appear live (issue #188). Compaction runs periodically to clean up deleted and updated records.
 
 The live consumer and backfill both write through a shared `ingest.Writer` (`internal/ingest`), which owns segment append/flush/fsync, seq assignment, and the in-memory readable log the live tail reads from. All upstream data is untrusted: a validation gate at each conversion point drops bad revs, bad op paths, and unrepresentable fields with a labeled metric rather than crashing or corrupting (`docs/README.md` §4.4).
 
@@ -38,7 +38,7 @@ The durability ordering between these two is the invariant that keeps a crash sa
 
 ### Serve — getting data out
 
-- **`/subscribe` websocket** (`internal/subscribe`): pull-based fan-out. Every subscriber runs the same loop and is served from wherever its cursor points — the writer's readable log (the hot tail) for recent events, or the cold reader (a bounded disk walk over sealed segments through a shared block cache) for older cursors. There's no per-client outbound queue, so a slow reader can't blow up server memory. This package carries a lot of deliberate v1 wire-compatibility quirks; `internal/subscribe/doc.go` lists them.
+- **`/subscribe` websocket** (`internal/subscribe`): pull-based fan-out. Every subscriber runs the same loop and is served from wherever its cursor points — the writer's readable log (the hot tail) for recent events, or the cold reader (a bounded disk walk over sealed segments through a shared block cache) for older cursors. There's no per-client outbound queue, so a slow reader can't blow up server memory. This package carries a lot of deliberate v1 wire-compatibility quirks; `internal/subscribe/doc.go` lists them. This maintains backwards compatibility with the original https://github.com/bluesky-social/jetstream-legacy system.
 - **Archive download over HTTP/XRPC** (`internal/xrpcapi`): the paginated `planBackfill` → `getSegment`/`getBlock` path clients use to pull sealed history before cutover.
 - **HTTP plumbing** (`internal/server`): the public (:8080) and debug (:6060) listeners and middleware. Status, health, and metrics live off these (`internal/status`, `internal/obs`).
 - **Client library** (`internal/client` and the module root): the "thick" Go client that negotiates the archive, folds the stream, dedupes by seq, and cuts over to live. `docs/README.md` §5.

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -70,7 +70,8 @@ This is unusually central to the project, so it's worth knowing even if you're n
 | The Go client | `internal/client`, module root, `docs/README.md` §5 |
 | Compaction / tombstones | `internal/tombstone`, `docs/README.md` §3.3 |
 | Timestamp import | `internal/timestamp`, `docs/README.md` §8 |
-| The oracle / simulator / mutation rig | `specs/oracle.md`, `internal/oracle/doc.go`, `internal/simulator/doc.go` |
+| The oracle / simulator | `specs/oracle.md`, `internal/oracle/doc.go`, `internal/simulator/doc.go` |
+| The mutation campaign (oracle scorecard) | `specs/mutation.md`, `testing/mutation/RESULTS.md` |
 | Coding conventions, workflow, task tracking | `AGENTS.md` |
 | Design history / why a thing is the way it is | `specs/notes/` (dated design + implementation notes) |
 

--- a/specs/glossary.md
+++ b/specs/glossary.md
@@ -1,0 +1,55 @@
+# Glossary
+
+Words that show up all over the code and docs, with a one-line meaning and where to read more. If a term here drifts from the code, the code and the linked source win — fix this file.
+
+## Storage and data format
+
+**Segment (segment file, `.jss`)** — the on-disk unit of storage: a columnar, zstd-compressed, length-prefixed log of firehose events. Files are named with a zero-padded base-36 counter so they sort in creation (and time) order. Source of truth: `docs/README.md` §3.1, `segment/doc.go`.
+
+**Block** — a compressed batch of events inside a segment. Blocks are the unit of decode and the unit the cold reader and block cache work with; each sealed segment's footer indexes its blocks. Source: `docs/README.md` §3.2, `segment/doc.go`.
+
+**Seal** — the one-way transition that finalizes an active segment into an immutable file: it writes the footer (block index, DID blooms, collection index) and a finalized 256-byte header with an xxh3 checksum. After sealing, the bytes never change. Source: `docs/README.md` §3.1, `segment/doc.go`.
+
+**Footer** — the trailing metadata block a seal writes: the block index, a segment-level DID bloom filter, per-block DID blooms, and the collection block index. Lets a reader find the right blocks without scanning the whole file. Source: `docs/README.md` §3.1.2–§3.1.4.
+
+**Generation** — informal term for a segment file's version across rewrites. Compaction and merge rewrite sealed files into new generations while preserving block topology (a fully-dropped block stays as an `event_count=0` block) so block numbers stay stable across generations. Source: `docs/README.md` §3.3 (block topology note near the end of the section).
+
+**Tombstone** — the record of a delete or update, keyed by AT URI. Tombstones aren't applied to segments synchronously; compaction applies them later. There is no read-time overlay — clients fold the stream themselves. Source: `docs/README.md` §3.3, `internal/tombstone`.
+
+**Watermark (compaction watermark, `compaction/seq`)** — the highest seq that physical compaction has covered. Below it, superseded create/update rows are physically gone; the uncompacted tail `(watermark, tip]` may still carry rows a later marker will kill. Owned by the compactor. Source: `docs/README.md` §3.3, §3.5.
+
+**Manifest** — the list of segments jetstream serves. It's deliberately not stored in pebble: it's just a directory scan plus each file's self-describing header, so it can't drift from what's on disk. Source: `docs/README.md` §3.5.
+
+**Metadata store** — the single pebble db at `data/meta.pebble/` holding everything that isn't cheaply re-derivable from segments: `relay/cursor`, lifecycle `phase`, `repo/<did>`, `account/<did>`, `sync/<did>`, `compaction/seq`. Source: `docs/README.md` §3.5, `internal/store`.
+
+## Ingestion lifecycle
+
+**Bootstrap phase** — the initial full-network backfill: paginate the relay's listRepos, download every repo via getRepo, and write it to disk, while a live consumer simultaneously captures the firehose into `backfill/live_segments/`. Source: `docs/README.md` §4.1, `internal/ingest/backfill/doc.go`.
+
+**Merge phase** — the cutover step that drains the captured live segments into the steady-state `segments/` tree, filtering out events already covered by the backfilled repo head. Source: `docs/README.md` §4.2, `internal/ingest/orchestrator/doc.go`.
+
+**Cutover** — the whole bootstrap → merging → steady-state transition, anchored by two durable commit points (`phase=merging`, `phase=steady_state`) so a crash mid-cutover recovers by re-entering the state machine. Source: `docs/README.md` §4, `internal/ingest/orchestrator/doc.go`.
+
+**Steady state** — normal operation after cutover: one live consumer pumps the firehose into `segments/`, net-new DIDs get backfilled on the side, and compaction runs periodically. Source: `docs/README.md` §4.3.
+
+**Cursor (seq, sequence number)** — the monotonic 64-bit id jetstream assigns each event at ingestion. Also the value clients pass as `?cursor=`. Inclusive, starts at 1, instance-local. Source: `docs/README.md` §2. See also `specs/invariants.md`.
+
+## Serving the stream
+
+**Readable log (hot tail)** — the byte-bounded, seq-indexed FIFO the ingest writer keeps of recently appended events, so caught-up subscribers get served from memory and wake on the next append. (This replaced the older push-broadcaster "hot ring" model — a slow reader no longer overflows a per-client channel.) Source: `internal/subscribe/doc.go`, `internal/ingest` writer.
+
+**Cold reader** — the fallback path when a subscriber's cursor is older than what the readable log still holds in memory: a bounded disk walk over sealed segments plus the active segment's flushed region, routed through a shared decoded-block LRU cache. Source: `internal/subscribe/doc.go`, `internal/subscribe/replay.go`.
+
+**Bucketed** — a timestamp-import status flag (`getImportStatus`) meaning the import's rows have been grouped/bucketed for processing. Narrow term, only in the import API — not a general storage concept. Source: `internal/timestamp`, `docs/README.md` §8.
+
+## Testing
+
+**Oracle** — the end-to-end correctness harness: boots a real server against the simulated network, drives its whole lifecycle, and compares durable output against an independent model. A bug detector, not a proof. Source: `specs/oracle.md`, `internal/oracle/doc.go`.
+
+**Simulator** — the fake atproto network (PLC + PDS + relay) that generates real atproto-shaped bytes for the oracle and for local dev. Source: `internal/simulator/doc.go`, `specs/oracle.md`.
+
+**Bubble** — a `testing/synctest` bubble: a test scope with a fake clock where the runtime knows when every goroutine is blocked, so the system quiesces deterministically. Only one is allowed per process. Source: `internal/oracle/doc.go`, `specs/oracle.md`.
+
+**Tier** — one family of oracle checks that share helpers but fail with a distinct explanation (storage, event-log, replay, XRPC egress, crash/restart, store-fault, simulator fidelity, corpus, soak, determinism). Source: `specs/oracle.md`.
+
+**Mutant / mutation campaign** — a curated single-edit bug (a "mutant") that models a realistic failure; the campaign applies each one and checks the oracle catches it, measuring the oracle's bug-detection power. Never fix production code to match a mutant. Source: `AGENTS.md`, `testing/mutation/RESULTS.md`, `specs/oracle.md`.

--- a/specs/gotchas.md
+++ b/specs/gotchas.md
@@ -1,0 +1,49 @@
+# Gotchas: accepted limitations and hard-won lessons
+
+This file is the shared home for two kinds of knowledge that otherwise live only in one person's head:
+
+- **Accepted limitations** — things that look like bugs but are deliberate. We considered them and decided to live with them. Don't "fix" one without checking here first and reopening the decision on purpose.
+- **Lessons** — mistakes that were expensive to learn, and traps that are easy to fall into twice.
+
+Each entry says what the thing is, why it's the way it is, and roughly where in the code it lives (by area, not line number, so it doesn't rot). If you hit something surprising and figure out why, add an entry. If you find yourself about to change something an entry describes, that's your cue to talk to Jim first.
+
+---
+
+## Accepted limitations
+
+### Net-new DID backfill is correct by design — don't "fix" it
+
+This one repeatedly confuses agents into thinking there's a data-loss bug. There isn't; the behavior is intentional. Here's what actually happens so you don't try to harden it.
+
+A repo can appear live that we never backfilled — say its PDS was firewalled during the bootstrap listRepos sweep, so the first event we ever see for it is well past its start. When the steady-state live consumer archives an event for a DID with no `repo/<did>` row, it writes one at `StatusPending` (`EnqueueNetNewRepo`). The retry loop treats `pending` exactly like a failed repo, so its next pass does a full `getRepo` and captures the repo's current state — the same model we use for a `#sync` resync.
+
+Two things that look like problems but aren't:
+
+- The event that triggered the discovery **is** archived normally. It isn't dropped while we go fetch the repo.
+- Events that predate our first sighting were never on our wire and can't be recovered event-by-event — `getRepo` serves the current head, not history. That's inherent to atproto, not a jetstream defect. The current repo state is captured; the archive stays correct going forward.
+
+This only matters in steady state. During bootstrap, a DID that first appears mid-sweep is still enumerated later in the same listRepos pagination, so there's no gap to close there. Area: `internal/ingest/backfill/enqueue.go` and `store.go` (`EnqueueNetNewRepo`), `docs/README.md` §4.3, issue #188.
+
+### Timestamp-import ReadRow can accept a suffix behind a quoted newline
+
+(Sourced from the in-code comment, which marks this a known, accepted limitation.) Phase C of the timestamp import re-reads one CSV row by byte offset and re-validates it, checking that the byte before the offset is a newline so a stale offset can't land mid-record. A newline embedded inside a quoted CSV field also satisfies that check, so an offset into such a multi-line record could parse as a suffix row. Closing it would need global quote-parity tracking (a full re-scan, or binding the CSV to the job by size+hash). The code comment records the decision not to: the only actor who can swap the CSV under a resumed job is the operator, who can already import arbitrary timestamps honestly, and an accidental desync that happens to produce a valid-parsing suffix behind a quoted newline is vanishingly unlikely. Area: `internal/timestamp/apply.go` (`ReadRow`) — read the comment there before touching it.
+
+### A spec-valid rkey longer than 255 bytes is dropped by design
+
+atproto record keys can be up to ~1023 bytes, but our segment format caps the rkey column at 255 bytes. A record with a legal-but-longer rkey is dropped at the ingest gate under `ErrFieldTooLong` with its own metric reason — distinct from "the network sent garbage" — so operators can tell a representation limit from actual bad input. This is a deliberate format trade-off, not a validation bug. Area: `internal/ingest` validation gate, `segment/block.go` column limits, `docs/README.md` §4.4.
+
+### `just run-prod` inherits the dev-speed flags from `.env`
+
+`set dotenv-load` in the justfile loads the committed `.env` for every recipe, and `run-prod` only overrides the relay/PLC/data-dir vars. So dev-speed flags like `JETSTREAM_SKIP_MERGE_DISCOVERY`, `JETSTREAM_DISABLE_REPO_ACTION_RATE_LIMITS`, and the 1s status-cache TTL still apply when `run-prod` points at real upstream services. This is intentional: `run-prod` is a local dev loop aimed at real upstream for fast iteration, not a production-config rehearsal. A faithful production-config recipe is deferred to pre-1.0 vetting (nothing runs the exact config production will use yet). If you're doing a maintainability/config audit, this is expected — don't file it as a bug. Area: `justfile` (`run-prod`).
+
+---
+
+## Lessons
+
+### There are several copies of the "is this just cancellation?" classifier — grep them all
+
+Deciding whether an error is a clean shutdown (context cancellation) versus a real failure shows up in more than one place, and they are NOT all the same predicate. The subtle one is `IsCancellationOnly` in the import path: a plain `errors.Is(err, context.Canceled)` is wrong there because `RunImport` can return `errors.Join(context.Canceled, realFailure)`, and `errors.Is` matches *any* leaf — which would launder a real failure into a resumable pause. It reports cancellation only when *every* leaf is cancellation. Other spots (`orchestrator/steady.go`, `backfill/retry.go`, `jetstreamd/runtime.go`, the simulator) do a plain `errors.Is` because they only care whether the top-level context was cancelled. Lesson: if you touch cancellation-vs-failure logic, grep for every copy and understand which semantics each one needs — they are not interchangeable. Area: `internal/ingest/orchestrator/import_metrics.go` (`IsCancellationOnly`) and the call sites above.
+
+### The mutation campaign needs a clean git working tree
+
+`just mutation-campaign` / `mutation-gate` apply and revert mutant patches with `git apply`. If the working tree is dirty, a revert can fail, and the driver crashes loud rather than trust a corrupted tree (`FATAL: ... working tree is DIRTY — aborting`). Commit or stash your work before running the campaign. Also: never apply the mutant patches by hand outside the driver, and never "fix" production code to match a mutant — they are deliberate bugs. Area: `testing/mutation/run.sh` (`revert_current`), `AGENTS.md`.

--- a/specs/invariants.md
+++ b/specs/invariants.md
@@ -1,0 +1,27 @@
+# Invariants
+
+This is the short list of rules jetstream must never break. It's a quick-reference for agents: if a change would violate one of these, stop and rethink. Each entry says what the rule is and where the authoritative explanation lives — `docs/README.md` is the spec, and this file just points into it. When the two disagree, `docs/README.md` wins; fix this file.
+
+Most of these are correctness properties that clients build on or that keep the archive from corrupting itself. They've each been paid for at least once, so treat them as load-bearing rather than aspirational.
+
+## The rules
+
+**Sealed segments are immutable.** Once a segment file is sealed, its bytes never change again. Compaction and merge produce *new* files and swap them in with a tmp-write-then-rename; they never edit a sealed file in place. Anything that caches segment contents can trust that a given sealed file's bytes are stable for the life of that file. See `docs/README.md` §3.1 and `segment/doc.go`.
+
+**fsync the segment before you commit to pebble.** For every block, the order is: append and fsync the block into the active segment file first, then commit the pebble batch (with `sync=true`) that advances `relay/cursor` and the per-DID `repo/<did>` bookkeeping. Never the other way around. This is what makes a crash safe: because the cursor is written after the data, a crash between the two leaves `relay/cursor` pointing at or before the last durable event, so restart just replays a few events instead of losing them. See `docs/README.md` §3.5.
+
+**The cursor is inclusive, and seq 0 means "nothing yet."** `?cursor=N` replays starting at the event with seq N (we deliver events with seq >= N). Sequence numbers start at 1; seq 0 is a reserved "before the beginning" sentinel, so `?cursor=0` replays everything. Seqs are assigned at ingestion and are instance-local — different jetstream instances assign their own. See `docs/README.md` §2.
+
+**At-least-once delivery; clients must be idempotent.** We do not do exactly-once. The same event can be delivered more than once (a resuming client re-receives its last-seen event; a re-merge can re-emit a row). This is a deliberate non-goal, not a bug — the same guarantee the upstream firehose gives. Anything consuming the stream has to dedupe. See `docs/README.md` §1.1 and §2.
+
+**Per-DID order is preserved, always.** Events for a single DID are replayed in the same order they were ingested, across every phase and every segment generation. Segment files lay events out by DID on disk specifically to hold this line, and it survives compaction and merge — a record's history for one DID never reorders. Building AppViews correctly depends on this. See `docs/README.md` §2 and §3.4.
+
+**Segment files sort in creation order, and that order is time order.** Segments are named with a zero-padded base-36 counter, so a lexicographic sort of filenames is creation order, and every event in `seg_N` was witnessed before every event in `seg_N+1`. The block topology (which DIDs and collections live in which block) is self-describing in each sealed file's footer and does not depend on any external index staying in sync. See `docs/README.md` §3.1 and §3.4.
+
+**Crash loud on our own corruption; never crash on bad upstream data.** These are two halves of one boundary. Invalid *internal* state — persistence corruption, fsync failures, impossible segment structure, a broken durability invariant — should crash the process loudly rather than limp along and risk corrupting the archive. Invalid *upstream* data — a malformed firehose frame, an over-limit field, garbage from the relay — must never crash, stop, or exit the server: drop the offending record or event, bump a warning/error metric, log bounded diagnostics, and keep running. Treat everything from the relay/firehose/backfill as untrusted input. See `AGENTS.md` ("Never crash, and never corrupt data") and `docs/README.md` §4.4.
+
+## See also
+
+- `docs/README.md` §2 — the canonical invariants list this file summarizes.
+- `specs/gotchas.md` — accepted limitations and hard-won lessons (the things that are *not* invariants because we deliberately decided to live with them).
+- `specs/architecture.md` — how the subsystems these rules govern fit together.

--- a/specs/mutation.md
+++ b/specs/mutation.md
@@ -1,0 +1,92 @@
+# Mutation Campaign Design
+
+## Purpose
+
+The oracle (`specs/oracle.md`) is our main bug detector, but a passing oracle only tells you the oracle didn't complain — it doesn't tell you the oracle *would* complain if a real bug were present. The mutation campaign is how we measure that. It deliberately breaks the production code in small, realistic ways and checks that the oracle catches each break. If a mutant survives, the oracle has a blind spot exactly there.
+
+So the campaign is the scorecard for the oracle's detection power. It turns "the tests are green" into "the tests can go red for the bugs we care about," which is the property that actually matters. Read `specs/oracle.md` first — the campaign only makes sense as a measurement of the thing that doc describes.
+
+This document explains what the system is and the rules that keep it honest. It is not a task list; active work lives in GitHub issues. The live scorecard lives in `testing/mutation/RESULTS.md` (human-facing) and `testing/mutation/baseline.json` (machine-enforced).
+
+## What a mutant is
+
+A **mutant** is a single-edit patch to production code that models a realistic bug. Each one lives as a `.patch` file in `testing/mutation/mutants/` (e.g. `m019_sync_tombstone_dropped.patch`) and carries a small metadata header before the diff:
+
+- `mutant` — its id.
+- `target` — the file it breaks.
+- `failure-mode` — the production bug it models, in prose. This is the point of the mutant: it's a bug someone could plausibly write.
+- `expected-detection` — which oracle check should catch it and why.
+- `expected-tier` — the tier we predict kills it, stated *before* the first run so we can't rationalize after the fact.
+- `tiers` — which tiers to actually run for this mutant.
+
+A mutant is a bug *model*, not a production patch. Two hard rules follow from that, and both are also in `AGENTS.md`:
+
+- **Never apply these patches outside the driver.** They are deliberate bugs; applying one by hand and forgetting leaves the tree broken.
+- **Never "fix" production code to make a mutant behave.** If a mutant won't die, the finding is a missing oracle check, not a wrong mutant. Fix the oracle (or retire the mutant with a reason), never the code-under-test.
+
+## How the campaign runs
+
+`testing/mutation/run.sh` is the driver; `just mutation-campaign` is the wrapper. For each mutant it:
+
+1. applies the patch to a clean tree,
+2. runs the tiers named in the mutant's `tiers` field,
+3. records whether the oracle went red (KILLED) or stayed green (SURVIVED),
+4. reverts the patch.
+
+The disposition of a run is one of:
+
+- **KILLED** — the oracle caught it. This is the outcome we want. The result note records which tier killed it (e.g. `KILLED@default`, `KILLED@partb`, `KILLED@corpus`).
+- **SURVIVED** — the oracle stayed green with the bug present. A blind spot; analyze and disposition it.
+- **STALE** — the patch no longer applies. The production code moved out from under the mutant; the mutant needs re-review and a refresh.
+- **BUILD-BROKEN** — the patch applies but no longer compiles. Same cause, same fix: refresh the mutant.
+
+A few things about running it that bite people:
+
+- **The working tree must be clean.** The driver applies and reverts patches with `git`, and refuses to start on a dirty tree. If a revert ever fails it aborts loud rather than trust a corrupted tree — crash-loud over corrupt, same as the rest of the project. Commit or stash first. (This one is also in `specs/gotchas.md`.)
+- **`--seeds N`** stress-sweeps a single mutant across N random seeds. Some bugs are boundary-dependent and only show up on some seeds; a mutant killed 4/5 seeds is a probabilistic detection, not a boundary-exact one, and that distinction matters when judging oracle strength.
+- **`--race`** runs every tier under the data-race detector so a race-only regression in the stress/restart interleavings becomes a kill. It's much slower, so the driver widens the per-tier timeouts.
+
+## The baseline gate
+
+The campaign is only useful if a regression fails CI, so the scorecard is enforced, not just written down.
+
+`testing/mutation/baseline.json` is the committed source of truth: `{commit, mutants: [{id, disposition, ...}]}`. The `testing/mutation/gate` command (via `just mutation-gate`, run on a schedule in CI) runs a fresh campaign and diffs it against the baseline. It fails on:
+
+- **REGRESSION** — a mutant the baseline records as KILLED is now SURVIVED. The oracle lost detection power. This is the important one.
+- **STALE / BUILD-BROKEN** — a patch that no longer applies or compiles.
+- **MISSING / NEW** — a baseline mutant absent from the run, or a run mutant absent from the baseline (the catalog and baseline drifted apart).
+
+A **SURVIVED→KILLED** flip is an *improvement*, not a failure: the gate surfaces it so you can bank it, but it never fails the build. To bank an improvement (or to add/retire a mutant), regenerate the baseline with `just mutation-baseline` and commit the reviewed diff.
+
+`RESULTS.md` is the human-readable history — each campaign appends a dated section and old sections are never back-edited, so the oracle's detection power over time stays visible. When the two disagree, `baseline.json` is the enforced truth; `RESULTS.md` is the narrative.
+
+## Why this matters more than usual here
+
+Two facts from past campaigns show why the gate earns its keep:
+
+- Most mutant kills come from oracle tiers, not unit tests — so the survivors map precisely onto oracle blind spots, which is exactly the signal we want.
+- We've been burned once already: deleting a package silently flipped a mutant from KILLED to SURVIVED, and the gate is what caught it. Without the gate, that lost coverage would have been invisible.
+
+That's the whole argument for the campaign: it's the difference between believing the tests are strong and knowing which bugs they'll actually catch.
+
+## Requirements for future changes
+
+### Adding a mutant
+
+Only add mutants that model a realistic single-edit bug. Every mutant should compile, avoid trivial panics, carry the metadata header above (including `expected-tier` stated before the first run), and be retired when code movement makes it stale or dead. After adding one, bank it KILLED via `just mutation-baseline` so the gate enforces the new coverage.
+
+### After changing ingest, segment, or orchestrator logic
+
+Re-run the campaign. A STALE result means the code moved and the mutant needs re-review, not a rubber-stamp refresh. New oracle capabilities should either kill a previously-surviving mutant or come with a new mutant that proves the new check has teeth — otherwise the capability is present but not measured.
+
+### Retiring a mutant
+
+A mutant that models a now-impossible bug (a code path that no longer exists, a dependency that changed behavior) should be retired from the active catalog with a recorded reason in `RESULTS.md`, not silently deleted. The reason is what stops a future agent from "restoring" it.
+
+## See also
+
+- `specs/oracle.md` — the oracle and simulator this campaign measures. Read first.
+- `testing/mutation/RESULTS.md` — the dated human scorecard and full mutant history.
+- `testing/mutation/baseline.json` — the machine-enforced baseline.
+- `testing/mutation/run.sh` — the driver.
+- `AGENTS.md` — the "never apply patches by hand, never fix code to match a mutant" rules and the change-class → recipe table.

--- a/specs/oracle.md
+++ b/specs/oracle.md
@@ -138,9 +138,9 @@ endpoints, then drives lifecycle phases:
 - shutdown and restart scenarios.
 
 The driver uses phase gates, durable append callbacks, sequence acknowledgers,
-and subprocess crash harnesses. These are not decorations: they are how the
-oracle avoids relying on sleeps as success criteria and how it proves that
-data reached durable surfaces before assertions run.
+and subprocess crash harnesses. These matter: they are how the oracle avoids
+relying on sleeps as success criteria, and how it proves data reached durable
+surfaces before assertions run.
 
 ### Observers
 
@@ -341,7 +341,7 @@ while final state still converges. `m025` was retired when its
 no longer reach the above-watermark over-drop it modelled). #183's re-derivation
 analysis concluded that NO single-edit mutant can uniquely trip the recorder
 under the windowed-fold architecture: the pass folds its tombstones from the
-exact on-disk window it compacts (so every genuinely-folded drop is also
+exact on-disk window it compacts (so every legitimately-folded drop is also
 approved by the recorder's identically-bounded filter — invisible to it), and
 the only edits that manufacture a filter-illegal drop (seq-comparison or
 seq-value corruption, whose sole new victim is the self-superseding update row)
@@ -373,31 +373,33 @@ log bounded diagnostics, and continue running.
 
 The adversarial ingest-gate modes (#204) set the tier's conventions:
 
-- **The world lies through the honest pipeline, not around it.** Op-path lies
-  enter via raw `mst.Tree.Insert` (bypassing `repo.Create` validation) inside
-  otherwise-real signed commits, so atmos's verifier — which checks MST
-  consistency, not spec validity — passes them through to the ingest gate.
-  Rev lies are signed into the inner commit. A lie the verifier would reject
-  structurally proves nothing about the gate.
-- **Layer ownership is explicit.** Each case is asserted at the layer that
-  owns it: gate-owned cases assert the labeled reason on
-  `jetstream_ingest_dropped_events_total`; verifier-owned cases (non-TID /
-  future / regressing #commit revs) assert rejection or resync repair with no
-  bad archive. `internal/simulator/world/adversarial.go` documents which lies
-  land where; the wire itself blocks one class (invalid UTF-8 cannot ride a
-  live op.Path — CBOR text strings reject it — so it is backfill-only).
-- **Every lie is ledgered.** `world.AdversarialLedger` records each lie at
-  generation time; the oracle filters expected event logs, final-state ground
-  truth, and cursor-gap accounting through it (one-directional-safe: a
-  wrongly-archived lie still fails compares as an extra). Anti-vacuity is
-  per-layer: gate-owned lies assert per-(source, reason) drop-counter floors
-  (`ExpectedDropFloors` skips verifier-layer entries — they never reach the
-  gate counter); verifier-owned lies prove they fired through their own
-  observable (the awaited resync-repair tombstone).
-- **Honest traffic must not touch lie records** (`pickUntouchedRecord` skips
-  ledgered keys): an honest mutation of an unrepresentable-but-spec-valid
-  record would be gate-dropped as an unledgered event and corrupt the
-  cursor accounting.
+- **Bad records go through the real pipeline, not around it.** A malformed op
+  path enters via raw `mst.Tree.Insert` (bypassing `repo.Create` validation)
+  inside an otherwise-real signed commit, so atmos's verifier — which checks
+  MST consistency, not spec validity — passes it through to the ingest gate. A
+  malformed rev is signed into the inner commit. If the verifier would reject a
+  record on structure alone, feeding it in proves nothing about the gate, so we
+  don't.
+- **Each case is asserted at the layer that owns it.** Gate-owned cases assert
+  the labeled reason on `jetstream_ingest_dropped_events_total`; verifier-owned
+  cases (non-TID, future, or regressing #commit revs) assert rejection or
+  resync repair with no bad data reaching the archive.
+  `internal/simulator/world/adversarial.go` documents which cases land where.
+  One class is blocked by the wire itself: invalid UTF-8 can't ride a live
+  op.Path because CBOR text strings reject it, so that case is backfill-only.
+- **Every injected record is tracked in a ledger.**
+  `world.AdversarialLedger` records each one at generation time, and the oracle
+  filters expected event logs, final-state ground truth, and cursor-gap
+  accounting through it. This is safe in one direction: a record that was
+  wrongly archived still shows up as an extra and fails the compare. Anti-vacuity
+  is per-layer — gate-owned cases assert per-(source, reason) drop-counter
+  floors (`ExpectedDropFloors` skips verifier-layer entries, since those never
+  reach the gate counter), and verifier-owned cases prove they fired through
+  their own observable (the awaited resync-repair tombstone).
+- **Normal traffic must not touch the injected records** (`pickUntouchedRecord`
+  skips keys already in the ledger): a normal mutation of an
+  unrepresentable-but-spec-valid record would be gate-dropped as an untracked
+  event and throw off the cursor accounting.
 
 ### Real-Data Corpus Tier
 

--- a/specs/oracle.md
+++ b/specs/oracle.md
@@ -204,7 +204,9 @@ records by default.
 
 `testing/mutation` measures oracle detection power with curated, realistic
 single-edit bugs. A mutant is not a production patch; it is a bug model with a
-documented failure mode and expected detection tier.
+documented failure mode and expected detection tier. `specs/mutation.md` is the
+dedicated design guide for the campaign; the summary here is enough to place it
+in the oracle's context.
 
 The mutation campaign is the scorecard for major oracle improvements:
 

--- a/specs/oracle.md
+++ b/specs/oracle.md
@@ -2,45 +2,26 @@
 
 ## Purpose
 
-Jetstream v2 is a durable archive and replay service. The oracle simulator
-exists to catch bugs that ordinary unit tests and happy-path integration tests
-will miss: data loss, replay holes, compaction mistakes, restart corruption,
-cursor drift, and failure handling that silently advances past unarchived data.
+Jetstream v2 is a durable archive and replay service. The oracle simulator exists to catch bugs that ordinary unit tests and happy-path integration tests will miss: data loss, replay holes, compaction mistakes, restart corruption, cursor drift, and failure handling that silently advances past unarchived data.
 
-The oracle is not a proof of correctness. It is a high-value bug detector. Its
-job is to create realistic enough atproto traffic, drive Jetstream through the
-same public and persistence paths clients rely on, and compare the result
-against an independently derived model. A green oracle means one set of strong
-contracts held for one scenario. It does not mean every interleaving,
-transport failure, protocol edge case, or production data shape has been
-covered.
+The oracle is not a proof of correctness. It is a high-value bug detector. Its job is to create realistic enough atproto traffic, drive Jetstream through the same public and persistence paths clients rely on, and compare the result against an independently derived model. A green oracle means one set of strong contracts held for one scenario. It does not mean every interleaving, transport failure, protocol edge case, or production data shape has been covered.
 
-This document is the durable design guide for that testing system. It explains
-why the oracle and simulator are structured the way they are, what requirements
-future changes must preserve, and how to extend the system without weakening
-its bug-finding value. Active work is tracked in GitHub issues under the
-testing epic, not in this document.
+This document is the durable design guide for that testing system. It explains why the oracle and simulator are structured the way they are, what requirements future changes must preserve, and how to extend the system without weakening its bug-finding value. Active work is tracked in GitHub issues under the testing epic, not in this document.
 
 ## Design Goals
 
 ### Test The Product Contract
 
-Jetstream's product is replay. Segment files are the storage format, but
-clients consume data through `/subscribe` and XRPC segment download paths. The
-oracle must therefore validate both:
+Jetstream's product is replay. Segment files are the storage format, but clients consume data through `/subscribe` and XRPC segment download paths. The oracle must therefore validate both:
 
-- storage correctness: what Jetstream wrote to disk is physically and
-  logically valid;
-- product-path correctness: what clients can replay through public APIs is the
-  same stream after applying the documented compaction and tombstone rules.
+- storage correctness: what Jetstream wrote to disk is physically and logically valid;
+- product-path correctness: what clients can replay through public APIs is the same stream after applying the documented compaction and tombstone rules.
 
-Direct segment observation remains valuable because it distinguishes storage
-bugs from serving bugs. It must not be the only observation surface.
+Direct segment observation remains valuable because it distinguishes storage bugs from serving bugs. It must not be the only observation surface.
 
 ### Prefer Independent Checks
 
-The strongest oracle checks do not ask Jetstream what it thinks happened. They
-derive expectations from separate state:
+The strongest oracle checks do not ask Jetstream what it thinks happened. They derive expectations from separate state:
 
 - simulator world state and MST data for final materialized repo state;
 - simulator firehose history for expected event-log rows;
@@ -48,48 +29,30 @@ derive expectations from separate state:
 - physical segment scans for storage invariants;
 - mutation campaigns for empirical bug-detection power.
 
-Shared code is a known blind spot. Both the simulator and Jetstream use
-`github.com/jcalabro/atmos` for atproto protocol handling, so symmetric bugs in
-that library can pass the oracle. Real-data corpus tests exist to reduce that
-closed-loop risk.
+Shared code is a known blind spot. Both the simulator and Jetstream use `github.com/jcalabro/atmos` for atproto protocol handling, so symmetric bugs in that library can pass the oracle. Real-data corpus tests exist to reduce that closed-loop risk.
 
 ### Assertion Power Before Determinism
 
-Perfect deterministic simulation testing is not a near-term requirement. Go's
-runtime scheduler, real network I/O, wall-clock timers, Pebble, and filesystem
-behavior make bit-identical execution expensive enough that it should not come
-before stronger assertions.
+Perfect deterministic simulation testing is not a near-term requirement. Go's runtime scheduler, real network I/O, wall-clock timers, Pebble, and filesystem behavior make bit-identical execution expensive enough that it should not come before stronger assertions.
 
 The practical target is deterministic enough:
 
 - seed simulator world generation and traffic decisions;
 - keep avoidable nondeterminism out of oracle-observed input bytes;
-- use barriers and durable append acknowledgements instead of timing-based
-  success conditions;
-- emit structured traces so an interleaving-dependent failure is diagnosable
-  even when it is not exactly replayable.
+- use barriers and durable append acknowledgements instead of timing-based success conditions;
+- emit structured traces so an interleaving-dependent failure is diagnosable even when it is not exactly replayable.
 
-Real crash/restart and public-serving tests must keep real process, socket,
-filesystem, and persistence behavior. Fake transports, fake time, in-memory
-stores, and `testing/synctest` experiments are supplemental logical tiers, not
-replacements for durability and product-path tiers.
+Real crash/restart and public-serving tests must keep real process, socket, filesystem, and persistence behavior. Fake transports, fake time, in-memory stores, and `testing/synctest` experiments are supplemental logical tiers, not replacements for durability and product-path tiers.
 
 ### Fail Loud Over Corrupt
 
-The production daemon must not crash on invalid upstream input, but the oracle
-should crash loud on invalid internal state, persistence corruption, fsync
-failures, impossible segment structure, and test harness anti-vacuity failures.
-Silent fallbacks create false confidence and are worse than a noisy test.
+The production daemon must not crash on invalid upstream input, but the oracle should crash loud on invalid internal state, persistence corruption, fsync failures, impossible segment structure, and test harness anti-vacuity failures. Silent fallbacks create false confidence and are worse than a noisy test.
 
-Every injected fault must be accounted for. If a fault plan is configured, the
-oracle should prove the expected faults fired; otherwise a disabled fault path
-can make a test pass vacuously.
+Every injected fault must be accounted for. If a fault plan is configured, the oracle should prove the expected faults fired; otherwise a disabled fault path can make a test pass vacuously.
 
 ### Keep Tiers Separate
 
-One giant oracle test would be hard to understand and hard to debug. The
-testing system should keep related tiers that share helpers but fail with
-different explanations:
+One giant oracle test would be hard to understand and hard to debug. The testing system should keep related tiers that share helpers but fail with different explanations:
 
 - storage and final-state correctness;
 - event-log equivalence;
@@ -103,33 +66,24 @@ different explanations:
 - long-horizon soak behavior;
 - deterministic-enough experiments.
 
-The default lifecycle should stay fast enough to run locally. Heavier stress,
-restart, mutation, and soak modes should be explicit recipes.
+The default lifecycle should stay fast enough to run locally. Heavier stress, restart, mutation, and soak modes should be explicit recipes.
 
 ## Current Architecture
 
 ### Simulator World
 
-`internal/simulator/world` owns deterministic account generation, repo state,
-traffic generation, firehose history, and simulator-side persistence. It
-creates real atproto-shaped bytes: CBOR frames, signed commits, CAR blocks,
-MST data, account events, and sync events. It is not a set of mocked
-`segment.Event` structs.
+`internal/simulator/world` owns deterministic account generation, repo state, traffic generation, firehose history, and simulator-side persistence. It creates real atproto-shaped bytes: CBOR frames, signed commits, CAR blocks, MST data, account events, and sync events. It is not a set of mocked `segment.Event` structs.
 
 The world has two important roles:
 
-- provide upstream-like inputs to Jetstream through simulator HTTP and
-  websocket handlers;
+- provide upstream-like inputs to Jetstream through simulator HTTP and websocket handlers;
 - provide independent expected state and event history for oracle checkers.
 
-Simulator data that appears in oracle-observed bytes should be stable under a
-fixed seed where practical. For example, account event timestamps use the
-simulator logical clock rather than wall-clock time.
+Simulator data that appears in oracle-observed bytes should be stable under a fixed seed where practical. For example, account event timestamps use the simulator logical clock rather than wall-clock time.
 
 ### Runtime Driver
 
-`internal/oracle` starts Jetstream with simulator-backed relay, PDS, and PLC
-endpoints, then drives lifecycle phases:
+`internal/oracle` starts Jetstream with simulator-backed relay, PDS, and PLC endpoints, then drives lifecycle phases:
 
 - bootstrap and bootstrap-live overlap;
 - merge into the steady archive;
@@ -137,55 +91,36 @@ endpoints, then drives lifecycle phases:
 - compaction;
 - shutdown and restart scenarios.
 
-The driver uses phase gates, durable append callbacks, sequence acknowledgers,
-and subprocess crash harnesses. These matter: they are how the oracle avoids
-relying on sleeps as success criteria, and how it proves data reached durable
-surfaces before assertions run.
+The driver uses phase gates, durable append callbacks, sequence acknowledgers, and subprocess crash harnesses. These matter: they are how the oracle avoids relying on sleeps as success criteria, and how it proves data reached durable surfaces before assertions run.
 
 ### Observers
 
 Observers collect what Jetstream produced through different surfaces:
 
 - filesystem segment observer: reads active and sealed segment files directly;
-- event-log recorder: captures lifecycle hook events keyed by upstream relay
-  cursor;
-- `/subscribe` replay observer: reads public websocket replay and live-tail
-  behavior;
-- XRPC segment observer: downloads public archive segments and decodes bytes as
-  a client would;
-- metadata and metrics observers: inspect durable cursor/status/watermark
-  state and operational signals where needed.
+- event-log recorder: captures lifecycle hook events keyed by upstream relay cursor;
+- `/subscribe` replay observer: reads public websocket replay and live-tail behavior;
+- XRPC segment observer: downloads public archive segments and decodes bytes as a client would;
+- metadata and metrics observers: inspect durable cursor/status/watermark state and operational signals where needed.
 
-Observers must not silently substitute for one another. If `/subscribe` replay
-is wrong while storage is correct, that is a product-path failure, not a reason
-to pass by falling back to filesystem reads.
+Observers must not silently substitute for one another. If `/subscribe` replay is wrong while storage is correct, that is a product-path failure, not a reason to pass by falling back to filesystem reads.
 
 ### Checkers
 
 Checkers turn observations into contracts:
 
-- physical invariants: seq ordering, valid event shape, non-empty commit revs,
-  valid segment block metadata;
-- final-state comparison: reconstruct observed rows and compare to simulator
-  world state;
-- event-log equivalence: compare normalized observed rows to simulator
-  firehose-derived expected rows;
-- compaction invariants: prove rows that must be removed at or below a
-  watermark are absent, while rows above that watermark are not over-dropped;
-- replay invariants: prove public replay surfaces match archive observations
-  and normalized event expectations;
-- failure-contract assertions: prove faults fail loud, preserve prior durable
-  state, or drop invalid upstream data with bounded diagnostics as specified.
+- physical invariants: seq ordering, valid event shape, non-empty commit revs, valid segment block metadata;
+- final-state comparison: reconstruct observed rows and compare to simulator world state;
+- event-log equivalence: compare normalized observed rows to simulator firehose-derived expected rows;
+- compaction invariants: prove rows that must be removed at or below a watermark are absent, while rows above that watermark are not over-dropped;
+- replay invariants: prove public replay surfaces match archive observations and normalized event expectations;
+- failure-contract assertions: prove faults fail loud, preserve prior durable state, or drop invalid upstream data with bounded diagnostics as specified.
 
-Final-state comparison and event-log comparison are complementary. Final state
-can converge after an intermediate event is lost; event-log equivalence catches
-that stream hole.
+Final-state comparison and event-log comparison are complementary. Final state can converge after an intermediate event is lost; event-log equivalence catches that stream hole.
 
 ### Trace Artifacts
 
-Oracle runs emit JSONL traces with monotonic trace indices and bounded payload
-digests. The trace is the practical substitute for perfect deterministic
-scheduling. It should identify:
+Oracle runs emit JSONL traces with monotonic trace indices and bounded payload digests. The trace is the practical substitute for perfect deterministic scheduling. It should identify:
 
 - scenario config, seed, mode, Go version, and fault mode;
 - generated events and compact event identities;
@@ -197,259 +132,109 @@ scheduling. It should identify:
 - shutdown, restart, and crash markers;
 - first divergence details when a checker fails.
 
-Traces should stay compact. Hash large payloads; do not dump full CARs or full
-records by default.
+Traces should stay compact. Hash large payloads; do not dump full CARs or full records by default.
 
 ### Mutation Campaign
 
-`testing/mutation` measures oracle detection power with curated, realistic
-single-edit bugs. A mutant is not a production patch; it is a bug model with a
-documented failure mode and expected detection tier. `specs/mutation.md` is the
-dedicated design guide for the campaign; the summary here is enough to place it
-in the oracle's context.
+`testing/mutation` measures oracle detection power with curated, realistic single-edit bugs. A mutant is not a production patch; it is a bug model with a documented failure mode and expected detection tier. `specs/mutation.md` is the dedicated design guide for the campaign; the summary here is enough to place it in the oracle's context.
 
 The mutation campaign is the scorecard for major oracle improvements:
 
 - new oracle capabilities should kill a mutant or explain why they cannot;
-- stale or dead mutants should be retired from the active catalog and kept in
-  `testing/mutation/RESULTS.md` with rationale;
-- every full or targeted campaign result should be appended to
-  `testing/mutation/RESULTS.md`;
+- stale or dead mutants should be retired from the active catalog and kept in `testing/mutation/RESULTS.md` with rationale;
+- every full or targeted campaign result should be appended to `testing/mutation/RESULTS.md`;
 - never "fix" production code to match a mutant.
 
-The scorecard is historical evidence, not task tracking. Active follow-up work
-belongs in GitHub issues.
+The scorecard is historical evidence, not task tracking. Active follow-up work belongs in GitHub issues.
 
 ## Oracle Tiers
 
 ### Storage And Final-State Tier
 
-This tier observes segment files directly, checks physical invariants, rebuilds
-materialized repo state, and compares it to simulator world state. It is the
-foundation for detecting archive data loss and corruption.
+This tier observes segment files directly, checks physical invariants, rebuilds materialized repo state, and compares it to simulator world state. It is the foundation for detecting archive data loss and corruption.
 
 It cannot prove public replay correctness by itself.
 
 ### Event-Log Tier
 
-This tier derives expected rows from simulator firehose history and compares
-them to normalized Jetstream observations. It is designed to detect missing
-intermediate events that final-state comparison can hide.
+This tier derives expected rows from simulator firehose history and compares them to normalized Jetstream observations. It is designed to detect missing intermediate events that final-state comparison can hide.
 
-Compaction-aware comparison may allow a missing row only when a committed
-watermark and later tombstone/update make that absence legal.
+Compaction-aware comparison may allow a missing row only when a committed watermark and later tombstone/update make that absence legal.
 
 ### Client-Driven Historical Tier
 
-This tier drives the real Go client (`github.com/bluesky-social/jetstream`)
-through the full archive-negotiation path — paginated `planBackfill` →
-`getSegment`/`getBlock` → cutover to `/subscribe-v2` — and asserts the
-documented **fold-convergence** contract on what the client replayed. This is
-the historical product-path surface: it validates what real clients replay
-through the public APIs, exercising the paginated bufferless cutover (pin
-`sealedTipSeq`, page until `plannedThroughSeq` reaches it, connect once) that a
-bespoke whole-archive `/subscribe?cursor=0` replay lacks.
+This tier drives the real Go client (`github.com/bluesky-social/jetstream`) through the full archive-negotiation path — paginated `planBackfill` → `getSegment`/`getBlock` → cutover to `/subscribe-v2` — and asserts the documented **fold-convergence** contract on what the client replayed. This is the historical product-path surface: it validates what real clients replay through the public APIs, exercising the paginated bufferless cutover (pin `sealedTipSeq`, page until `plannedThroughSeq` reaches it, connect once) that a bespoke whole-archive `/subscribe?cursor=0` replay lacks.
 
-The client is an **observation surface only**, and the check is
-eventually-consistent, not point-in-time: the oracle folds the full emitted
-stream (creates/updates apply; deletes/account-deletes/syncs remove) and
-compares the converged result against ground truth derived independently from
-simulator world state and the firehose history — matching a dead record's
-killer to a DID-level marker by DID, never comparing the client against itself.
-The contract is at-least-once with no silent loss of in-scope retrievable data;
-transient stale rows that a later marker kills are expected, not a violation.
-Because the client and Jetstream share `atmos` (and the client shares the
-segment decoders with the server), the direct segment and event-log tiers remain
-the independent storage check that distinguishes a server bug from a client bug
-— the client tier runs alongside them, not instead.
+The client is an **observation surface only**, and the check is eventually-consistent, not point-in-time: the oracle folds the full emitted stream (creates/updates apply; deletes/account-deletes/syncs remove) and compares the converged result against ground truth derived independently from simulator world state and the firehose history — matching a dead record's killer to a DID-level marker by DID, never comparing the client against itself. The contract is at-least-once with no silent loss of in-scope retrievable data; transient stale rows that a later marker kills are expected, not a violation. Because the client and Jetstream share `atmos` (and the client shares the segment decoders with the server), the direct segment and event-log tiers remain the independent storage check that distinguishes a server bug from a client bug — the client tier runs alongside them, not instead.
 
-The client emits jetstream's own seq, so the drain stops at a jetstream-seq
-watermark (e.g. the steady compaction watermark), not the simulator's upstream
-relay cursor — the two spaces do not map.
+The client emits jetstream's own seq, so the drain stops at a jetstream-seq watermark (e.g. the steady compaction watermark), not the simulator's upstream relay cursor — the two spaces do not map.
 
 ### Live-Tail Replay Tier
 
-This tier treats `/subscribe` replay as a first-class observation surface for
-its real role — the recent live tail. It covers mid-stream cursors, boundary
-cursors around blocks and segments, compaction watermarks, and selected
-filters. It does **not** replay the whole archive from cursor zero; historical
-reads go through the client-driven tier above (the archive transport real
-clients use), per issue #77.
+This tier treats `/subscribe` replay as a first-class observation surface for its real role — the recent live tail. It covers mid-stream cursors, boundary cursors around blocks and segments, compaction watermarks, and selected filters. It does **not** replay the whole archive from cursor zero; historical reads go through the client-driven tier above (the archive transport real clients use), per issue #77.
 
-The replay tier validates hot tail / cold reader handoff, cursor semantics,
-JSON encoding (v1 and v2 wire shapes), pending writer snapshots, manifest
-refresh, and compaction cache invalidation.
+The replay tier validates hot tail / cold reader handoff, cursor semantics, JSON encoding (v1 and v2 wire shapes), pending writer snapshots, manifest refresh, and compaction cache invalidation.
 
 ### XRPC Segment Egress Tier
 
-This tier downloads archive segments through public XRPC/HTTP paths, decodes
-the bytes independently, and compares them to filesystem and expected event
-observations. It validates manifest readiness, cache behavior, headers,
-checksums, block indexes, and post-compaction refresh.
+This tier downloads archive segments through public XRPC/HTTP paths, decodes the bytes independently, and compares them to filesystem and expected event observations. It validates manifest readiness, cache behavior, headers, checksums, block indexes, and post-compaction refresh.
 
 ### Crash And Restart Tier
 
-This tier kills real child processes and reopens real persistent state. It
-must not be replaced with in-memory storage. Enumerated crashpoints and seeded
-crashpoint ordinals are the preferred mutation-gated form because failures
-replay exactly; random wall-clock kills are not part of the mutation campaign
-contract.
+This tier kills real child processes and reopens real persistent state. It must not be replaced with in-memory storage. Enumerated crashpoints and seeded crashpoint ordinals are the preferred mutation-gated form because failures replay exactly; random wall-clock kills are not part of the mutation campaign contract.
 
-Beyond "no records lost across a crash," this tier lands **durable
-intermediate events** through the merge so it can exercise the lost-intermediate
-and no-permanent-tombstone contracts the storage tier's final-state check is
-blind to (per §180-182). Because a production PDS's `getRepo` serves only the
-current head (creates, never updates/deletes), the only way a durable
-update/delete/tombstone reaches disk is via the live firehose at a rev above the
-backfill head. The harness reproduces that exactly: a `OnGetRepoServed` timing
-signal tells the simulator (running in the parent process) that a DID's backfill
-head is pinned, after which it generates a seed-derived chain on the live
-firehose that survives the merge rev-filter. The chains are pinned shapes with
-seed-varied specifics (account/collection/rkey/payload), so every run exercises
-the same seams while the nightly sweep explores the state space:
+Beyond "no records lost across a crash," this tier lands **durable intermediate events** through the merge so it can exercise the lost-intermediate and no-permanent-tombstone contracts the storage tier's final-state check is blind to (per §180-182). Because a production PDS's `getRepo` serves only the current head (creates, never updates/deletes), the only way a durable update/delete/tombstone reaches disk is via the live firehose at a rev above the backfill head. The harness reproduces that exactly: a `OnGetRepoServed` timing signal tells the simulator (running in the parent process) that a DID's backfill head is pinned, after which it generates a seed-derived chain on the live firehose that survives the merge rev-filter. The chains are pinned shapes with seed-varied specifics (account/collection/rkey/payload), so every run exercises the same seams while the nightly sweep explores the state space:
 
-- R_bf create→update and create→delete (a backfilled create superseded by a
-  live mutation — the rev-filter survival boundary, and the §180-182 lost-create
-  shape);
+- R_bf create→update and create→delete (a backfilled create superseded by a live mutation — the rev-filter survival boundary, and the §180-182 lost-create shape);
 - R_live create→update→delete (a record born entirely in the live window);
-- R_live delete→recreate on a reused rkey (record-level no-permanent-tombstone:
-  the recreate above the tombstone must reconstruct visible);
+- R_live delete→recreate on a reused rkey (record-level no-permanent-tombstone: the recreate above the tombstone must reconstruct visible);
 - account-delete→reactivate→post (DID-level no-permanent-tombstone);
-- #sync divergence (a silent mutation + #sync forces a verifier getRepo resync
-  whose KindSync tombstone + KindCreateResync rows must survive the merge and
-  rebuild the full repo — landed on an early-served DID so the async resync
-  completes before cutover);
-- control guards (a live create-only record and a pure-backfill untouched DID)
-  so a fixture that lands nothing fails loud rather than passing vacuously.
+- #sync divergence (a silent mutation + #sync forces a verifier getRepo resync whose KindSync tombstone + KindCreateResync rows must survive the merge and rebuild the full repo — landed on an early-served DID so the async resync completes before cutover);
+- control guards (a live create-only record and a pure-backfill untouched DID) so a fixture that lands nothing fails loud rather than passing vacuously.
 
-Three post-restart checks run over the recovered segments: final-state
-`Compare` (existing); at-least-once event-log **coverage** (every model-derived
-durable row is present at least once, tolerant of the contract-permitted
-re-merge duplicate, sensitive to loss); and the compaction contract via
-fold-convergence (fold the recovered stream and compare the converged result to
-ground truth). The expected side is model-derived from the chain the test issued
-(oracle independence), using on-disk seqs only to position the
-watermark-compaction filter.
+Three post-restart checks run over the recovered segments: final-state `Compare` (existing); at-least-once event-log **coverage** (every model-derived durable row is present at least once, tolerant of the contract-permitted re-merge duplicate, sensitive to loss); and the compaction contract via fold-convergence (fold the recovered stream and compare the converged result to ground truth). The expected side is model-derived from the chain the test issued (oracle independence), using on-disk seqs only to position the watermark-compaction filter.
 
-The convergence-hiding compaction over-drop (#100) is NOT reachable here: the
-merge-tail compaction snapshot always spans the whole sealed stream, so every
-drop decision is complete. That check's end-to-end proof lived in the
-steady-state tier (mutation `m025`), where a delete arriving after the pass's
-force-rotate sits above the watermark and a survivor can be wrongly dropped
-while final state still converges. `m025` was retired when its
-`Set.SnapshotRange` mechanism was deleted in #178 (the on-disk windowed fold can
-no longer reach the above-watermark over-drop it modelled). #183's re-derivation
-analysis concluded that NO single-edit mutant can uniquely trip the recorder
-under the windowed-fold architecture: the pass folds its tombstones from the
-exact on-disk window it compacts (so every legitimately-folded drop is also
-approved by the recorder's identically-bounded filter — invisible to it), and
-the only edits that manufacture a filter-illegal drop (seq-comparison or
-seq-value corruption, whose sole new victim is the self-superseding update row)
-are maximal and die at after-merge final-state Compare on every seed. The
-recorder is therefore a **regression assertion without a gated mutant**: it
-still runs on every lifecycle run, and its unique power reactivates only if a
-future change reintroduces an out-of-window tombstone source (an in-memory
-readout, a cross-window cache) — whoever makes such a change must re-derive a
-mutant for it then. Full argument: the 2026-07-04 section of
-`testing/mutation/RESULTS.md`.
+The convergence-hiding compaction over-drop (#100) is NOT reachable here: the merge-tail compaction snapshot always spans the whole sealed stream, so every drop decision is complete. That check's end-to-end proof lived in the steady-state tier (mutation `m025`), where a delete arriving after the pass's force-rotate sits above the watermark and a survivor can be wrongly dropped while final state still converges. `m025` was retired when its `Set.SnapshotRange` mechanism was deleted in #178 (the on-disk windowed fold can no longer reach the above-watermark over-drop it modelled). #183's re-derivation analysis concluded that NO single-edit mutant can uniquely trip the recorder under the windowed-fold architecture: the pass folds its tombstones from the exact on-disk window it compacts (so every legitimately-folded drop is also approved by the recorder's identically-bounded filter — invisible to it), and the only edits that manufacture a filter-illegal drop (seq-comparison or seq-value corruption, whose sole new victim is the self-superseding update row) are maximal and die at after-merge final-state Compare on every seed. The recorder is therefore a **regression assertion without a gated mutant**: it still runs on every lifecycle run, and its unique power reactivates only if a future change reintroduces an out-of-window tombstone source (an in-memory readout, a cross-window cache) — whoever makes such a change must re-derive a mutant for it then. Full argument: the 2026-07-04 section of `testing/mutation/RESULTS.md`.
 
 ### Store-Fault Tier
 
-This tier injects deterministic local persistence failures at high-risk store
-boundaries. It tests fail-loud and no-corruption contracts for cursor saves,
-seq/next writes, repo status writes, syncstate commits, compaction watermark
-updates, and manifest refreshes.
+This tier injects deterministic local persistence failures at high-risk store boundaries. It tests fail-loud and no-corruption contracts for cursor saves, seq/next writes, repo status writes, syncstate commits, compaction watermark updates, and manifest refreshes.
 
 ### Simulator Fidelity Tier
 
-This tier expands upstream behavior beyond polite happy paths: identity
-events, account statuses, unknown lexicons, Unicode, near-limit records,
-oversized fields, malformed bounded frames, missing CAR blocks, sequence gaps,
-duplicates, and reconnect/resume edge cases.
+This tier expands upstream behavior beyond polite happy paths: identity events, account statuses, unknown lexicons, Unicode, near-limit records, oversized fields, malformed bounded frames, missing CAR blocks, sequence gaps, duplicates, and reconnect/resume edge cases.
 
-Each invalid-input case must define whether Jetstream should archive surviving
-good events, drop an unarchivable event, advance a cursor, increment a metric,
-log bounded diagnostics, and continue running.
+Each invalid-input case must define whether Jetstream should archive surviving good events, drop an unarchivable event, advance a cursor, increment a metric, log bounded diagnostics, and continue running.
 
 The adversarial ingest-gate modes (#204) set the tier's conventions:
 
-- **Bad records go through the real pipeline, not around it.** A malformed op
-  path enters via raw `mst.Tree.Insert` (bypassing `repo.Create` validation)
-  inside an otherwise-real signed commit, so atmos's verifier — which checks
-  MST consistency, not spec validity — passes it through to the ingest gate. A
-  malformed rev is signed into the inner commit. If the verifier would reject a
-  record on structure alone, feeding it in proves nothing about the gate, so we
-  don't.
-- **Each case is asserted at the layer that owns it.** Gate-owned cases assert
-  the labeled reason on `jetstream_ingest_dropped_events_total`; verifier-owned
-  cases (non-TID, future, or regressing #commit revs) assert rejection or
-  resync repair with no bad data reaching the archive.
-  `internal/simulator/world/adversarial.go` documents which cases land where.
-  One class is blocked by the wire itself: invalid UTF-8 can't ride a live
-  op.Path because CBOR text strings reject it, so that case is backfill-only.
-- **Every injected record is tracked in a ledger.**
-  `world.AdversarialLedger` records each one at generation time, and the oracle
-  filters expected event logs, final-state ground truth, and cursor-gap
-  accounting through it. This is safe in one direction: a record that was
-  wrongly archived still shows up as an extra and fails the compare. Anti-vacuity
-  is per-layer — gate-owned cases assert per-(source, reason) drop-counter
-  floors (`ExpectedDropFloors` skips verifier-layer entries, since those never
-  reach the gate counter), and verifier-owned cases prove they fired through
-  their own observable (the awaited resync-repair tombstone).
-- **Normal traffic must not touch the injected records** (`pickUntouchedRecord`
-  skips keys already in the ledger): a normal mutation of an
-  unrepresentable-but-spec-valid record would be gate-dropped as an untracked
-  event and throw off the cursor accounting.
+- **Bad records go through the real pipeline, not around it.** A malformed op path enters via raw `mst.Tree.Insert` (bypassing `repo.Create` validation) inside an otherwise-real signed commit, so atmos's verifier — which checks MST consistency, not spec validity — passes it through to the ingest gate. A malformed rev is signed into the inner commit. If the verifier would reject a record on structure alone, feeding it in proves nothing about the gate, so we don't.
+- **Each case is asserted at the layer that owns it.** Gate-owned cases assert the labeled reason on `jetstream_ingest_dropped_events_total`; verifier-owned cases (non-TID, future, or regressing #commit revs) assert rejection or resync repair with no bad data reaching the archive. `internal/simulator/world/adversarial.go` documents which cases land where. One class is blocked by the wire itself: invalid UTF-8 can't ride a live op.Path because CBOR text strings reject it, so that case is backfill-only.
+- **Every injected record is tracked in a ledger.** `world.AdversarialLedger` records each one at generation time, and the oracle filters expected event logs, final-state ground truth, and cursor-gap accounting through it. This is safe in one direction: a record that was wrongly archived still shows up as an extra and fails the compare. Anti-vacuity is per-layer — gate-owned cases assert per-(source, reason) drop-counter floors (`ExpectedDropFloors` skips verifier-layer entries, since those never reach the gate counter), and verifier-owned cases prove they fired through their own observable (the awaited resync-repair tombstone).
+- **Normal traffic must not touch the injected records** (`pickUntouchedRecord` skips keys already in the ledger): a normal mutation of an unrepresentable-but-spec-valid record would be gate-dropped as an untracked event and throw off the cursor accounting.
 
 ### Real-Data Corpus Tier
 
-This tier breaks the `atmos` closed loop by running real network bytes with
-expectations pinned by foreign implementations through stable offline
-regression tests. It lives in `internal/corpus` (separate from the lifecycle
-oracle) and runs in normal CI; the `corpus` mutation tier gates it.
+This tier breaks the `atmos` closed loop by running real network bytes with expectations pinned by foreign implementations through stable offline regression tests. It lives in `internal/corpus` (separate from the lifecycle oracle) and runs in normal CI; the `corpus` mutation tier gates it.
 
-Four fixture families, all under `internal/corpus/testdata/` with provenance
-and the re-capture procedure in its README:
+Four fixture families, all under `internal/corpus/testdata/` with provenance and the re-capture procedure in its README:
 
-- a contiguous raw relay firehose window (byte-for-byte websocket frames)
-  replayed through the complete production live path — atmos frame decode,
-  offline Sync 1.1 signature verification against captured DID documents,
-  ConvertEvent, ingest, segment seal — with the v1 JSON output required to
-  match what production Jetstream v1 (an independent implementation) served
-  concurrently for the same events;
-- a production getRepo CAR (maintainer-owned repo) through the backfill
-  handler, with rows and recomputed record CIDs compared to a listing pinned
-  by indigo's `goat` at capture time;
-- a byte-pinned golden sealed segment built from the real CAR's records,
-  compared byte-exactly on the write side and opened through the full reader
-  path on the read side — the committed bytes are facts from a known-good
-  build, so a symmetric writer+reader bug (the m009 class the closed loop
-  structurally cannot see) fails against them from both directions;
-- malformed variants derived mechanically from the real bytes (truncated
-  frames, bit flips, cut CARs) asserting the drop-and-continue and fail-loud
-  contracts on production-shaped garbage.
+- a contiguous raw relay firehose window (byte-for-byte websocket frames) replayed through the complete production live path — atmos frame decode, offline Sync 1.1 signature verification against captured DID documents, ConvertEvent, ingest, segment seal — with the v1 JSON output required to match what production Jetstream v1 (an independent implementation) served concurrently for the same events;
+- a production getRepo CAR (maintainer-owned repo) through the backfill handler, with rows and recomputed record CIDs compared to a listing pinned by indigo's `goat` at capture time;
+- a byte-pinned golden sealed segment built from the real CAR's records, compared byte-exactly on the write side and opened through the full reader path on the read side — the committed bytes are facts from a known-good build, so a symmetric writer+reader bug (the m009 class the closed loop structurally cannot see) fails against them from both directions;
+- malformed variants derived mechanically from the real bytes (truncated frames, bit flips, cut CARs) asserting the drop-and-continue and fail-loud contracts on production-shaped garbage.
 
-Independence discipline: fixture expectations must never be derived with
-atmos. The capture tool is built on `bluesky-social/indigo` and is
-deliberately NOT committed (indigo must not enter this module's dependency
-graph); its source is preserved on issue #32. Manifest event counts serve as
-anti-vacuity assertions, and the committed corpus stays small (~640 KiB) —
-production incident fixtures can be added as new windows via the documented
-re-capture procedure.
+Independence discipline: fixture expectations must never be derived with atmos. The capture tool is built on `bluesky-social/indigo` and is deliberately NOT committed (indigo must not enter this module's dependency graph); its source is preserved on issue #32. Manifest event counts serve as anti-vacuity assertions, and the committed corpus stays small (~640 KiB) — production incident fixtures can be added as new windows via the documented re-capture procedure.
 
 ### Soak Tier
 
-This tier runs repeated traffic, compaction, restart, replay, and final
-comparison cycles to catch accumulation bugs: watermark drift, manifest/cache
-growth, goroutine leaks, tombstone memory growth, and slow cursor divergence.
+This tier runs repeated traffic, compaction, restart, replay, and final comparison cycles to catch accumulation bugs: watermark drift, manifest/cache growth, goroutine leaks, tombstone memory growth, and slow cursor divergence.
 
 Soak belongs in manual or scheduled runs, not the default developer loop.
 
 ### Determinism Experiments Tier
 
-This tier explores `testing/synctest`, in-process transport, fake time, and
-in-memory storage for narrow logical slices. Adoption should depend on measured
-value: fewer flakes, clearer failures, or materially faster tests.
+This tier explores `testing/synctest`, in-process transport, fake time, and in-memory storage for narrow logical slices. Adoption should depend on measured value: fewer flakes, clearer failures, or materially faster tests.
 
 Do not move public serving or crash durability checks into fake I/O modes.
 
@@ -469,11 +254,7 @@ When adding a new oracle capability:
 
 ### Adding Simulator Behavior
 
-Simulator additions should preserve deterministic-enough input generation for
-seeded runs. Use logical clocks and seeded RNGs where output bytes or trace
-facts depend on time or randomness. If a behavior is intentionally adversarial
-or nondeterministic, put it behind an explicit scenario mode and trace what it
-did.
+Simulator additions should preserve deterministic-enough input generation for seeded runs. Use logical clocks and seeded RNGs where output bytes or trace facts depend on time or randomness. If a behavior is intentionally adversarial or nondeterministic, put it behind an explicit scenario mode and trace what it did.
 
 ### Adding Mutants
 
@@ -487,22 +268,16 @@ Only add mutants that model a realistic single-edit bug. Every mutant should:
 
 ### Updating Documentation
 
-Keep this document focused on durable design and contracts. Do not add task
-lists or implementation progress here. Use GitHub issues for active work; the
-current testing revamp epic is #35.
+Keep this document focused on durable design and contracts. Do not add task lists or implementation progress here. Use GitHub issues for active work; the current testing revamp epic is #35.
 
-Keep `testing/mutation/RESULTS.md` as the mutation scorecard. It is historical
-evidence and should not be folded into this design document.
+Keep `testing/mutation/RESULTS.md` as the mutation scorecard. It is historical evidence and should not be folded into this design document.
 
 ## Current Work Tracking
 
 Active oracle testing work is tracked in GitHub issues:
 
 - #35: overall testing revamp epic;
-- child issues for product replay, XRPC egress, crash/fault depth, simulator
-  fidelity, corpus, soak, and determinism experiments;
+- child issues for product replay, XRPC egress, crash/fault depth, simulator fidelity, corpus, soak, and determinism experiments;
 - targeted issues for specific mutation escapes or coverage gaps.
 
-When an issue reveals smaller independently shippable work, split it into new
-issues rather than expanding scope in place. Close issues through commits or
-PRs with `Closes #N`.
+When an issue reveals smaller independently shippable work, split it into new issues rather than expanding scope in place. Close issues through commits or PRs with `Closes #N`.

--- a/testing/mutation/RESULTS.md
+++ b/testing/mutation/RESULTS.md
@@ -2,8 +2,8 @@
 
 Each campaign appends a dated section; history is never overwritten so the
 oracle's detection power is visible over time. See
-`docs/superpowers/specs/2026-06-12-oracle-mutation-campaign-design.md` for the
-method and `testing/mutation/run.sh` for the driver.
+`specs/mutation.md` for the method and `testing/mutation/run.sh` for the
+driver.
 
 **Current catalog (keep this line current): 35 active mutants on disk
 (m001–m043; m007, m010, m013, m014, m020, m021, m023, m025 retired). Current

--- a/testing/mutation/run.sh
+++ b/testing/mutation/run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Oracle mutation campaign driver.
-# See docs/superpowers/specs/2026-06-12-oracle-mutation-campaign-design.md
+# See specs/mutation.md
 #
 # Usage:
 #   testing/mutation/run.sh                 # run every mutant


### PR DESCRIPTION
Closes #216.

## What this does

Adds a set of living documents aimed at agents (reviewed by humans) to speed up future work and cut down on repeated mistakes, plus cleans up cross-reference rot found along the way.

### New `specs/` docs
- **`architecture.md`** — high-level map of the ingest / storage / serve subsystems and the test rig, ending with a "where to look" routing table. Defers to `docs/README.md` as authoritative.
- **`invariants.md`** — the short list of rules that must never break, each linking to the `docs/README.md` section that elaborates it.
- **`glossary.md`** — one-line definitions of the terms used throughout the code and docs.
- **`gotchas.md`** — accepted limitations and hard-won lessons: the knowledge category that previously lived only in per-session memory.

### Package docs
- Added `internal/oracle/doc.go` (defines the synctest *bubble* and the observer/checker/driver/tier vocabulary) and `internal/simulator/doc.go` (world/http/fanout).
- Demoted the per-file `// Package X: foo.go ...` comments in `backfill/` and `orchestrator/` to plain file comments, separated from the `package` clause by a blank line so godoc exposes only the canonical `doc.go`. Verified with `go doc`.

### AGENTS.md
- Refreshed the layout tree (was missing ~13 internal packages).
- Added an Orientation pointer to the new living docs with a reading order.
- Added a change-class → required `just` recipe table and a memory-promotion rule.

### Reference cleanup (folded in)
- Repointed every `DESIGN.md` citation to `docs/README.md` (the file was renamed; the §-anchors still resolve).
- Repointed `docs/superpowers/specs/...` paths to `specs/notes/...` (moved file).
- Dropped the two dangling `DESIGN.md §6.3` cross-references (the Replication section they cited was dropped), keeping the inline explanation.

## Scope changes vs the issue
Recorded in a comment on #216:
- **Notes index + notes-lifecycle rule: dropped.** A `specs/notes/` index isn't worth the maintenance surface; without it there's no lifecycle rule to attach.
- **Invariants hoist: relocated.** `docs/README.md` is human-owned, so the invariants summary lives in the new `specs/invariants.md` and links back to it rather than editing it.

## Verification
`go build ./...`, `go vet`, and `just lint` (0 issues) all pass. `go doc` confirms `backfill`/`orchestrator` now surface the canonical `doc.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)