### PR TITLE
obs: add upstream firehose freshness metrics

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -630,6 +630,36 @@ These will be configurable over time as we scale.
 
 This is of course an implementation detail of the Bluesky-hosted instance. Others can do what they please.
 
+### 7.1 Operational Freshness and Crash Diagnostics
+
+The debug listener exposes `/healthz`, `/readyz`, `/metrics`, and pprof.
+`/readyz` only means both HTTP listeners are bound and serving; it is not an
+ingest-health or steady-state signal. Use `/status` and Prometheus metrics for
+the ingestion view.
+
+Normal steady-state relay freshness is exported as two gauges:
+
+- `jetstream_current_timestamp_seconds` — current Unix timestamp at scrape time.
+- `jetstream_livestream_last_seen_upstream_event_timestamp_seconds` — the last
+  local time the steady-state live consumer observed a normal upstream
+  `subscribeRepos` event. Bootstrap, backfill, merge replay, failed-repo retry,
+  sync-triggered or synthetic data resyncs, and import/compaction work do not
+  update it.
+
+A typical alert is:
+
+```promql
+jetstream_livestream_last_seen_upstream_event_timestamp_seconds > 0
+and
+jetstream_current_timestamp_seconds
+  - jetstream_livestream_last_seen_upstream_event_timestamp_seconds > 30
+```
+
+Jetstream preserves crash-loud behavior for internal corruption and persistence
+failures. Set `GOTRACEBACK=all` in production service units so a crash includes
+all goroutines; the runtime also logs panics from long-lived goroutine roots in
+structured logs with build metadata before re-panicking.
+
 ## 8. Timestamp Import
 
 Any new firehose indexer has the same problem: it stamps every record with roughly the time it backfilled, so a post from 2022 looks like it was made today. `createdAt` doesn't save us — it's client-supplied and spoofable, which is both a bad product experience and a trust-and-safety hole. To build a real AppView you have to carry over the original indexer's timestamps. Bluesky's dataplane has been running since 2022 and has them; a fresh jetstream does not.

