### PR TITLE
segment: right-size per-block DID blooms to actual block cardinality at seal time

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -236,7 +236,7 @@ The variable-length footer has two structures that work together to enable fast 
 
 We use gloom for both and persist its current `MarshalBinary` representation directly. A backwards-incompatible gloom serialization change is therefore a Jetstream segment format change; readers are only expected to support the format produced by the pinned gloom version. We serialize the segment-level bloom to disk upon segment seal, and also keep all segment's blooms in Jetstream server's memory since it's small.
 
-The per-block blooms are kept on disk (one bloom per block, all sized for the configured max events per block so we can index them by multiplication with no offset table). Today the manifest holds every segment's per-block blooms resident in memory; if that footprint becomes a problem, a future change may swap them for an LRU cache of the hot set.
+The per-block blooms are kept on disk (one bloom per block, all sized identically — for the segment's max per-block unique-DID count, computed at seal time — so we can index them by multiplication with no offset table; blocks below the max realize a better-than-target false-positive rate). The region header is self-describing (`bloom_size_bytes`), so segments sealed under different sizing rules coexist. Today the manifest holds every segment's per-block blooms resident in memory; right-sizing keeps that footprint to a few GiB even at full-network scale (see `specs/notes/2026-07-10-bloom-memory-exploration.md`).
 
 The lookup flow for "give me all events for DID X in this segment" is:
 

--- a/segment/bloom.go
+++ b/segment/bloom.go
@@ -14,8 +14,21 @@ import (
 // The 0.001 (0.1%) false-positive rate balances on-disk size
 // (negligible relative to a ~256 MB segment) against scan-time false
 // positives (each FP costs a full block decompress + column scan,
-// which is meaningfully expensive). AGENTS.md and docs/README.md
-// document RAM as cheap on these servers, so we don't penny-pinch.
+// which is meaningfully expensive).
+//
+// Per-block bloom CAPACITY is not a constant: filters are sized for the
+// segment's actual max per-block unique-DID cardinality at seal time
+// (issue #302). Real blocks hold runs of a few repos — the measured
+// median is 1-3 unique DIDs against the old fixed capacity of 4096
+// (MaxEventsPerBlock), which made the blooms ~1000x oversized at the
+// median and >90% of server heap (44-88 GiB resident; see
+// specs/notes/2026-07-10-bloom-memory-exploration.md). Sizing to the
+// segment-wide max keeps every bloom in a segment identical in size —
+// the invariant that lets the reader index the region by multiplication
+// with no offset table — while blocks below the max simply realize a
+// better-than-target FP rate. The region header is self-describing
+// (bloom_size_bytes), so right-sized and legacy fixed-size segments
+// coexist with no format change.
 const (
 	perBlockBloomFPRate = 0.001
 
@@ -23,25 +36,7 @@ const (
 	// across all segments is bounded; FP cost is one extra pread to
 	// load per-block-blooms, which is also small but measurable. Same
 	// rate keeps the trade-off symmetric.
-	//
-	// Defined here for consistency; used by segment-level bloom
-	// construction in a future task.
 	segmentBloomFPRate = 0.001
-
-	// perBlockBloomCapacity is the expected-items count we feed gloom
-	// when constructing per-block filters. Per the spec §5.4, all
-	// per-block filters are sized identically so the region is
-	// indexable by multiplication; we use the writer's configured
-	// MaxEventsPerBlock as the upper bound. The actual cardinality of
-	// unique DIDs in a block is always ≤ MaxEventsPerBlock, so the
-	// configured FP rate is an upper bound on the realized rate.
-	//
-	// Callers that need a different cap (e.g., compaction with a
-	// rebuilt block) should pass an explicit capacity; for now this
-	// constant is what Seal uses. We tie it to DefaultMaxEventsPerBlock
-	// because that's the writer default; the seal-time call is
-	// parameterized so an alternate cap is supported.
-	perBlockBloomCapacity = uint64(DefaultMaxEventsPerBlock)
 )
 
 // blockBloomsRegionHeaderSize is the 8-byte uncompressed header that

--- a/segment/bloom_test.go
+++ b/segment/bloom_test.go
@@ -14,7 +14,7 @@ func fixedSizeBlooms(t *testing.T, n int) []*gloom.Filter {
 	t.Helper()
 	out := make([]*gloom.Filter, n)
 	for i := range out {
-		out[i] = gloom.New(perBlockBloomCapacity, perBlockBloomFPRate)
+		out[i] = gloom.New(64, perBlockBloomFPRate)
 	}
 	return out
 }

--- a/segment/rewrite.go
+++ b/segment/rewrite.go
@@ -178,7 +178,7 @@ func Rewrite(path string, decide func(*Event) RowDecision, opts RewriteOptions) 
 	}
 
 	footerOffset := int64(nextOffset)
-	footerBytes, newHeader, err := buildFooterWithBloomParams(walk, DefaultMaxEventsPerBlock, footerOffset, perBlockParams)
+	footerBytes, newHeader, err := buildFooterWithBloomParams(walk, footerOffset, perBlockParams)
 	if err != nil {
 		return RewriteResult{}, err
 	}

--- a/segment/seal.go
+++ b/segment/seal.go
@@ -118,7 +118,7 @@ func (w *Writer) sealAfterFlush() (SealResult, error) {
 		return SealResult{}, err
 	}
 
-	footerBytes, header, err := buildFooter(walk, w.cfg.MaxEventsPerBlock, footerOffset)
+	footerBytes, header, err := buildFooter(walk, footerOffset)
 	if err != nil {
 		return SealResult{}, err
 	}
@@ -417,11 +417,11 @@ func walkActiveFrames(f io.ReaderAt, maxOffset int64) (blockWalkResult, error) {
 // specified in docs/README.md §3.1.2 and spec §5.6 and returns them
 // concatenated, plus the partially-populated Header (Checksum left
 // zero; the caller fills it in after computing xxh3).
-func buildFooter(walk blockWalkResult, maxEventsPerBlock int, footerOffset int64) ([]byte, Header, error) {
-	return buildFooterWithBloomParams(walk, maxEventsPerBlock, footerOffset, nil)
+func buildFooter(walk blockWalkResult, footerOffset int64) ([]byte, Header, error) {
+	return buildFooterWithBloomParams(walk, footerOffset, nil)
 }
 
-func buildFooterWithBloomParams(walk blockWalkResult, maxEventsPerBlock int, footerOffset int64, perBlockParams *bloomParams) ([]byte, Header, error) {
+func buildFooterWithBloomParams(walk blockWalkResult, footerOffset int64, perBlockParams *bloomParams) ([]byte, Header, error) {
 	// 1. Block index.
 	blockIndexBytes := encodeBlockIndex(walk.infos)
 
@@ -435,14 +435,27 @@ func buildFooterWithBloomParams(walk blockWalkResult, maxEventsPerBlock int, foo
 		return nil, Header{}, fmt.Errorf("segment: marshal segment bloom: %w", err)
 	}
 
-	// 3. Per-block DID blooms.
+	// 3. Per-block DID blooms, right-sized to the segment's actual max
+	// per-block unique-DID cardinality (see the sizing rationale in
+	// bloom.go). Sizing every filter for the max — rather than each
+	// block's own count — is what preserves the equal-size region
+	// invariant; the FP target is realized exactly on the max block
+	// and beaten on the rest. Capacity clamps to >= 1 so a segment of
+	// DID-less events (identity/account markers) still produces a
+	// valid minimal filter.
+	perBlockCapacity := uint64(1)
+	for _, dids := range walk.perBlockDIDs {
+		if n := uint64(len(dids)); n > perBlockCapacity {
+			perBlockCapacity = n
+		}
+	}
 	perBlockFilters := make([]*gloom.Filter, len(walk.perBlockDIDs))
 	for i, dids := range walk.perBlockDIDs {
 		var f *gloom.Filter
 		if perBlockParams != nil {
 			f = gloom.NewWithParams(perBlockParams.numBlocks, perBlockParams.k)
 		} else {
-			f = gloom.New(uint64(maxEventsPerBlock), perBlockBloomFPRate)
+			f = gloom.New(perBlockCapacity, perBlockBloomFPRate)
 		}
 		for did := range dids {
 			f.AddString(did)

--- a/segment/seal_bloom_test.go
+++ b/segment/seal_bloom_test.go
@@ -1,0 +1,178 @@
+package segment
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// sealSegmentForBloomTest writes events at the DEFAULT MaxEventsPerBlock
+// (4096) and flushes every flushEvery events, modelling the production
+// live-write shape where the 30s timer flushes partial blocks. This is
+// exactly the shape where capacity-from-config oversizes blooms.
+func sealSegmentForBloomTest(t *testing.T, events []Event, flushEvery int) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "seg.jss")
+	w, err := New(Config{Path: path})
+	require.NoError(t, err)
+	for i, ev := range events {
+		full, err := w.Append(ev)
+		require.NoError(t, err)
+		if full || (i+1)%flushEvery == 0 {
+			require.NoError(t, w.Flush())
+		}
+	}
+	_, err = w.Seal()
+	require.NoError(t, err)
+	return path
+}
+
+// TestSealRightSizesPerBlockBlooms pins issue #302: per-block DID
+// blooms must be sized for the segment's actual max per-block
+// unique-DID cardinality, not for MaxEventsPerBlock. A segment whose
+// blocks each hold a handful of DIDs must carry proportionally small
+// blooms (the old fixed sizing was 8,409 bytes for capacity 4096).
+func TestSealRightSizesPerBlockBlooms(t *testing.T) {
+	t.Parallel()
+
+	// 4 blocks x 64 events, but every block holds only 2 unique DIDs.
+	var events []Event
+	seq := uint64(0)
+	for b := range 4 {
+		for i := range 64 {
+			seq++
+			events = append(events, Event{
+				Seq: seq, WitnessedAt: int64(seq), Kind: KindCreate,
+				DID:        fmt.Sprintf("did:plc:block%d-user%d", b, i%2),
+				Collection: "app.bsky.feed.post",
+				Rkey:       fmt.Sprintf("k%d", seq), Rev: "v", Payload: []byte("p"),
+			})
+		}
+	}
+	path := sealSegmentForBloomTest(t, events, 64)
+
+	ins, err := Inspect(path)
+	require.NoError(t, err)
+	require.True(t, ins.Sealed)
+	require.Len(t, ins.Blocks, 4)
+
+	// Capacity 2 at FP 0.001 marshals to well under 300 bytes; the old
+	// fixed capacity-4096 sizing was 8,409. Assert "proportionally
+	// small" rather than an exact byte count so gloom tuning changes
+	// don't break this test.
+	require.NotZero(t, ins.PerBlockBloomBytes)
+	require.Lessf(t, ins.PerBlockBloomBytes, uint32(300),
+		"per-block blooms not right-sized: %d bytes for 2 unique DIDs/block",
+		ins.PerBlockBloomBytes)
+}
+
+// TestSealBloomSizeScalesWithCardinality: a DID-dense segment must
+// still size its blooms up so the FP target holds.
+func TestSealBloomSizeScalesWithCardinality(t *testing.T) {
+	t.Parallel()
+
+	// One block of 512 events, all distinct DIDs.
+	var events []Event
+	for i := range 512 {
+		events = append(events, Event{
+			Seq: uint64(i + 1), WitnessedAt: int64(i + 1), Kind: KindCreate,
+			DID:        fmt.Sprintf("did:plc:user%08d", i),
+			Collection: "app.bsky.feed.post",
+			Rkey:       fmt.Sprintf("k%d", i), Rev: "v", Payload: []byte("p"),
+		})
+	}
+	path := sealSegmentForBloomTest(t, events, 512)
+
+	ins, err := Inspect(path)
+	require.NoError(t, err)
+	require.Len(t, ins.Blocks, 1)
+
+	// 512 distinct DIDs at FP 0.001 needs on the order of a KiB of
+	// filter; anything under that means the bloom was undersized and
+	// the FP contract is broken.
+	require.Greaterf(t, ins.PerBlockBloomBytes, uint32(700),
+		"bloom undersized for 512 unique DIDs: %d bytes", ins.PerBlockBloomBytes)
+}
+
+// TestSealMixedCardinalityUsesSegmentMax: with one dense block among
+// sparse ones, every bloom is sized for the max (region invariant:
+// equal sizes within a segment) and no false negatives appear in any
+// block.
+func TestSealMixedCardinalityUsesSegmentMax(t *testing.T) {
+	t.Parallel()
+
+	var events []Event
+	seq := uint64(0)
+	// Block 0: sparse (1 DID x 32 events).
+	for range 32 {
+		seq++
+		events = append(events, Event{
+			Seq: seq, WitnessedAt: int64(seq), Kind: KindCreate,
+			DID: "did:plc:sparse", Collection: "app.bsky.feed.post",
+			Rkey: fmt.Sprintf("k%d", seq), Rev: "v", Payload: []byte("p"),
+		})
+	}
+	// Block 1: dense (32 distinct DIDs).
+	for i := range 32 {
+		seq++
+		events = append(events, Event{
+			Seq: seq, WitnessedAt: int64(seq), Kind: KindCreate,
+			DID:        fmt.Sprintf("did:plc:dense%04d", i),
+			Collection: "app.bsky.feed.post",
+			Rkey:       fmt.Sprintf("k%d", seq), Rev: "v", Payload: []byte("p"),
+		})
+	}
+	path := sealSegmentForBloomTest(t, events, 32)
+
+	r, err := Open(ReaderConfig{Path: path})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+	require.Len(t, r.Blocks(), 2)
+
+	// Region invariant: equal-sized blooms, loadable in bulk.
+	blooms, err := r.LoadAllBlockBlooms()
+	require.NoError(t, err)
+	require.Len(t, blooms, 2)
+
+	// One-sided contract: every DID selects its true block.
+	sel, err := r.BlocksContainingDID("did:plc:sparse")
+	require.NoError(t, err)
+	require.Contains(t, sel, 0)
+	for i := range 32 {
+		sel, err := r.BlocksContainingDID(fmt.Sprintf("did:plc:dense%04d", i))
+		require.NoError(t, err)
+		require.Containsf(t, sel, 1, "dense DID %d lost from block 1", i)
+	}
+
+	// Full metadata verification (includes per-block bloom FN checks).
+	require.NoError(t, VerifySealedMetadata(r))
+}
+
+// TestSealEmptyDIDOnlySegment: events with no DID (identity/account/
+// sync markers) contribute nothing to blooms; capacity clamps to a
+// minimal valid filter and the segment still opens and verifies.
+func TestSealEmptyDIDOnlySegment(t *testing.T) {
+	t.Parallel()
+
+	var events []Event
+	for i := range 8 {
+		events = append(events, Event{
+			Seq: uint64(i + 1), WitnessedAt: int64(i + 1),
+			Kind: KindAccount, DID: "", Payload: []byte("p"),
+		})
+	}
+	path := sealSegmentForBloomTest(t, events, 4)
+
+	r, err := Open(ReaderConfig{Path: path})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+	require.NoError(t, VerifySealedMetadata(r))
+
+	ins, err := Inspect(path)
+	require.NoError(t, err)
+	// Minimal filter: one 512-bit gloom block + framing, ~90 bytes.
+	require.NotZero(t, ins.PerBlockBloomBytes)
+	require.Less(t, ins.PerBlockBloomBytes, uint32(150))
+}


### PR DESCRIPTION
Closes #302

## What

Per-block DID blooms were built with fixed capacity `MaxEventsPerBlock` (4096), marshaling to 8,409 bytes each regardless of content — but they only ever receive a block's **unique DIDs**, whose measured median on real archives is 1–3 (backfill writes one repo's events contiguously). The oversizing made resident blooms >90% of server heap: 44.3 GiB on the full-network archive, 88.1 GiB on the 100k-repo archive (measured on cpu2-pop3; `specs/notes/2026-07-10-bloom-memory-exploration.md`).

`buildFooter` now sizes every per-block bloom for the segment's actual **max per-block unique-DID cardinality** (clamped to ≥ 1), computed from the seal walk's existing per-block DID sets. Measured effect against the real archives: **44.3 → 2.2 GiB** and **88.1 → 12.9 GiB** resident.

## Why this is not a format change

Sizing to the segment-wide max (not each block's own count) keeps every bloom in a segment identical in size — the invariant that lets the reader index the region by multiplication with no offset table. The region header is self-describing (`bloom_size_bytes`), so right-sized and legacy fixed-size segments coexist freely; the golden-seal fixture needed no regeneration (its tiny segment sizes to the same minimal filter under both rules). The 0.001 FP target is realized exactly on the max-cardinality block and beaten on all others, so DID-query behavior is unchanged.

Also drops the now-dead `maxEventsPerBlock` parameter from `buildFooter`/`buildFooterWithBloomParams`. Compaction `Rewrite` still pins source-segment params — recomputing there so legacy archives shrink incrementally is #303.

## Tests

Red-first (asserted 8,409 B before the fix, proportional sizes after):
- sparse blocks (2 DIDs/block at default 4096-event config) → < 300 B blooms
- DID-dense block (512 distinct) still sizes up (> 700 B) so the FP contract holds
- mixed cardinality → all blooms sized for segment max; FN-freedom pinned via `VerifySealedMetadata` + `BlocksContainingDID` per DID
- all-empty-DID segment (identity/account markers) → minimal valid filter, opens and verifies

## Verification

- `just` (lint + 2,240 short tests) ✅
- `just test-long ./internal/oracle` (211 tests) ✅
- `just oracle-sweep` (36 tests) ✅
- `just fuzz 30s ./segment` (all 7 targets, ~6M execs each) ✅
- `just bench ./segment`: `BenchmarkSeal` 23.6 ms → 2.9 ms (~7×) — seal no longer allocates/marshals 8.4 KB per block ✅
- `just mutation-gate` on the committed tree: PASS, 43/43 mutants match baseline (m016/m044/m045 unaffected) ✅

Note for review: includes a one-sentence correction to `docs/README.md` §3.1.3, which previously documented the old sizing rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)