### PR TITLE
simulator: deflake verifier-overflow E2E sentinel

### DIFF
--- a/cmd/simulator/e2e_helpers_test.go
+++ b/cmd/simulator/e2e_helpers_test.go
@@ -3,9 +3,11 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"net"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -85,4 +87,40 @@ func (b *lockedBuffer) String() string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.buf.String()
+}
+
+// logMsgSet parses jetstream's JSON slog stream (the subprocess default
+// format, see obs.ParseLogFormat) and returns the set of distinct slog
+// `msg` values it emitted.
+//
+// The E2E warning sentinels key off this set rather than substring-
+// matching the raw JSON. Substring matching is brittle: it silently
+// matches structured field *values* as well as messages, and — as
+// issue #283 showed — it breaks the moment a producer's message text
+// drifts from what the test hard-codes. Matching whole `msg` values
+// keeps the sentinels explicit: a rename in the producer surfaces as a
+// sentinel miss (a maintainer must update the constant) instead of a
+// silent false pass.
+//
+// Non-JSON lines (e.g. an early panic or Go runtime output before the
+// logger is wired) are ignored here; callers that need to fail loudly
+// on those inspect the raw buffer separately.
+func logMsgSet(logs string) map[string]struct{} {
+	msgs := make(map[string]struct{})
+	for line := range strings.Lines(logs) {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var rec struct {
+			Msg string `json:"msg"`
+		}
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			continue
+		}
+		if rec.Msg != "" {
+			msgs[rec.Msg] = struct{}{}
+		}
+	}
+	return msgs
 }

