### PR TITLE
status: hydrate account PDS from resolver

### DIFF
--- a/internal/status/collect.go
+++ b/internal/status/collect.go
@@ -331,10 +331,21 @@ func collectAccount(ctx context.Context, s *store.Store, resolver identity.Resol
 	acct.Found = true
 	acct.DID = string(did)
 	acct.Handle = rs.Handle
-	if acct.Handle == "" {
-		acct.Handle = fallbackDeclaredHandle(ctx, resolver, acct.QueryKind, acct.Query, did)
-	}
 	acct.PDS = rs.PDS
+	var resolved identityMetadata
+	if acct.Handle == "" || acct.PDS == "" {
+		resolved = fallbackIdentityMetadata(ctx, resolver, did)
+	}
+	if acct.Handle == "" {
+		if resolved.Handle != "" {
+			acct.Handle = resolved.Handle
+		} else if acct.QueryKind == "handle" && acct.Query != "" {
+			acct.Handle = acct.Query
+		}
+	}
+	if acct.PDS == "" && resolved.PDS != "" {
+		acct.PDS = resolved.PDS
+	}
 	acct.Host = rs.Host
 	acct.Active = rs.Active
 	acct.Backfill = string(rs.Backfill.Status)
@@ -350,22 +361,28 @@ func collectAccount(ctx context.Context, s *store.Store, resolver identity.Resol
 	return acct
 }
 
-func fallbackDeclaredHandle(ctx context.Context, resolver identity.Resolver, queryKind, query string, did atmos.DID) string {
-	if queryKind == "handle" && query != "" {
-		return query
-	}
+type identityMetadata struct {
+	Handle string
+	PDS    string
+}
+
+func fallbackIdentityMetadata(ctx context.Context, resolver identity.Resolver, did atmos.DID) identityMetadata {
 	if resolver == nil {
-		return ""
+		return identityMetadata{}
 	}
 	doc, err := resolver.ResolveDID(ctx, did)
 	if err != nil || doc == nil {
-		return ""
+		return identityMetadata{}
 	}
 	ident, err := identity.IdentityFromDocument(doc)
-	if err != nil || ident.Handle == "" || ident.Handle == atmos.HandleInvalid {
-		return ""
+	if err != nil {
+		return identityMetadata{}
 	}
-	return string(ident.Handle)
+	meta := identityMetadata{PDS: ident.PDSEndpoint()}
+	if ident.Handle != "" && ident.Handle != atmos.HandleInvalid {
+		meta.Handle = string(ident.Handle)
+	}
+	return meta
 }
 
 func treeFromManifest(ms manifest.SegmentTreeStats) TreeAggregate {

--- a/internal/status/collect_test.go
+++ b/internal/status/collect_test.go
@@ -430,6 +430,11 @@ func TestCollect_AccountLookupDIDHydratesMissingHandleFromResolver(t *testing.T)
 			did: {
 				ID:          string(did),
 				AlsoKnownAs: []string{"at://resolved.test"},
+				Service: []identity.Service{{
+					ID:              "#atproto_pds",
+					Type:            "AtprotoPersonalDataServer",
+					ServiceEndpoint: "https://pds.example.com",
+				}},
 			},
 		}},
 	})
@@ -440,6 +445,7 @@ func TestCollect_AccountLookupDIDHydratesMissingHandleFromResolver(t *testing.T)
 	require.True(t, snap.Account.Found)
 	require.Equal(t, string(did), snap.Account.DID)
 	require.Equal(t, "resolved.test", snap.Account.Handle)
+	require.Equal(t, "https://pds.example.com", snap.Account.PDS)
 }
 
 func TestCollect_AccountLookupByHandlePrefersResolverOverLocalIndex(t *testing.T) {


### PR DESCRIPTION
## Summary
- hydrate missing account status handle/PDS fields from the configured identity resolver for the rendered snapshot
- preserve stored account metadata when it is already present
- cover resolver-provided PDS metadata in account lookup tests

## Verification
- `just test ./internal/status -run TestCollect_Account`
- `just test ./internal/status ./internal/web`
- `just`

Closes #277