### PR TITLE
oracle: pace generateN below atmos's per-DID queue cap

### DIFF
--- a/internal/oracle/harness_test.go
+++ b/internal/oracle/harness_test.go
@@ -1307,7 +1307,17 @@ func generateN(t *testing.T, w *world.World, n int) {
 		// and skips the gap. Periodically yield so the consumer keeps pace,
 		// mirroring the real-time interleaving a socket run gets for free. A
 		// no-op outside a bubble (restart tier), so it stays correct there.
-		if (i+1)%128 == 0 {
+		//
+		// The interval is load-bearing (#266): atmos's per-DID FIFO scheduler
+		// drops the oldest queued event when a single DID accumulates more
+		// than keyQueueCap = Parallelism*2 = 64 in-flight events, and a drop
+		// permanently breaks the seqAck contiguity wait. drain() returns only
+		// once every bubble goroutine is durably blocked, i.e. the scheduler
+		// queues have fully flushed, so an interval strictly below the cap
+		// makes same-DID overflow impossible (worst case: every event in the
+		// interval targets one DID) — even under host CPU starvation. 32
+		// rather than 64 leaves headroom in case atmos halves the cap.
+		if (i+1)%32 == 0 {
 			drain()
 		}
 	}


### PR DESCRIPTION
## Context

`just oracle-sweep` intermittently failed `TestOracle_DefaultLifecycle` (stress mode) with a contiguity-wait timeout when host CPU contention starved atmos's per-DID verify worker. Full analysis in #266; summary:

- `generateN` emits all steady events in zero fake-time inside the synctest bubble, draining only every 128 events.
- atmos's per-DID FIFO scheduler (default `Parallelism = 32`, per-DID queue cap `Parallelism*2 = 64`) **drops the oldest queued event** when a single DID exceeds the cap — by design, as OOM protection against hot accounts.
- The simulator's Zipfian author draw concentrates traffic on one hot DID, so >64 same-DID arrivals between drains becomes possible when contention starves the worker; the failing run logged 119 drops, all one DID.
- A single drop makes `seqAck`'s gap-free contiguity wait permanently unsatisfiable → bare timeout. Not a Jetstream bug: the *simulated upstream* discarded the events before Jetstream ever saw them.

## Fix

Option 1 from the issue (pace generation to the queue): tighten the drain cadence from every 128 events to every 32.

This is airtight, not just probabilistic: `drain()` (`synctest.Wait`) returns only once every other bubble goroutine is durably blocked — the scheduler queues have fully flushed — so with an interval strictly below the cap, same-DID overflow is impossible even in the worst case where every event in the interval targets one DID. Everything in the chain (pipe listener, in-memory dial, workers) is bubble-internal, so the flush guarantee holds. 32 rather than 64 leaves headroom in case a future atmos version halves the cap. The comment at the change site documents the interval as load-bearing.

The oracle keeps `Parallelism = 32` (production parity), preserving the out-of-order batch-completion coverage the `seqAck` design calls out as the crux.

## Verification

- `just` (lint + short suite): 2146 tests pass
- `just test-long ./internal/oracle`: 211 tests pass
- Stress mode with the originally failing seed `18071793876353772706`: PASS, zero `event dropped` warnings
- 12 concurrent stress instances under mutual CPU contention on the fixed binary: 12/12 PASS, zero drops
- Mutant overlap checked: no mutation patch touches `generateN` (m034 mentions harness_test.go in prose only)

Fixes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)