### PR TITLE
client: parallelize block-mode getBlock fetches

### DIFF
--- a/internal/client/downloader.go
+++ b/internal/client/downloader.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 
 	"github.com/bluesky-social/jetstream/api/jetstream"
@@ -134,7 +135,9 @@ type decodeResult struct {
 // 1's, …) regardless of decode-completion order. It runs a three-stage pipeline:
 //
 //  1. a single PREFETCHER fetches whole-segment files a little ahead (bounded),
-//     overlapping the next segment's download with the current one's decode;
+//     overlapping the next segment's download with the current one's decode,
+//     while a BLOCK-FETCH COORDINATOR runs block-mode getBlock round trips on
+//     its own parallel pool across blocks and entries (#292);
 //  2. a POOL of d.concurrency DECODE workers decompresses + CBOR-decodes block
 //     frames in parallel — the CPU-heavy work, fanned out across cores;
 //  3. a single REASSEMBLER emits decoded blocks in global-seq order, so output
@@ -225,13 +228,18 @@ func inFlightWindow(concurrency int) int {
 }
 
 // runFramer is stages 1+2: walk entries in plan order, fetch each (whole-segment
-// files prefetched a little ahead; block-mode ranges fetched inline), slice
-// block frames, and dispatch them to the decode pool with a dense ascending
-// global seq. It closes jobs on return. A per-entry fetch/read error is
-// dispatched as an in-order error job and that entry stops (the next continues).
+// files prefetched a little ahead; block-mode frames via the parallel
+// block-fetch coordinator), slice block frames, and dispatch them to the decode
+// pool with a dense ascending global seq. It closes jobs on return. A per-entry
+// fetch/read error is dispatched as an in-order error job and that entry stops
+// (the next continues).
 func (d *Downloader) runFramer(ctx context.Context, entries []PlanEntry, jobs chan<- decodeJob, sem chan struct{}) {
 	defer close(jobs)
 
+	// The block-fetch coordinator (nil when the plan has no block-mode entries)
+	// runs getBlock round trips on a parallel pool, across blocks AND entries,
+	// handing the framer per-entry ordered future streams (#292).
+	bc := d.startBlockFetches(ctx, entries)
 	prefetch := d.startPrefetch(ctx, entries)
 	var seq uint64
 
@@ -269,7 +277,7 @@ func (d *Downloader) runFramer(ctx context.Context, entries []PlanEntry, jobs ch
 				return
 			}
 		case f.entry.Mode == ModeBlocks:
-			if !d.frameBlocks(ctx, f.idx, f.entry, dispatch) {
+			if !frameBlocks(ctx, f.idx, bc.futuresByEntry[f.idx], bc.inflight, dispatch) {
 				return
 			}
 		default:
@@ -301,21 +309,184 @@ func (d *Downloader) frameWholeSegment(entryIdx int, entry PlanEntry, raw []byte
 	return true
 }
 
-// frameBlocks fetches the entry's listed block ranges via getBlock and dispatches
-// each frame in ascending block index. getBlock failure is dispatched in order
-// and stops this entry. Returns false if the pipeline was cancelled.
-func (d *Downloader) frameBlocks(ctx context.Context, entryIdx int, entry PlanEntry, dispatch func(entryIdx, blockIdx int, frame []byte, ferr error) bool) bool {
+// frameBlocks consumes one entry's block-fetch futures in ascending block index
+// and dispatches each frame. The fetches themselves run in parallel on the
+// coordinator's pool (#292); consuming strictly in order HERE is what preserves
+// the framer's ordered-dispatch contract — head-of-line waiting on the next
+// future is fine because the round trips behind it are already overlapped. A
+// fetch error is dispatched in order and stops this entry: the remaining
+// futures are drained without dispatching. The drain still awaits each fetch
+// (the coordinator keeps enqueueing the entry's tail as tokens free), so an
+// entry error wastes that entry's remaining getBlocks — acceptable because
+// errors survive 3 xrpc retries first, and the serial alternative would
+// reintroduce the head-of-line stall this pool exists to remove. One in-flight
+// token is released per future consumed, drained or not, so the coordinator
+// keeps looking ahead. Returns false if the pipeline was cancelled.
+func frameBlocks(ctx context.Context, entryIdx int, futures <-chan blockFuture, inflight <-chan struct{}, dispatch func(entryIdx, blockIdx int, frame []byte, ferr error) bool) bool {
+	failed := false
+	for fut := range futures {
+		var res blockFetch
+		select {
+		case res = <-fut.result:
+		case <-ctx.Done():
+			return false
+		}
+		<-inflight
+		if failed {
+			continue
+		}
+		// int narrowing is safe: blockIdx <= math.MaxUint32 by the planner's
+		// validation (the widened-uint64 loop in the coordinator).
+		switch {
+		case res.err != nil:
+			failed = true
+			if !dispatch(entryIdx, int(fut.blockIdx), nil, res.err) {
+				return false
+			}
+		default:
+			if !dispatch(entryIdx, int(fut.blockIdx), res.frame, nil) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// maxBlockFetchConc caps the parallel getBlock fetch pool. 64 stays comfortably
+// under the transport's MaxConnsPerHost (100) while collapsing a sparse WAN
+// backfill's block-per-RTT serialization (#292); getBlock is nearly free
+// server-side (one stored frame read), so the client optimizes its own
+// end-to-end latency rather than protecting the server here.
+const maxBlockFetchConc = 64
+
+// blockFetchPoolSize sizes the getBlock fetch pool from the decode concurrency:
+// fetches are IO-bound round trips, not CPU work, so they deserve more
+// parallelism than the decode pool itself.
+func blockFetchPoolSize(concurrency int) int {
+	return min(2*concurrency, maxBlockFetchConc)
+}
+
+// blockFetch is the outcome of one getBlock fetch.
+type blockFetch struct {
+	frame []byte
+	err   error
+}
+
+// blockFuture is the framer's in-order handle to one parallel getBlock fetch.
+// result has capacity 1 and is written exactly once by a fetch worker, so
+// workers never block on delivery and an abandoned result is simply GC'd.
+type blockFuture struct {
+	blockIdx uint64
+	result   chan blockFetch
+}
+
+// blockJob pairs one getBlock fetch with the future its result resolves.
+type blockJob struct {
+	segmentName string
+	future      blockFuture
+}
+
+// blockFetchCoordinator runs the plan's getBlock fetches on a parallel worker
+// pool, ahead of and independently from the framer, while preserving the
+// framer's in-order consumption: futuresByEntry[i] streams entry i's futures in
+// ascending block index, and the coordinator fills entries in plan order. Jobs
+// are FIFO across entries, so plan-order blocks fetch first and later entries'
+// blocks fill idle workers — cross-entry parallelism, which is what collapses a
+// sparse (DID-filtered) plan of many few-block entries from one RTT per block
+// to one RTT per pool-width (#292).
+type blockFetchCoordinator struct {
+	futuresByEntry []<-chan blockFuture // nil for non-block-mode entries
+	// inflight bounds fetched-or-fetching frames: acquired before a job is
+	// enqueued, released by the framer as it consumes each future. Without it
+	// the coordinator could race arbitrarily far ahead of the framer, holding
+	// one fetched frame per future across unboundedly many entries.
+	inflight chan struct{}
+}
+
+// startBlockFetches launches the block-fetch coordinator, or returns nil when
+// the plan has no block-mode entries. Workers exit when the coordinator has
+// enqueued every block (or on cancellation, when in-flight requests fail fast
+// via ctx and the per-entry channels are closed so the framer never hangs).
+func (d *Downloader) startBlockFetches(ctx context.Context, entries []PlanEntry) *blockFetchCoordinator {
+	if !slices.ContainsFunc(entries, func(e PlanEntry) bool { return e.Mode == ModeBlocks }) {
+		return nil
+	}
+	size := blockFetchPoolSize(d.concurrency)
+	bc := &blockFetchCoordinator{
+		futuresByEntry: make([]<-chan blockFuture, len(entries)),
+		inflight:       make(chan struct{}, 2*size),
+	}
+	chans := make([]chan blockFuture, len(entries))
+	for i := range entries {
+		if entries[i].Mode == ModeBlocks {
+			chans[i] = make(chan blockFuture, size)
+			bc.futuresByEntry[i] = chans[i]
+		}
+	}
+
+	jobs := make(chan blockJob, size)
+	for range size {
+		go func() {
+			for j := range jobs {
+				frame, err := jetstream.JetstreamGetBlock(ctx, d.xc, int64(j.future.blockIdx), j.segmentName)
+				if err != nil {
+					err = fmt.Errorf("jetstream: getBlock %d of %q: %w", j.future.blockIdx, j.segmentName, err)
+				}
+				j.future.result <- blockFetch{frame: frame, err: err}
+			}
+		}()
+	}
+
+	// The coordinator: walk block-mode entries in plan order, enqueue one job
+	// per block in ascending index, stream the future to that entry's channel.
+	go func() {
+		defer close(jobs)
+		for i := range entries {
+			if chans[i] == nil {
+				continue
+			}
+			if !enqueueEntryBlocks(ctx, entries[i], jobs, chans[i], bc.inflight) {
+				// Cancelled: close every remaining channel so a framer mid-range
+				// never hangs (it will exit via ctx anyway, but never wedge).
+				for j := i; j < len(entries); j++ {
+					if chans[j] != nil {
+						close(chans[j])
+						chans[j] = nil
+					}
+				}
+				return
+			}
+			close(chans[i])
+			chans[i] = nil
+		}
+	}()
+	return bc
+}
+
+// enqueueEntryBlocks submits one fetch job per listed block of one entry, in
+// ascending index order, streaming each future to the framer's channel as it
+// is issued. Returns false on cancellation (the caller closes the channel).
+func enqueueEntryBlocks(ctx context.Context, entry PlanEntry, jobs chan<- blockJob, futures chan<- blockFuture, inflight chan<- struct{}) bool {
 	for _, br := range entry.Blocks {
 		// idx is widened to uint64 so a range ending at the uint32 max
 		// (math.MaxUint32 passes the planner's `> MaxUint32` validation) does not
 		// wrap back to 0 on the final increment and loop forever. The body only
 		// runs for idx <= br.Last <= MaxUint32, so int64/int narrowing is safe.
 		for idx := uint64(br.First); idx <= uint64(br.Last); idx++ {
-			frame, err := jetstream.JetstreamGetBlock(ctx, d.xc, int64(idx), entry.SegmentName)
-			if err != nil {
-				return dispatch(entryIdx, int(idx), nil, fmt.Errorf("jetstream: getBlock %d of %q: %w", idx, entry.SegmentName, err))
+			select {
+			case inflight <- struct{}{}:
+			case <-ctx.Done():
+				return false
 			}
-			if !dispatch(entryIdx, int(idx), frame, nil) {
+			fut := blockFuture{blockIdx: idx, result: make(chan blockFetch, 1)}
+			select {
+			case jobs <- blockJob{segmentName: entry.SegmentName, future: fut}:
+			case <-ctx.Done():
+				return false
+			}
+			select {
+			case futures <- fut:
+			case <-ctx.Done():
 				return false
 			}
 		}
@@ -324,7 +495,8 @@ func (d *Downloader) frameBlocks(ctx context.Context, entryIdx int, entry PlanEn
 }
 
 // fetchedEntry is one whole-segment file fetched ahead of framing (raw nil for
-// non-whole-segment entries, which the framer fetches itself), or a fetch error.
+// non-whole-segment entries, whose blocks arrive via the block-fetch
+// coordinator), or a fetch error.
 type fetchedEntry struct {
 	idx   int
 	entry PlanEntry
@@ -336,8 +508,9 @@ type fetchedEntry struct {
 // plan order, a little ahead of the framer, so the next segment's download
 // overlaps the current one's decode. The depth-bounded channel caps how far
 // ahead it runs (and thus how many ~280 MB buffers are resident). Block-mode
-// entries pass through without fetching (the framer getBlocks them inline — the
-// sparse path). It closes the channel on completion or cancellation.
+// entries pass through without fetching — their getBlock fetches run on the
+// block-fetch coordinator's pool, which looks ahead independently of this
+// depth bound (#292). It closes the channel on completion or cancellation.
 func (d *Downloader) startPrefetch(ctx context.Context, entries []PlanEntry) <-chan fetchedEntry {
 	out := make(chan fetchedEntry, prefetchDepth)
 	go func() {

--- a/internal/client/downloader_test.go
+++ b/internal/client/downloader_test.go
@@ -723,7 +723,17 @@ func TestDownloadNoGoroutineLeak(t *testing.T) {
 			events = append(events, makeCreate(t, seq, "did:plc:a", "app.bsky.feed.post", "r"+strconv.FormatUint(seq, 10)))
 		}
 		as.addSegment(t, segName(s), events)
-		entries = append(entries, PlanEntry{SegmentName: segName(s), Index: uint32(s), Mode: ModeWholeSegment})
+		// Alternate modes so every run also exercises the block-fetch pool's
+		// spin-up/teardown (#292) — its workers/coordinator must unwind on both
+		// clean completion and early stop just like the rest of the pipeline.
+		if s%2 == 0 {
+			entries = append(entries, PlanEntry{SegmentName: segName(s), Index: uint32(s), Mode: ModeWholeSegment})
+		} else {
+			entries = append(entries, PlanEntry{
+				SegmentName: segName(s), Index: uint32(s), Mode: ModeBlocks,
+				Blocks: []BlockRange{{First: 0, Last: 2}},
+			})
+		}
 	}
 
 	settle := func() int {
@@ -941,6 +951,255 @@ func TestDownloadBlocksMaxUint32NoWraparound(t *testing.T) {
 	require.Equal(t, []uint64{1}, seqs(got))
 	require.Equal(t, int64(1), calls.Load(), "exactly one getBlock call for a single-index range at MaxUint32; >1 means the counter wrapped")
 	require.Equal(t, strconv.FormatUint(math.MaxUint32, 10), firstIdx.Load(), "the single call must be for the MaxUint32 index")
+}
+
+// blockGate instruments getBlock with an in-flight counter and an optional
+// hold: while holding, requests park until released, so a test can observe the
+// true fetch parallelism deterministically (no wall-clock races).
+type blockGate struct {
+	inflight    atomic.Int64
+	maxInflight atomic.Int64
+	release     chan struct{} // closed to release parked requests; nil = no hold
+}
+
+func (g *blockGate) enter(r *http.Request) {
+	cur := g.inflight.Add(1)
+	for {
+		prev := g.maxInflight.Load()
+		if cur <= prev || g.maxInflight.CompareAndSwap(prev, cur) {
+			break
+		}
+	}
+	if g.release != nil {
+		select {
+		case <-g.release:
+		case <-r.Context().Done():
+		}
+	}
+}
+
+func (g *blockGate) exit() { g.inflight.Add(-1) }
+
+// gatedBlockServer wraps an archiveServer's getBlock handler with a blockGate.
+func gatedBlockServer(t *testing.T, as *archiveServer, gate *blockGate) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/xrpc/network.bsky.jetstream.getBlock", func(w http.ResponseWriter, r *http.Request) {
+		gate.enter(r)
+		defer gate.exit()
+		as.mux.ServeHTTP(w, r)
+	})
+	mux.HandleFunc("/", as.mux.ServeHTTP)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestDownloadBlocksFetchInParallel is the core guard for #292: block-mode
+// getBlock fetches must overlap instead of running one round trip at a time.
+// The gate parks every getBlock until the expected parallelism is observed, so
+// a serial regression hangs at maxInflight=1 and fails via the watchdog rather
+// than passing slowly.
+func TestDownloadBlocksFetchInParallel(t *testing.T) {
+	t.Parallel()
+	as := newArchiveServer(t)
+	// One segment, 16 blocks of 2 events.
+	var events []segment.Event
+	for i := uint64(1); i <= 32; i++ {
+		events = append(events, makeCreate(t, i, "did:plc:a", "app.bsky.feed.post", "r"+strconv.FormatUint(i, 10)))
+	}
+	as.addSegment(t, segName(0), events)
+	entries := []PlanEntry{{
+		SegmentName: segName(0), Index: 0, Mode: ModeBlocks,
+		Blocks: []BlockRange{{First: 0, Last: 15}},
+	}}
+
+	const conc = 4
+	wantParallel := int64(blockFetchPoolSize(conc)) // 8
+	gate := &blockGate{release: make(chan struct{})}
+	srv := gatedBlockServer(t, as, gate)
+
+	// Release the gate once the pool has ramped to full width.
+	go func() {
+		for gate.inflight.Load() < wantParallel {
+			time.Sleep(time.Millisecond)
+		}
+		close(gate.release)
+	}()
+
+	d := NewDownloader(&xrpc.Client{Host: srv.URL}, conc, nil)
+	done := make(chan []Event, 1)
+	go func() { done <- collectOrdered(t, d, entries) }()
+	select {
+	case got := <-done:
+		want := make([]uint64, 32)
+		for i := range want {
+			want[i] = uint64(i + 1)
+		}
+		require.Equal(t, want, seqs(got), "parallel fetch must not perturb block order")
+	case <-time.After(15 * time.Second):
+		t.Fatalf("block fetches never reached parallelism %d (max observed %d) — serial regression",
+			wantParallel, gate.maxInflight.Load())
+	}
+	require.GreaterOrEqual(t, gate.maxInflight.Load(), wantParallel,
+		"getBlock fetches must overlap up to the pool width")
+}
+
+// TestDownloadBlocksParallelAcrossEntries pins the cross-entry property that
+// makes #292 matter: a sparse plan is MANY entries of FEW blocks, so fetch
+// parallelism must span entries, not just blocks within one entry. 8 entries ×
+// 1 block with a gate requiring 8 concurrent fetches can only pass if later
+// entries' fetches start before entry 0's future is consumed.
+func TestDownloadBlocksParallelAcrossEntries(t *testing.T) {
+	t.Parallel()
+	as := newArchiveServer(t)
+	const nSeg = 8
+	var entries []PlanEntry
+	for s := range nSeg {
+		as.addSegment(t, segName(s), []segment.Event{
+			makeCreate(t, uint64(s*10+1), "did:plc:a", "app.bsky.feed.post", "r1"),
+			makeCreate(t, uint64(s*10+2), "did:plc:a", "app.bsky.feed.post", "r2"),
+		})
+		entries = append(entries, PlanEntry{
+			SegmentName: segName(s), Index: uint32(s), Mode: ModeBlocks,
+			Blocks: []BlockRange{{First: 0, Last: 0}},
+		})
+	}
+
+	gate := &blockGate{release: make(chan struct{})}
+	srv := gatedBlockServer(t, as, gate)
+	go func() {
+		for gate.inflight.Load() < nSeg {
+			time.Sleep(time.Millisecond)
+		}
+		close(gate.release)
+	}()
+
+	d := NewDownloader(&xrpc.Client{Host: srv.URL}, 8, nil)
+	done := make(chan []Event, 1)
+	go func() { done <- collectOrdered(t, d, entries) }()
+	select {
+	case got := <-done:
+		want := []uint64{1, 2, 11, 12, 21, 22, 31, 32, 41, 42, 51, 52, 61, 62, 71, 72}
+		require.Equal(t, want, seqs(got), "cross-entry parallel fetch must preserve plan order")
+	case <-time.After(15 * time.Second):
+		t.Fatalf("fetches never spanned %d entries concurrently (max observed %d)",
+			nSeg, gate.maxInflight.Load())
+	}
+}
+
+// TestDownloadBlocksErrorStopsEntryNotPlan mirrors the whole-segment error
+// contract on the parallel block path: a failing getBlock surfaces as an
+// in-order per-entry error after the good prefix, that entry stops, and the
+// NEXT entry still completes — even though its fetches were already in flight
+// on the shared pool when the error hit.
+func TestDownloadBlocksErrorStopsEntryNotPlan(t *testing.T) {
+	t.Parallel()
+	as := newArchiveServer(t)
+	for s := range 2 {
+		var events []segment.Event
+		for i := range 6 { // 3 blocks of 2
+			seq := uint64(s*100 + i + 1)
+			events = append(events, makeCreate(t, seq, "did:plc:a", "app.bsky.feed.post", "r"+strconv.FormatUint(seq, 10)))
+		}
+		as.addSegment(t, segName(s), events)
+	}
+
+	// Fail entry 0's block 1 (getBlock 500s it); everything else serves normally.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/xrpc/network.bsky.jetstream.getBlock", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("segment") == segName(0) && r.URL.Query().Get("blockIndex") == "1" {
+			writeXRPCError(w, http.StatusInternalServerError, "InternalError")
+			return
+		}
+		as.mux.ServeHTTP(w, r)
+	})
+	mux.HandleFunc("/", as.mux.ServeHTTP)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	entries := []PlanEntry{
+		{SegmentName: segName(0), Index: 0, Mode: ModeBlocks, Blocks: []BlockRange{{First: 0, Last: 2}}},
+		{SegmentName: segName(1), Index: 1, Mode: ModeBlocks, Blocks: []BlockRange{{First: 0, Last: 2}}},
+	}
+	d := NewDownloader(&xrpc.Client{Host: srv.URL}, 8, nil)
+
+	var perEntry [2][]uint64
+	var entry0Err error
+	err := d.Download(context.Background(), entries, func(res EntryResult) bool {
+		if res.Err != nil {
+			require.Equal(t, 0, res.Index, "only entry 0 may error")
+			require.Nil(t, res.Events)
+			entry0Err = res.Err
+			return true
+		}
+		perEntry[res.Index] = append(perEntry[res.Index], seqs(res.Events)...)
+		return true
+	})
+	require.NoError(t, err, "a per-block fetch failure is a per-entry error, not a Download failure")
+	require.Error(t, entry0Err, "entry 0's failing block must surface in order")
+	require.ErrorContains(t, entry0Err, "getBlock 1")
+	require.Equal(t, []uint64{1, 2}, perEntry[0], "entry 0 delivers only the good prefix before the error")
+	require.Equal(t, []uint64{101, 102, 103, 104, 105, 106}, perEntry[1], "entry 1 must complete despite entry 0's error")
+}
+
+// TestDownloadBlocksConcurrencyEquivalence extends the equivalence guard to
+// block mode: the emitted stream must be identical at any pool width.
+func TestDownloadBlocksConcurrencyEquivalence(t *testing.T) {
+	t.Parallel()
+	as := newArchiveServer(t)
+	const nSeg = 6
+	var entries []PlanEntry
+	for s := range nSeg {
+		var events []segment.Event
+		for i := range 8 { // 4 blocks
+			seq := uint64(s*1000 + i + 1)
+			events = append(events, makeCreate(t, seq, "did:plc:a", "app.bsky.feed.post", "r"+strconv.FormatUint(seq, 10)))
+		}
+		as.addSegment(t, segName(s), events)
+		// Skip block 2 of each segment to exercise sparse ranges.
+		entries = append(entries, PlanEntry{
+			SegmentName: segName(s), Index: uint32(s), Mode: ModeBlocks,
+			Blocks: []BlockRange{{First: 0, Last: 1}, {First: 3, Last: 3}},
+		})
+	}
+
+	base := seqs(collectOrdered(t, as.downloader(1), entries))
+	for _, c := range []int{4, 16, 32} {
+		got := seqs(collectOrdered(t, as.downloader(c), entries))
+		require.Equal(t, base, got, "block-mode output must be independent of concurrency=%d", c)
+	}
+}
+
+// TestDownloadBlocksEarlyStopNoLeak exercises the pool teardown path: an
+// emit-driven early stop mid-plan (with many block fetches in flight) must
+// unwind cleanly. Combined with the serial goroutine-leak tests above, and run
+// under -race, this pins the coordinator's cancellation paths.
+func TestDownloadBlocksEarlyStopNoLeak(t *testing.T) {
+	t.Parallel()
+	as := newArchiveServer(t)
+	const nSeg = 20
+	var entries []PlanEntry
+	for s := range nSeg {
+		var events []segment.Event
+		for i := range 6 {
+			seq := uint64(s*100 + i + 1)
+			events = append(events, makeCreate(t, seq, "did:plc:a", "app.bsky.feed.post", "r"+strconv.FormatUint(seq, 10)))
+		}
+		as.addSegment(t, segName(s), events)
+		entries = append(entries, PlanEntry{
+			SegmentName: segName(s), Index: uint32(s), Mode: ModeBlocks,
+			Blocks: []BlockRange{{First: 0, Last: 2}},
+		})
+	}
+
+	emitted := 0
+	err := as.downloader(4).Download(context.Background(), entries, func(EntryResult) bool {
+		emitted++
+		return false
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, emitted)
 }
 
 func seqs(events []Event) []uint64 {

--- a/options.go
+++ b/options.go
@@ -171,9 +171,15 @@ func WithBatchSize(n int) Option {
 	}
 }
 
-// WithDownloadConcurrency bounds how many sealed segment/block downloads (and
-// their decode work) run in parallel during backfill. Must be > 0; ignored
-// otherwise.
+// WithDownloadConcurrency sizes the backfill parallelism: n bounds the block
+// decode pool directly, and the block-mode getBlock fetch pool is derived from
+// it (2n, capped at 64) so sparse (DID/collection-filtered) backfills overlap
+// network round trips instead of paying one RTT per block. Must be > 0;
+// ignored otherwise.
+//
+// Whole-segment downloads are prefetched ahead of decode but currently run one
+// at a time, so over a WAN this knob governs decode and sparse-fetch
+// parallelism, not whole-segment wire throughput.
 //
 // The default is auto-sized from the CPU count (GOMAXPROCS, clamped to
 // [4, 32]), so a many-core host uses more of its cores without configuration

--- a/specs/notes/2026-07-08-performance-exploration-cpu2-pop3.md
+++ b/specs/notes/2026-07-08-performance-exploration-cpu2-pop3.md
@@ -477,6 +477,13 @@ out-of-order completion; the plan gives every block's identity up front).
 multiplicatively with block count. This is the highest leverage change in
 the client for real-world use.
 
+**Done (#292, 2026-07-09):** block fetches now run on a shared pool
+(2×download-concurrency, capped 64) with per-entry ordered futures.
+Re-measured, same 3-DID scenario: 15.4 s → **1.6 s** over the WAN, and the
++100 ms-added-RTT case 54.3 s → **2.6 s** (~21× at elevated RTT). Ordering,
+per-entry error, and early-stop contracts unchanged; whole-segment path
+untouched (A6.2 still open).
+
 ### A6.2 P0 — Stripe whole-segment downloads across ranges/streams
 
 The single-flight prefetcher caps every WAN backfill at one TCP stream's


### PR DESCRIPTION
## Context

Block-mode plan entries were fetched serially — one `getBlock` round trip per block, inline on the framer goroutine — so a sparse (DID/collection-filtered) backfill over a WAN was RTT-bound at ~14 blocks/s at 70 ms regardless of bandwidth. Measured 139× slower than localhost for a 3-DID backfill (0.11 s → 15.4 s), scaling multiplicatively with block count × RTT. Full analysis in `specs/notes/2026-07-08-performance-exploration-cpu2-pop3.md` §A3/§A6.1.

## Change

- Adds a **block-fetch coordinator**: a shared getBlock worker pool sized `min(2×download-concurrency, 64)` (under the transport's `MaxConnsPerHost=100`), fed FIFO across entries so plan-order blocks fetch first and later entries' blocks fill idle workers — cross-entry parallelism, which is what matters for sparse plans (many entries of few blocks).
- The framer consumes **per-entry ordered future streams**, so dispatch order — and therefore emission order, per-entry error semantics (good prefix → in-order error → entry stops → next continues), and early-stop behavior — is unchanged. Only the round trips overlap.
- An in-flight token bound keeps fetched-frame memory O(pool width), small next to the existing 2×~280 MB whole-segment prefetch budget.
- Pool sizing derives from the existing `WithDownloadConcurrency` knob (no new option); getBlock is nearly free server-side (one stored frame read), so the client optimizes its own end-to-end latency. Docs updated to say what the knob actually governs, including the caveat that whole-segment WAN throughput is still single-stream (§A6.2, separate work).

## Measured

Boston → cpu2-pop3 (Seattle), 70 ms RTT, 3-DID backfill over the 100k-repo archive (~200 blocks):

| scenario | before | after |
|---|---|---|
| real WAN | 15.4 s | **1.6 s** |
| +100 ms added RTT | 54.3 s | **2.6 s** |

Whole-segment and mixed-window WAN paths re-verified unchanged.

## Tests

- Parallelism guard that parks getBlock requests until pool-width concurrency is observed — a serial regression hangs deterministically and fails via watchdog (no wall-clock flakiness).
- Cross-entry parallelism guard (8 entries × 1 block requiring 8 concurrent fetches).
- Block-mode error-stops-entry-not-plan, concurrency-equivalence (1/4/16/32), early-stop teardown; goroutine-leak test now alternates whole-segment/block modes to cover pool teardown.
- `just` (lint + short tests) green, `just test-race ./internal/client` green (136 tests). No mutants target `downloader.go`.

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)