### PR TITLE
livestream: classify atmos DropError as verify-queue loss, not decode error

### DIFF
--- a/internal/ingest/live/consumer.go
+++ b/internal/ingest/live/consumer.go
@@ -521,6 +521,12 @@ func (c *Consumer) Run(ctx context.Context) error {
 //     ahead of the relay (cursor corruption or a relay restored from an
 //     older backup) and never self-resolves — the labeled counter is the
 //     operator's signal to intervene.
+//   - DropError: atmos's parallel verifier shed an event because one DID
+//     overflowed its per-DID verify queue. PERMANENT local archival loss —
+//     the event was received but never stored, and the watermark advances
+//     past it — so it must not be miscounted as a decode error (#266's
+//     side finding). The count folds in coalesced drops so the metric is
+//     exact loss accounting.
 //   - anything else: a garbage frame we chose to skip (decode error).
 func (c *Consumer) noteStreamError(ctx context.Context, err error) {
 	if gap, ok := errors.AsType[*streaming.GapError](err); ok {
@@ -546,6 +552,16 @@ func (c *Consumer) noteStreamError(ctx context.Context, err error) {
 		c.logger.WarnContext(ctx, "error frame from relay",
 			"code", se.Code,
 			"message", se.Message,
+		)
+		return
+	}
+	if de, ok := errors.AsType[*streaming.DropError](err); ok {
+		c.cfg.Metrics.noteVerifyQueueDrops(de.AdditionalDropsSuppressed + 1)
+		c.logger.WarnContext(ctx, "verify queue overflow dropped event",
+			"did", de.DID,
+			"seq", de.Seq,
+			"queue_len", de.QueueLen,
+			"additional_drops_suppressed", de.AdditionalDropsSuppressed,
 		)
 		return
 	}

--- a/internal/ingest/live/consumer_test.go
+++ b/internal/ingest/live/consumer_test.go
@@ -320,6 +320,49 @@ func TestProcessBatch_MalformedCommitDoesNotShutDownConsumer(t *testing.T) {
 		"the skipped malformed event must be visible in decode_errors_total")
 }
 
+// TestNoteStreamError_DropErrorClassifiedAsVerifyQueueLoss pins the
+// stream-error taxonomy for atmos's *DropError (#266 side finding): a
+// per-DID verify-queue overflow is permanent local archival loss and
+// must land on its own counter — folding in the coalesced-drop count
+// for exact loss accounting — not on decode_errors_total, whose
+// remediation story (malformed frames, upgrade/ignore) is unrelated.
+func TestNoteStreamError_DropErrorClassifiedAsVerifyQueueLoss(t *testing.T) {
+	t.Parallel()
+
+	st := newTestStore(t)
+	dir := filepath.Join(t.TempDir(), "live_segments")
+	metrics := NewMetrics(prometheus.NewRegistry())
+
+	c, err := Open(Config{
+		SegmentsDir: dir,
+		Store:       st,
+		SeqKey:      "live_segments/seq/next",
+		CursorKey:   "relay/cursor",
+		RelayURL:    "https://example.invalid",
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Verifier:    newTestVerifier(t),
+		Metrics:     metrics,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	c.noteStreamError(t.Context(), &streaming.DropError{
+		DID: "did:plc:hot", Seq: 42, QueueLen: 64,
+	})
+	require.InDelta(t, 1.0, testutil.ToFloat64(metrics.VerifyQueueDrops), 0,
+		"a lone DropError must count exactly one lost event")
+
+	c.noteStreamError(t.Context(), &streaming.DropError{
+		DID: "did:plc:hot", Seq: 99, QueueLen: 64,
+		AdditionalDropsSuppressed: 4,
+	})
+	require.InDelta(t, 6.0, testutil.ToFloat64(metrics.VerifyQueueDrops), 0,
+		"coalesced drops must fold into the counter (1 + 4 more on the second error)")
+
+	require.InDelta(t, 0.0, testutil.ToFloat64(metrics.DecodeErrors), 0,
+		"verify-queue loss must NOT be miscounted as a decode error")
+}
+
 func TestProcessBatch_OverwideRecordKeyDoesNotShutDownConsumer(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ingest/live/metrics.go
+++ b/internal/ingest/live/metrics.go
@@ -17,6 +17,7 @@ type Metrics struct {
 	SequenceGaps          prometheus.Counter
 	SequenceGapMissedSeqs prometheus.Counter
 	UnknownEvents         prometheus.Counter
+	VerifyQueueDrops      prometheus.Counter
 	StreamErrorFrames     *prometheus.CounterVec
 	StaleResyncsDropped   prometheus.Counter
 	ReplayedAccountsDrop  prometheus.Counter
@@ -69,6 +70,19 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 				"advances past them once later events flush, so they are NOT re-delivered " +
 				"to a future build unless it re-backfills the range.",
 		}),
+		VerifyQueueDrops: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: metricsNamespace, Subsystem: metricsSubsystem,
+			Name: "verify_queue_dropped_events_total",
+			Help: "Number of upstream events atmos's parallel verifier discarded because " +
+				"a single DID overflowed its per-DID verify queue (drop-oldest, cap = " +
+				"Parallelism*2). Each one is PERMANENT archival loss for that DID: the " +
+				"event was received but never verified or stored, and the watermark " +
+				"cursor advances past it, so no reconnect re-delivers it. Includes " +
+				"coalesced drops (DropError.AdditionalDropsSuppressed). A sustained " +
+				"rate means one hot account is outrunning verification — distinct from " +
+				"decode_errors_total (malformed frames) and sequence_gaps_total " +
+				"(relay-side loss).",
+		}),
 		StreamErrorFrames: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: metricsNamespace, Subsystem: metricsSubsystem,
 			Name: "stream_error_frames_total",
@@ -115,7 +129,7 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 	reg.MustRegister(
 		m.EventsReceived, m.Reconnects,
 		m.DecodeErrors, m.SequenceGaps, m.SequenceGapMissedSeqs,
-		m.UnknownEvents, m.StreamErrorFrames, m.StaleResyncsDropped,
+		m.UnknownEvents, m.VerifyQueueDrops, m.StreamErrorFrames, m.StaleResyncsDropped,
 		m.ReplayedAccountsDrop, m.ReplayedIdentityDrop, m.UpstreamCursor,
 	)
 	return m
@@ -151,6 +165,12 @@ func (m *Metrics) noteSequenceGap(missed int64) {
 func (m *Metrics) incUnknownEvents() {
 	if m != nil {
 		m.UnknownEvents.Inc()
+	}
+}
+
+func (m *Metrics) noteVerifyQueueDrops(n uint64) {
+	if m != nil && n > 0 {
+		m.VerifyQueueDrops.Add(float64(n))
 	}
 }
 


### PR DESCRIPTION
## Context

Side finding from the #266 investigation (see PR #270 for the oracle-side fix).

atmos's parallel verifier (`Parallelism > 1`, the production default) sheds events when a single DID overflows its per-DID verify queue (drop-oldest, cap = `Parallelism*2`), reporting each shed as a typed `*streaming.DropError` with bursts coalesced via `AdditionalDropsSuppressed`. Each shed event is **permanent local archival loss**: received but never verified or stored, and atmos's watermark advances past it by design, so no reconnect re-delivers it.

`noteStreamError` had typed arms for `GapError`, `UnknownFrameError`, and `StreamError`, but `DropError` fell through to the catch-all and incremented `decode_errors_total` — real archival loss misread as "malformed frames received", the wrong severity and remediation story.

## Changes

- `internal/ingest/live/consumer.go` — typed `*streaming.DropError` arm in `noteStreamError` before the decode-error fallthrough; logs `did`, `seq`, `queue_len`, `additional_drops_suppressed`. Taxonomy doc comment updated.
- `internal/ingest/live/metrics.go` — new counter `jetstream_livestream_verify_queue_dropped_events_total` counting exact loss (`AdditionalDropsSuppressed + 1` per DropError, per atmos's coalescing contract), with help text distinguishing it from `decode_errors_total` (malformed frames) and `sequence_gaps_total` (relay-side loss). Nil-safe helper follows the package pattern.
- `internal/ingest/live/consumer_test.go` — `TestNoteStreamError_DropErrorClassifiedAsVerifyQueueLoss` pins the taxonomy: a lone drop counts 1, a coalesced drop folds in the suppressed count (1 + 4 → 6 total), and `decode_errors_total` stays at zero.

Out of scope (deliberately, per #271): whether production should get a lossless/backpressure option for the verify queue — that's a separate atmos design question.

## Verification

- `just` (lint + full short suite): 2147 tests pass
- New test exercises both the lone and coalesced DropError paths

Fixes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)