### PR TITLE
ingest: make readable-log pinned-bytes metric O(1)

### DIFF
--- a/internal/ingest/readlog.go
+++ b/internal/ingest/readlog.go
@@ -72,9 +72,17 @@ type ReadableLog struct {
 	tipSeq   uint64
 	durable  uint64
 	curBytes int64
-	maxBytes int64
-	notify   chan struct{}
-	metrics  *Metrics
+	// pinnedBytes is the running sum of entry bytes for entries at or
+	// above durable (Seq >= durable) — the events retained because they
+	// are not yet durably flushed. Maintained incrementally so
+	// publishMetricsLocked stays O(1): a prior per-append linear scan of
+	// every resident entry made append O(n) and, as the resident set grew
+	// to the byte cap (~500k entries), throttled live ingest into an
+	// O(n^2) collapse that could not keep pace with the firehose.
+	pinnedBytes int64
+	maxBytes    int64
+	notify      chan struct{}
+	metrics     *Metrics
 }
 
 func newReadableLog(nextSeq uint64, maxBytes int64, metrics *Metrics) *ReadableLog {
@@ -107,6 +115,9 @@ func (l *ReadableLog) append(ev *segment.Event) {
 	l.entries = append(l.entries, entry)
 	l.tipSeq++
 	l.curBytes += entry.bytes
+	// A freshly appended entry has Seq == old tipSeq >= durable, so it is
+	// pinned until a later advanceDurable moves past it.
+	l.pinnedBytes += entry.bytes
 	l.evictLocked()
 	old := l.notify
 	l.notify = make(chan struct{})
@@ -132,6 +143,18 @@ func (l *ReadableLog) advanceDurable(nextSeq uint64) {
 	}
 	if nextSeq > l.tipSeq {
 		panic(fmt.Sprintf("ingest: readable log durable %d beyond tip %d", nextSeq, l.tipSeq))
+	}
+	// Entries with Seq in [old durable, nextSeq) transition from pinned to
+	// durable; drop their bytes from the pinned accumulator. They remain
+	// resident (subject to eviction) but no longer count as pinned.
+	for seq := l.durable; seq < nextSeq; seq++ {
+		if seq < l.baseSeq {
+			continue // already evicted; never counted
+		}
+		idx := seq - l.baseSeq
+		if idx < uint64(len(l.entries)) {
+			l.pinnedBytes -= l.entries[idx].bytes
+		}
 	}
 	l.durable = nextSeq
 	l.evictLocked()
@@ -236,12 +259,7 @@ func (l *ReadableLog) publishMetricsLocked() {
 	if l.metrics == nil {
 		return
 	}
-	pinned := int64(0)
-	for _, entry := range l.entries {
-		if entry.event.Seq >= l.durable {
-			pinned += entry.bytes
-		}
-	}
+	pinned := l.pinnedBytes
 	l.metrics.setReadLogBytes(l.curBytes)
 	l.metrics.setReadLogPinnedBytes(pinned)
 	l.metrics.setReadLogPinnedOverrunBytes(maxInt64(0, pinned-l.maxBytes))

--- a/internal/ingest/readlog_test.go
+++ b/internal/ingest/readlog_test.go
@@ -35,6 +35,61 @@ func TestReadLog_AppendedEventVisibleBeforeDurabilityAndEvictedAfterFlush(t *tes
 	require.Equal(t, w.NextSeq(), w.ReadLog().FloorSeq(), "zero retention evicts once durable")
 }
 
+// brutePinned recomputes pinned bytes the old O(n) way: every resident
+// entry with Seq >= durable. Used to assert the incremental pinnedBytes
+// accumulator never drifts.
+func brutePinned(l *ReadableLog) int64 {
+	var sum int64
+	for _, e := range l.entries {
+		if e.event.Seq >= l.durable {
+			sum += e.bytes
+		}
+	}
+	return sum
+}
+
+// TestReadLog_PinnedBytesAccumulatorMatchesScan drives interleaved
+// append / advanceDurable / evict cycles and asserts the incremental
+// pinnedBytes accumulator equals a full rescan at every step. This is the
+// invariant behind replacing publishMetricsLocked's per-append O(n) scan
+// (which throttled live ingest into an O(n^2) collapse) with an O(1) read.
+func TestReadLog_PinnedBytesAccumulatorMatchesScan(t *testing.T) {
+	t.Parallel()
+
+	// Small byte cap so eviction actually fires while entries stay pinned
+	// above durable — the exact regime where the old scan blew up.
+	l := newReadableLog(1, 512, nil)
+
+	seq := uint64(1)
+	appendN := func(n int) {
+		for range n {
+			ev := &segment.Event{
+				Kind: segment.KindCreate, DID: "did:plc:a", Collection: "c",
+				Rkey: "r", Rev: "1", Payload: []byte{byte(seq)}, Seq: seq,
+			}
+			l.append(ev)
+			seq++
+			require.Equal(t, brutePinned(l), l.pinnedBytes, "pinned drift after append")
+		}
+	}
+
+	appendN(20)
+	require.Equal(t, brutePinned(l), l.pinnedBytes)
+
+	// Advance durability in uneven chunks; each advance moves entries from
+	// pinned to durable and lets eviction reclaim below-durable bytes.
+	for _, d := range []uint64{5, 5, 12, 21} { // 21 == tipSeq after 20 appends
+		l.advanceDurable(d)
+		require.Equal(t, brutePinned(l), l.pinnedBytes, "pinned drift after advanceDurable(%d)", d)
+	}
+
+	// Interleave more appends after eviction has moved baseSeq forward.
+	appendN(15)
+	l.advanceDurable(l.tipSeq)
+	require.Equal(t, brutePinned(l), l.pinnedBytes, "pinned drift after tail drain")
+	require.GreaterOrEqual(t, l.pinnedBytes, int64(0), "pinned must never go negative")
+}
+
 func TestReadLog_DeepCopiesPayload(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

`ReadableLog.publishMetricsLocked` recomputed the pinned-bytes gauge by linearly scanning the **entire** resident entry slice on **every append**. The readable log is held at its 256 MiB retention cap (~545k small entries), and `publishMetricsLocked` runs from `append` on every ingested firehose event — so each append was a ~545k-element scan, making ingest **O(n²)**.

As the resident set filled toward the cap, per-append cost rose until live-consumer throughput fell to ≈ the firehose input rate and stalled during bursts. The process accreted a **multi-hour lag** behind the firehose and could not recover.

This surfaced to an operator as a sync 1.1 repo-verification **"Match failure"**: the affected repo's commits were on the firehose but had not been ingested yet, so the locally-reconstructed root lagged the authoritative PDS root. It looked like per-account data loss; it was actually ingest throughput collapse. Full investigation in #289.

## Fix

Maintain pinned bytes as an incremental accumulator (`pinnedBytes`) instead of rescanning:

- `append` adds a new entry's bytes (`Seq == tipSeq >= durable`, so always pinned).
- `advanceDurable` subtracts the bytes of entries whose `Seq` moves below the new durable watermark. That loop covers only one flush's newly-durable seq range → **amortized O(1) per event**.
- `evictLocked` only removes entries already below `durable` (never counted), so it needs no adjustment.

`publishMetricsLocked` now reads the accumulator — O(1).

## Verification

- Added `TestReadLog_PinnedBytesAccumulatorMatchesScan`: drives interleaved `append`/`advanceDurable`/`evict` cycles and asserts the accumulator equals a brute-force rescan at every step (would catch any drift).
- `go test -race ./internal/ingest/...` — all pass (incl. orchestrator).
- `golangci-lint` — 0 issues.
- **Live on the affected box:** before the fix, live ingest ran ~400 events/s (real-time, stalling), CPU profile attributed **99.80%** to `publishMetricsLocked`. After the fix, ~6,700 events/s — drained a ~4h backlog in ~35 min, then settled at ~415/s (1:1 with the live firehose). The account's repo verification returned to **Match**.

## Follow-ups (not in this PR)

- `ReadableLog.PendingForDID` has the same scan-the-~545k-buffer pattern, but on the operator request path under `RLock` (contends with the writer's `append`). Lower severity; needs a per-DID index rather than a one-line accumulator.
- No metric for "live-consumer lag behind the firehose tip" — would have surfaced this in minutes. Worth adding.

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)