--- a/cmd/simulator/e2e_test.go
+++ b/cmd/simulator/e2e_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"net/http/httptest"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -148,23 +147,35 @@ func TestEndToEnd_JetstreamConsumesSimulator(t *testing.T) {
 	// commit / atmos's verifier resync emits a synthetic event with
 	// no public envelope).
 	//
-	// Caveat: a drop in atmos's per-DID FIFO scheduler ("event dropped")
-	// is *expected* to surface a downstream chain break on the next event
-	// for that DID — the previous rev's data hash no longer matches the
-	// new event's prev_data because the linking event was dropped. The
-	// verifier's PolicyResync recovers asynchronously, but it logs a
-	// "verification failure" for visibility. That's not a regression in
-	// jetstream; it's atmos doing exactly what it's designed to do under
-	// upstream loss. We tune the simulator above to avoid drops, but
-	// under heavy CI contention they can still happen, so we relax the
-	// chain-break sentinel iff a drop preceded it. The unknown-event
-	// sentinel stays strict — no upstream condition causes it.
+	// Caveat: a drop in atmos's per-DID FIFO scheduler is *expected* to
+	// surface a downstream chain break on the next event for that DID —
+	// the previous rev's data hash no longer matches the new event's
+	// prev_data because the linking event was dropped. The verifier's
+	// PolicyResync recovers asynchronously, but it logs a "verification
+	// failure" for visibility. That's not a regression in jetstream;
+	// it's atmos doing exactly what it's designed to do under upstream
+	// loss. We tune the simulator above to avoid drops, but under heavy
+	// CI contention they can still happen, so we relax the chain-break
+	// sentinel iff a drop preceded it. The unknown-event sentinel stays
+	// strict — no upstream condition causes it.
+	//
+	// The drop signal is jetstream's own log message, NOT atmos's raw
+	// DropError text ("event dropped: ..."): the live consumer catches
+	// the *streaming.DropError and re-logs it under its own message with
+	// structured fields (see internal/ingest/live/consumer.go's
+	// "verify queue overflow dropped event"). atmos's string never
+	// reaches this buffer. Keying off the structured slog `msg` field
+	// keeps this explicit — issue #283 was a silent false pass caused by
+	// substring-matching a message text that jetstream never emits.
 	logs := stderr.String()
-	dropOccurred := strings.Contains(logs, `"event dropped`)
+	msgs := logMsgSet(logs)
+	_, dropOccurred := msgs["verify queue overflow dropped event"]
 	if !dropOccurred {
-		require.Falsef(t, strings.Contains(logs, `"verification failure"`),
+		_, verificationFailed := msgs["verification failure"]
+		require.Falsef(t, verificationFailed,
 			"jetstream emitted verification failure during E2E run; logs:\n%s", logs)
 	}
-	require.Falsef(t, strings.Contains(logs, `"unknown event kind"`),
+	_, unknownEventKind := msgs["unknown event kind"]
+	require.Falsef(t, unknownEventKind,
 		"jetstream emitted unknown event kind during E2E run; logs:\n%s", logs)
 }

--- a/cmd/simulator/main_test.go
+++ b/cmd/simulator/main_test.go
@@ -1,1 +1,56 @@
 package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestLogMsgSet pins the E2E warning-sentinel log parser (issue #283).
+// The heavy E2E test keys its verifier-overflow and unknown-event
+// sentinels off the structured slog `msg` field this returns, so a
+// regression here would silently disable those sentinels.
+func TestLogMsgSet(t *testing.T) {
+	t.Parallel()
+
+	t.Run("extracts distinct msg values from JSON slog lines", func(t *testing.T) {
+		t.Parallel()
+		logs := `{"time":"t","level":"WARN","msg":"verify queue overflow dropped event","did":"did:plc:x","seq":42,"queue_len":64}
+{"time":"t","level":"WARN","msg":"verification failure","did":"did:plc:x","err":"chain break"}
+{"time":"t","level":"INFO","msg":"steady state reached"}
+{"time":"t","level":"INFO","msg":"steady state reached"}`
+		msgs := logMsgSet(logs)
+		require.Len(t, msgs, 3)
+		require.Contains(t, msgs, "verify queue overflow dropped event")
+		require.Contains(t, msgs, "verification failure")
+		require.Contains(t, msgs, "steady state reached")
+	})
+
+	t.Run("the drop message is a distinct msg, not a substring of atmos text", func(t *testing.T) {
+		t.Parallel()
+		// Regression guard for #283: the old sentinel scanned for the
+		// substring "event dropped", which jetstream's message
+		// ("verify queue overflow dropped event") does not contain.
+		// Confirm we match the whole message the consumer actually
+		// emits, and that we do NOT spuriously key off field values.
+		logs := `{"time":"t","level":"WARN","msg":"verify queue overflow dropped event","did":"did:plc:x","seq":42}`
+		msgs := logMsgSet(logs)
+		_, dropOccurred := msgs["verify queue overflow dropped event"]
+		require.True(t, dropOccurred, "must recognize jetstream's own drop message")
+		_, atmosText := msgs["event dropped"]
+		require.False(t, atmosText, "atmos's raw DropError text never reaches the log buffer")
+	})
+
+	t.Run("ignores non-JSON and blank lines", func(t *testing.T) {
+		t.Parallel()
+		logs := "panic: runtime error\n\ngoroutine 1 [running]:\n{\"level\":\"WARN\",\"msg\":\"unknown event kind\",\"kind\":9}\n"
+		msgs := logMsgSet(logs)
+		require.Len(t, msgs, 1)
+		require.Contains(t, msgs, "unknown event kind")
+	})
+
+	t.Run("empty input yields empty set", func(t *testing.T) {
+		t.Parallel()
+		require.Empty(t, logMsgSet(""))
+	})
+}


### PR DESCRIPTION
## Summary

Fixes the flaky `TestEndToEnd_JetstreamConsumesSimulator` verifier-overflow sentinel (#283). This is a **test-only** change — no production behavior is modified.

## Root cause

The sentinel's `dropOccurred := strings.Contains(logs, "event dropped")` (`cmd/simulator/e2e_test.go:163`) was a dead check. Jetstream's live consumer catches atmos's `*streaming.DropError` and re-logs it under its **own** message — `"verify queue overflow dropped event"` (`internal/ingest/live/consumer.go:561`) — with structured fields. atmos's raw `"event dropped: ..."` text never reaches the captured stderr buffer, so `dropOccurred` could never be true. When a drop-induced chain break then emitted a `"verification failure"`, the sentinel fired and failed the test under CI contention — exactly the failure reported.

Secondary brittleness: the sentinels substring-matched the whole JSON blob, which also matches structured field *values*, not just messages.

## Fix

- Add `logMsgSet` (`e2e_helpers_test.go`): parses jetstream's JSON slog stream and returns the set of distinct `msg` values. Sentinels now key off the structured `msg` field instead of substring-matching raw JSON.
- The drop signal now matches jetstream's actual message, `"verify queue overflow dropped event"`. The unknown-event sentinel stays strict.
- Add `TestLogMsgSet` (fast unit test) pinning the parser, with a regression guard that the drop message is not a substring of atmos's text.

## Verification

- Reproduced by temporarily cranking `CommitsPerSec` to 5000: confirmed jetstream logs `"verify queue overflow dropped event"` followed by `"verification failure"`, and that `"event dropped"` never appears — proving the old check was dead and the sentinel would have failed. New logic correctly relaxes it.
- `just test-race ./cmd/simulator -run TestEndToEnd_JetstreamConsumesSimulator -count=5` passes.
- `just lint` clean; `TestLogMsgSet` passes.

## Follow-up

The E2E can't deterministically exercise the drop-relaxation path without cranking the rate (which the test deliberately avoids for stability), so that branch is only covered opportunistically under contention. If guaranteed coverage is wanted, a separate focused test could be split out — worth a follow-up issue.

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)