--- a/internal/ingest/live/config.go
+++ b/internal/ingest/live/config.go
@@ -156,6 +156,15 @@ type Config struct {
 	// longer-lived consumer.
 	OnEvent func(*segment.Event)
 
+	// OnUpstreamEventSeen is called when this consumer observes a normal
+	// upstream subscribeRepos event. The orchestrator wires this only for the
+	// steady-state live consumer; bootstrap-live capture deliberately leaves it
+	// nil so freshness metrics reflect normal relay interaction only.
+	//
+	// Synthetic verifier resync events and upstream #sync resync deliveries do
+	// not trigger this hook.
+	OnUpstreamEventSeen func(time.Time)
+
 	// OnAfterSeal is forwarded to the inner ingest.Writer's
 	// Config.OnAfterSeal. See internal/ingest.Config.OnAfterSeal for
 	// the full contract. Optional.

--- a/internal/ingest/live/consumer.go
+++ b/internal/ingest/live/consumer.go
@@ -573,7 +573,8 @@ func (c *Consumer) noteStreamError(ctx context.Context, err error) {
 // processBatch writes one batch of decoded events into the writer.
 func (c *Consumer) processBatch(ctx context.Context, batch []streaming.Event) error {
 	return obs.Span(ctx, func(ctx context.Context) error {
-		witnessedAt := c.cfg.now().UnixMicro()
+		witnessed := c.cfg.now()
+		witnessedAt := witnessed.UnixMicro()
 
 		for _, evt := range batch {
 			c.cfg.Metrics.incEventsReceived()
@@ -671,6 +672,10 @@ func (c *Consumer) processBatch(ctx context.Context, batch []streaming.Event) er
 				return err
 			} else if stale {
 				continue
+			}
+
+			if c.cfg.OnUpstreamEventSeen != nil && evt.Resync == streaming.ResyncNone && len(segEvts) > 0 {
+				c.cfg.OnUpstreamEventSeen(witnessed)
 			}
 
 			if replayed, err := c.dropReplayedAccountEvent(ctx, segEvts); err != nil {

--- a/internal/ingest/live/consumer_test.go
+++ b/internal/ingest/live/consumer_test.go
@@ -162,6 +162,72 @@ func TestProcessBatch_UnknownEventDoesNotAdvanceCursor(t *testing.T) {
 		"unknown trailing event must not advance the cursor past it")
 }
 
+func TestProcessBatch_ObservesOrdinaryUpstreamEvents(t *testing.T) {
+	t.Parallel()
+
+	st := newTestStore(t)
+	seenAt := time.Date(2026, 7, 8, 13, 0, 0, 0, time.UTC)
+	var observed atomic.Int64
+
+	c, err := Open(Config{
+		SegmentsDir: filepath.Join(t.TempDir(), "live_segments"),
+		Store:       st,
+		SeqKey:      "live_segments/seq/next",
+		CursorKey:   "relay/cursor",
+		RelayURL:    "https://example.invalid",
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Verifier:    newTestVerifier(t),
+		now:         func() time.Time { return seenAt },
+		OnUpstreamEventSeen: func(t time.Time) {
+			observed.Store(t.Unix())
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	require.NoError(t, c.processBatch(t.Context(), []streaming.Event{
+		{Seq: 5, Identity: &comatproto.SyncSubscribeRepos_Identity{
+			DID: "did:plc:aaa", Time: "2026-05-21T00:00:00Z",
+		}},
+	}))
+	require.Equal(t, seenAt.Unix(), observed.Load())
+}
+
+func TestProcessBatch_DoesNotObserveDataResyncs(t *testing.T) {
+	t.Parallel()
+
+	st := newTestStore(t)
+	seenAt := time.Date(2026, 7, 8, 13, 0, 0, 0, time.UTC)
+	var observed atomic.Int64
+
+	c, err := Open(Config{
+		SegmentsDir: filepath.Join(t.TempDir(), "live_segments"),
+		Store:       st,
+		SeqKey:      "live_segments/seq/next",
+		CursorKey:   "relay/cursor",
+		RelayURL:    "https://example.invalid",
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Verifier:    newTestVerifier(t),
+		now:         func() time.Time { return seenAt },
+		OnUpstreamEventSeen: func(t time.Time) {
+			observed.Store(t.Unix())
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	require.NoError(t, c.processBatch(t.Context(), []streaming.Event{
+		{
+			Seq:    11,
+			Resync: streaming.ResyncSyncEvent,
+			Sync: &comatproto.SyncSubscribeRepos_Sync{
+				DID: "did:plc:aaa", Rev: "3mmoojp7vgo2g", Time: "2026-05-21T00:00:00Z",
+			},
+		},
+	}))
+	require.Zero(t, observed.Load())
+}
+
 func TestMaybeTriggerCompactionReportsCoalescedTriggers(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ingest/live/metrics.go
+++ b/internal/ingest/live/metrics.go
@@ -1,6 +1,11 @@
 package live
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 const (
 	metricsNamespace = "jetstream"
@@ -11,18 +16,21 @@ const (
 // consumer. A nil *Metrics is a valid zero-value: every method is a
 // no-op, so tests can skip metric registration entirely.
 type Metrics struct {
-	EventsReceived        prometheus.Counter
-	Reconnects            prometheus.Counter
-	DecodeErrors          prometheus.Counter
-	SequenceGaps          prometheus.Counter
-	SequenceGapMissedSeqs prometheus.Counter
-	UnknownEvents         prometheus.Counter
-	VerifyQueueDrops      prometheus.Counter
-	StreamErrorFrames     *prometheus.CounterVec
-	StaleResyncsDropped   prometheus.Counter
-	ReplayedAccountsDrop  prometheus.Counter
-	ReplayedIdentityDrop  prometheus.Counter
-	UpstreamCursor        prometheus.Gauge
+	EventsReceived                 prometheus.Counter
+	Reconnects                     prometheus.Counter
+	DecodeErrors                   prometheus.Counter
+	SequenceGaps                   prometheus.Counter
+	SequenceGapMissedSeqs          prometheus.Counter
+	UnknownEvents                  prometheus.Counter
+	VerifyQueueDrops               prometheus.Counter
+	StreamErrorFrames              *prometheus.CounterVec
+	StaleResyncsDropped            prometheus.Counter
+	ReplayedAccountsDrop           prometheus.Counter
+	ReplayedIdentityDrop           prometheus.Counter
+	UpstreamCursor                 prometheus.Gauge
+	LastSeenUpstreamEventTimestamp prometheus.Gauge
+
+	lastSeenUpstreamEventUnix atomic.Int64
 }
 
 // NewMetrics registers the livestream counters/gauges against reg.
@@ -125,12 +133,17 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 			Name: "upstream_cursor",
 			Help: "Last persisted upstream relay cursor.",
 		}),
+		LastSeenUpstreamEventTimestamp: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: metricsNamespace, Subsystem: metricsSubsystem,
+			Name: "last_seen_upstream_event_timestamp_seconds",
+			Help: "Unix timestamp in seconds when steady-state live ingest last observed an upstream subscribeRepos event.",
+		}),
 	}
 	reg.MustRegister(
 		m.EventsReceived, m.Reconnects,
 		m.DecodeErrors, m.SequenceGaps, m.SequenceGapMissedSeqs,
 		m.UnknownEvents, m.VerifyQueueDrops, m.StreamErrorFrames, m.StaleResyncsDropped,
-		m.ReplayedAccountsDrop, m.ReplayedIdentityDrop, m.UpstreamCursor,
+		m.ReplayedAccountsDrop, m.ReplayedIdentityDrop, m.UpstreamCursor, m.LastSeenUpstreamEventTimestamp,
 	)
 	return m
 }
@@ -219,4 +232,28 @@ func (m *Metrics) setUpstreamCursor(v int64) {
 	if m != nil {
 		m.UpstreamCursor.Set(float64(v))
 	}
+}
+
+// NoteLastSeenUpstreamEvent records the wall-clock time at which the
+// steady-state firehose consumer observed a real upstream relay event.
+func (m *Metrics) NoteLastSeenUpstreamEvent(t time.Time) {
+	if m == nil || t.IsZero() {
+		return
+	}
+	sec := t.Unix()
+	m.lastSeenUpstreamEventUnix.Store(sec)
+	m.LastSeenUpstreamEventTimestamp.Set(float64(sec))
+}
+
+// LastSeenUpstreamEvent returns the last timestamp recorded by
+// NoteLastSeenUpstreamEvent. A zero time means no event has been observed.
+func (m *Metrics) LastSeenUpstreamEvent() time.Time {
+	if m == nil {
+		return time.Time{}
+	}
+	sec := m.lastSeenUpstreamEventUnix.Load()
+	if sec == 0 {
+		return time.Time{}
+	}
+	return time.Unix(sec, 0).UTC()
 }

--- a/internal/ingest/live/metrics_test.go
+++ b/internal/ingest/live/metrics_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/jcalabro/atmos/streaming"
 	"github.com/prometheus/client_golang/prometheus"
@@ -44,6 +45,7 @@ func TestNewMetrics_RegistersAllSeries(t *testing.T) {
 		"jetstream_livestream_stale_resyncs_dropped_total",
 		"jetstream_livestream_replayed_account_events_dropped_total",
 		"jetstream_livestream_upstream_cursor",
+		"jetstream_livestream_last_seen_upstream_event_timestamp_seconds",
 	} {
 		_, ok := names[want]
 		require.True(t, ok, "missing metric %s", want)
@@ -110,4 +112,17 @@ func TestNoteStreamError_ClassifiesStreamErrors(t *testing.T) {
 	require.InDelta(t, 1.0, testutil.ToFloat64(metrics.StreamErrorFrames.WithLabelValues("missing")), 0)
 	require.Zero(t, testutil.ToFloat64(metrics.StreamErrorFrames.WithLabelValues("TotallyMadeUp-1")),
 		"raw upstream code must never become a label value")
+}
+
+func TestMetrics_LastSeenUpstreamEvent(t *testing.T) {
+	t.Parallel()
+
+	metrics := NewMetrics(prometheus.NewRegistry())
+	require.True(t, metrics.LastSeenUpstreamEvent().IsZero())
+
+	seen := time.Date(2026, 7, 8, 12, 34, 56, 789, time.UTC)
+	metrics.NoteLastSeenUpstreamEvent(seen)
+
+	require.True(t, metrics.LastSeenUpstreamEvent().Equal(time.Unix(seen.Unix(), 0).UTC()))
+	require.InDelta(t, float64(seen.Unix()), testutil.ToFloat64(metrics.LastSeenUpstreamEventTimestamp), 0)
 }

--- a/internal/ingest/orchestrator/steady.go
+++ b/internal/ingest/orchestrator/steady.go
@@ -74,6 +74,7 @@ func (o *Orchestrator) runSteadyState(ctx context.Context) error {
 			SegmentMetrics:        o.cfg.SegmentMetrics,
 			ReadLogRetentionBytes: o.cfg.ReadLogRetentionBytes,
 			OnEvent:               o.cfg.OnEvent,
+			OnUpstreamEventSeen:   o.cfg.LiveMetrics.NoteLastSeenUpstreamEvent,
 			OnAfterSeal:           o.cfg.IngestOnAfterSeal,
 			TimestampStamper:      o.cfg.TimestampStamper,
 			ReconnectBackoff:      o.cfg.LiveReconnectBackoff,

--- a/internal/jetstreamd/runtime.go
+++ b/internal/jetstreamd/runtime.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"runtime"
+	"runtime/debug"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -170,6 +172,7 @@ func Build(ctx context.Context, opts Options) (*Runtime, error) {
 	verifierMetrics := obs.NewVerifierMetrics(metrics.Registry)
 	subscribeMetrics := subscribe.NewMetrics(metrics.Registry)
 	manifestMetrics := manifest.NewMetrics(metrics.Registry)
+	liveMetrics := live.NewMetrics(metrics.Registry)
 
 	if err := mkdirAllRuntimeFS(opts.StorageFS, opts.DataDir, 0o755); err != nil {
 		return fail(fmt.Errorf("serve: create data dir %s: %w", opts.DataDir, err))
@@ -352,7 +355,7 @@ func Build(ctx context.Context, opts Options) (*Runtime, error) {
 		Logger:                         processLogger,
 		Metrics:                        orchestrator.NewMetrics(metrics.Registry, tombstones),
 		IngestMetrics:                  ingest.NewMetrics(metrics.Registry),
-		LiveMetrics:                    live.NewMetrics(metrics.Registry),
+		LiveMetrics:                    liveMetrics,
 		DropMetrics:                    ingest.NewDropMetrics(metrics.Registry),
 		BackfillMetrics:                backfillMetrics,
 		SegmentMetrics:                 segmentMetrics,
@@ -443,12 +446,13 @@ func Build(ctx context.Context, opts Options) (*Runtime, error) {
 	// Status collector + handler are built here (after the import manager) so
 	// the status page can surface the current import job.
 	statusCollector, err := status.New(status.Options{
-		Store:            metaStore,
-		DataDir:          opts.DataDir,
-		Manifest:         mft,
-		CursorLookback:   opts.CursorLookback,
-		IdentityResolver: resolver,
-		ImportReporter:   importReporter{mgr: importMgr},
+		Store:                 metaStore,
+		DataDir:               opts.DataDir,
+		Manifest:              mft,
+		CursorLookback:        opts.CursorLookback,
+		IdentityResolver:      resolver,
+		ImportReporter:        importReporter{mgr: importMgr},
+		LastSeenUpstreamEvent: liveMetrics.LastSeenUpstreamEvent,
 	})
 	if err != nil {
 		return fail(fmt.Errorf("serve: build status collector: %w", err))
@@ -548,13 +552,13 @@ func (r *Runtime) PublicAddr() string {
 func (r *Runtime) Run(ctx context.Context) error {
 	g, gctx := errgroup.WithContext(ctx)
 
-	g.Go(func() error {
+	g.Go(r.goroutineRoot("manifest_cancel", func() error {
 		<-gctx.Done()
 		r.cancelManifestLoad()
 		return nil
-	})
+	}))
 
-	g.Go(func() error {
+	g.Go(r.goroutineRoot("manifest_wait", func() error {
 		if err := r.manifest.Wait(gctx); err != nil {
 			if errors.Is(err, context.Canceled) {
 				return nil
@@ -562,17 +566,17 @@ func (r *Runtime) Run(ctx context.Context) error {
 			return fmt.Errorf("manifest load: %w", err)
 		}
 		return nil
-	})
+	}))
 
 	if !r.opts.Headless {
-		g.Go(func() error {
+		g.Go(r.goroutineRoot("http_server", func() error {
 			return r.server.Run(gctx)
-		})
+		}))
 	}
 
-	g.Go(func() error {
+	g.Go(r.goroutineRoot("orchestrator", func() error {
 		return r.orchestrator.Run(gctx)
-	})
+	}))
 
 	// Auto-resume a timestamp-import job that a prior process left incomplete
 	// (design Q-RESUME), but only after the steady-state writer is published:
@@ -582,7 +586,7 @@ func (r *Runtime) Run(ctx context.Context) error {
 	// re-submit. The job's background run is rooted at importRunCtx (cancelled
 	// in Close), not gctx.
 	if r.importer != nil {
-		g.Go(func() error {
+		g.Go(r.goroutineRoot("import_resume", func() error {
 			select {
 			case <-r.steadyReady:
 			case <-gctx.Done():
@@ -592,7 +596,7 @@ func (r *Runtime) Run(ctx context.Context) error {
 				r.logger.Warn("resume incomplete import failed", "err", err)
 			}
 			return nil
-		})
+		}))
 	}
 
 	// Graceful client drain. Live websocket subscribers are hijacked
@@ -605,7 +609,7 @@ func (r *Runtime) Run(ctx context.Context) error {
 	// handshake. The drain context is rooted at Background (not gctx,
 	// which is already cancelled by the time we drain) and bounded by the
 	// option, so a wedged client can't delay exit past the budget.
-	g.Go(func() error {
+	g.Go(r.goroutineRoot("client_drain", func() error {
 		<-gctx.Done()
 		drainCtx, drainCancel := context.WithTimeout(context.Background(), r.opts.ClientDrainTimeout)
 		defer drainCancel()
@@ -613,7 +617,7 @@ func (r *Runtime) Run(ctx context.Context) error {
 			r.logger.Warn("client drain did not complete within budget; severing remaining subscribers", "err", err)
 		}
 		return nil
-	})
+	}))
 
 	verifierLogger := r.processLogger.With(slog.String("component", "verifier"))
 	// Verifier async-error drain. Verification failures are
@@ -621,7 +625,7 @@ func (r *Runtime) Run(ctx context.Context) error {
 	// malformed PDS input, which is invalid user data, not a
 	// jetstream bug. We warn-log and the OnVerificationFailure hook
 	// fires for operator visibility, but never crash.
-	g.Go(func() error {
+	g.Go(r.goroutineRoot("verifier_async_errors", func() error {
 		for {
 			select {
 			case <-gctx.Done():
@@ -633,7 +637,7 @@ func (r *Runtime) Run(ctx context.Context) error {
 				verifierLogger.Warn("async error", "err", err)
 			}
 		}
-	})
+	}))
 
 	// A caller-driven shutdown surfaces as context.Canceled from
 	// the errgroup: the orchestrator's steady-state consumer and the HTTP
@@ -645,6 +649,32 @@ func (r *Runtime) Run(ctx context.Context) error {
 		runErr = nil
 	}
 	return runErr
+}
+
+func (r *Runtime) goroutineRoot(name string, fn func() error) func() error {
+	return func() error {
+		defer func() {
+			if rec := recover(); rec != nil {
+				info := version.Get()
+				logger := slog.Default()
+				if r != nil && r.logger != nil {
+					logger = r.logger
+				}
+				logger.Error("panic in runtime goroutine",
+					"goroutine", name,
+					"panic", fmt.Sprint(rec),
+					"panic_type", fmt.Sprintf("%T", rec),
+					"stack", string(debug.Stack()),
+					"go_version", runtime.Version(),
+					"version", info.Version,
+					"commit", info.Commit,
+					"built", info.Date,
+				)
+				panic(rec)
+			}
+		}()
+		return fn()
+	}
 }
 
 // Close tears down resources owned by the runtime. It is safe to call once

--- a/internal/jetstreamd/runtime_test.go
+++ b/internal/jetstreamd/runtime_test.go
@@ -44,6 +44,34 @@ func TestRuntimePublicAddrBeforeRunIsEmpty(t *testing.T) {
 	})
 }
 
+func TestGoroutineRoot_LogsPanicThenRethrows(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	rt := &Runtime{
+		logger: slog.New(slog.NewJSONHandler(&buf, nil)),
+	}
+
+	var rec any
+	func() {
+		defer func() { rec = recover() }()
+		_ = rt.goroutineRoot("test_root", func() error {
+			panic("boom")
+		})()
+	}()
+
+	require.Equal(t, "boom", rec)
+	body := buf.String()
+	require.Contains(t, body, `"msg":"panic in runtime goroutine"`)
+	require.Contains(t, body, `"goroutine":"test_root"`)
+	require.Contains(t, body, `"panic":"boom"`)
+	require.Contains(t, body, `"panic_type":"string"`)
+	require.Contains(t, body, `"stack":`)
+	require.Contains(t, body, `"go_version":`)
+	require.Contains(t, body, `"version":`)
+	require.Contains(t, body, `"commit":`)
+}
+
 func TestOptionsValidateRejectsNegativeSegmentCache(t *testing.T) {
 	t.Parallel()
 

--- a/internal/obs/metrics.go
+++ b/internal/obs/metrics.go
@@ -1,6 +1,8 @@
 package obs
 
 import (
+	"time"
+
 	"github.com/bluesky-social/jetstream/internal/version"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
@@ -38,6 +40,15 @@ func NewMetrics() *Metrics {
 	}, []string{"version", "commit", "date"})
 	buildInfo.WithLabelValues(info.Version, info.Commit, info.Date).Set(1)
 	reg.MustRegister(buildInfo)
+
+	currentTimestamp := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name:      "current_timestamp_seconds",
+		Namespace: namespace,
+		Help:      "Current Unix timestamp in seconds at scrape time.",
+	}, func() float64 {
+		return float64(time.Now().Unix())
+	})
+	reg.MustRegister(currentTimestamp)
 
 	// Labels are deliberately minimal. `commit` is intentionally not
 	// a label here even though every request runs under one commit:

--- a/internal/obs/metrics_test.go
+++ b/internal/obs/metrics_test.go
@@ -1,0 +1,29 @@
+package obs
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMetrics_RegistersCurrentTimestampGauge(t *testing.T) {
+	t.Parallel()
+
+	metrics := NewMetrics()
+	gathered, err := metrics.Registry.Gather()
+	require.NoError(t, err)
+
+	var got float64
+	found := false
+	for _, mf := range gathered {
+		if mf.GetName() != "jetstream_current_timestamp_seconds" {
+			continue
+		}
+		require.Len(t, mf.GetMetric(), 1)
+		got = mf.GetMetric()[0].GetGauge().GetValue()
+		found = true
+	}
+	require.True(t, found, "missing jetstream_current_timestamp_seconds")
+	require.InDelta(t, float64(time.Now().Unix()), got, 2)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -352,6 +352,9 @@ func (s *Server) debugMux() http.Handler {
 		_, _ = w.Write([]byte("ok\n"))
 	})
 
+	// /readyz means both listeners have bound and their Serve loops are
+	// running. It is not an ingest-health or steady-state signal; operators
+	// should use /status and /metrics for ingestion health.
 	mux.HandleFunc("GET /readyz", func(w http.ResponseWriter, _ *http.Request) {
 		if !s.ready.Load() {
 			http.Error(w, "not ready", http.StatusServiceUnavailable)

--- a/internal/status/collect.go
+++ b/internal/status/collect.go
@@ -66,7 +66,7 @@ func collectPhase(s *store.Store) (PhaseInfo, error) {
 	return PhaseInfo{Phase: p, PhaseEnteredAt: at}, nil
 }
 
-func collectLive(s *store.Store) (LiveStats, error) {
+func collectLive(s *store.Store, now time.Time, lastSeen func() time.Time) (LiveStats, error) {
 	cur, err := live.LoadUpstreamCursor(s, live.CursorKey)
 	if err != nil {
 		return LiveStats{}, err
@@ -79,11 +79,18 @@ func collectLive(s *store.Store) (LiveStats, error) {
 	if err != nil {
 		return LiveStats{}, err
 	}
-	return LiveStats{
+	stats := LiveStats{
 		UpstreamCursor: cur,
 		NextSeq:        nextSeq,
 		BootstrapSeq:   bootSeq,
-	}, nil
+	}
+	if lastSeen != nil {
+		stats.LastSeenUpstreamEventAt = lastSeen()
+		if !stats.LastSeenUpstreamEventAt.IsZero() && now.After(stats.LastSeenUpstreamEventAt) {
+			stats.LastSeenUpstreamEventAge = now.Sub(stats.LastSeenUpstreamEventAt)
+		}
+	}
+	return stats, nil
 }
 
 func collectBackfill(s *store.Store) (BackfillStats, error) {
@@ -613,7 +620,7 @@ func build(ctx context.Context, opts Options, startedAt time.Time) (*Snapshot, e
 		return nil, err
 	}
 
-	liveStats, err := collectLive(opts.Store)
+	liveStats, err := collectLive(opts.Store, now, opts.LastSeenUpstreamEvent)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/status/collect_test.go
+++ b/internal/status/collect_test.go
@@ -116,6 +116,31 @@ func TestCollect_BuildsFreshSnapshotEachCall(t *testing.T) {
 	require.NotEqual(t, a.GeneratedAt, b.GeneratedAt)
 }
 
+func TestCollect_LiveLastSeenUpstreamEvent(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+	st, err := store.Open(dataDir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	now := time.Date(2026, 7, 8, 12, 0, 30, 0, time.UTC)
+	seen := now.Add(-17 * time.Second)
+	c, err := status.New(status.Options{
+		Store:   st,
+		DataDir: dataDir,
+		Now:     func() time.Time { return now },
+		LastSeenUpstreamEvent: func() time.Time {
+			return seen
+		},
+	})
+	require.NoError(t, err)
+
+	snap, err := c.Snapshot(context.Background())
+	require.NoError(t, err)
+	require.True(t, snap.Live.LastSeenUpstreamEventAt.Equal(seen))
+	require.Equal(t, 17*time.Second, snap.Live.LastSeenUpstreamEventAge)
+}
+
 func TestCollect_PhaseAndEnteredAt(t *testing.T) {
 	t.Parallel()
 	dataDir := t.TempDir()

--- a/internal/status/collector.go
+++ b/internal/status/collector.go
@@ -37,6 +37,10 @@ type Options struct {
 	// ImportReporter yields the current/most-recent timestamp-import job for
 	// the status page. Optional; nil means the import panel is omitted.
 	ImportReporter ImportReporter
+
+	// LastSeenUpstreamEvent returns the last steady-state subscribeRepos event
+	// observation time. Optional; nil means the live freshness fields are empty.
+	LastSeenUpstreamEvent func() time.Time
 }
 
 // Collector builds Snapshots on demand. Concurrent callers share one

--- a/internal/status/snapshot.go
+++ b/internal/status/snapshot.go
@@ -153,9 +153,11 @@ type AccountLookup struct {
 
 // LiveStats summarizes the upstream cursor and seq counters.
 type LiveStats struct {
-	UpstreamCursor int64
-	NextSeq        uint64
-	BootstrapSeq   uint64
+	UpstreamCursor           int64
+	NextSeq                  uint64
+	BootstrapSeq             uint64
+	LastSeenUpstreamEventAt  time.Time
+	LastSeenUpstreamEventAge time.Duration
 }
 
 // SegmentSummary mirrors segment.Inspection's user-facing fields,

--- a/internal/web/handler_test.go
+++ b/internal/web/handler_test.go
@@ -61,7 +61,13 @@ func newFixtureSnap() *status.Snapshot {
 			CompletedAt:     time.Date(2026, 5, 23, 7, 5, 0, 0, time.UTC),
 			Duration:        3*24*time.Hour + 7*time.Hour + 5*time.Minute,
 		},
-		Live: status.LiveStats{UpstreamCursor: 1234567, NextSeq: 999, BootstrapSeq: 0},
+		Live: status.LiveStats{
+			UpstreamCursor:           1234567,
+			NextSeq:                  999,
+			BootstrapSeq:             0,
+			LastSeenUpstreamEventAt:  time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC),
+			LastSeenUpstreamEventAge: 5 * time.Second,
+		},
 		SegmentAggregate: &status.SegmentAggregate{
 			Trees: []status.TreeAggregate{
 				{
@@ -198,6 +204,8 @@ func TestHandler_RendersOK(t *testing.T) {
 	require.Contains(t, body, "5,000")        // OldestRetainedSeq formatted
 	require.Contains(t, body, "12,345")       // Network event count via humanInt
 	require.Contains(t, body, "[100, 1,233]") // Seq range
+	require.Contains(t, body, "Last upstream event")
+	require.Contains(t, body, "5s ago")
 	require.Contains(t, body, "2026-05-24")
 	require.Contains(t, body, "Witnessed range")
 	require.Contains(t, body, "overflow-wrap: anywhere")

--- a/internal/web/templates/status.html
+++ b/internal/web/templates/status.html
@@ -284,6 +284,7 @@ document.addEventListener("input", function (event) {
     <h2>Live ingest</h2>
     <dl>
       <dt>Upstream cursor</dt><dd>{{if eq .Live.UpstreamCursor 0}}not yet started{{else}}{{humanInt64 .Live.UpstreamCursor}}{{end}}</dd>
+      <dt>Last upstream event</dt><dd>{{if .Live.LastSeenUpstreamEventAt.IsZero}}not yet observed{{else}}{{relativeTime .Live.LastSeenUpstreamEventAt .Now}}{{end}}</dd>
       <dt>Sequence allocated</dt><dd>{{humanInt .Live.NextSeq}} events</dd>
       {{if gt .Live.BootstrapSeq 0}}<dt>Bootstrap-time live seq</dt><dd>{{humanInt .Live.BootstrapSeq}}</dd>{{end}}
     </dl>


### PR DESCRIPTION
## Summary
- add `jetstream_current_timestamp_seconds` and steady-state-only `jetstream_livestream_last_seen_upstream_event_timestamp_seconds`
- surface last upstream event observation on `/status`
- log long-lived runtime goroutine panics structurally before re-panicking
- document `/readyz` semantics, alert shape, and `GOTRACEBACK=all` guidance

## Verification
```sh
just test ./internal/obs ./internal/ingest/live ./internal/status ./internal/web ./internal/server ./internal/jetstreamd
just
```

Closes #215