### PR TITLE
simulator: make e2e readiness failures actionable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
 
       - name: Test (race detector)
         env:
-          JETSTREAM_RACE_ARTIFACT_DIR: ${{ github.workspace }}/race-artifacts
+          RACE_ARTIFACT_DIR: ${{ github.workspace }}/race-artifacts
         run: ./dev.sh --command just test-race-ci
 
       - name: Upload race diagnostics

--- a/cmd/simulator/e2e_helpers_test.go
+++ b/cmd/simulator/e2e_helpers_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coder/websocket"
 	"github.com/stretchr/testify/require"
 )
 
@@ -48,6 +49,102 @@ func buildJetstreamForTest(t *testing.T) string {
 
 func newJetstreamCmd(ctx context.Context, bin string, args []string) *exec.Cmd {
 	return exec.CommandContext(ctx, bin, args...)
+}
+
+type jetstreamProcess struct {
+	cmd  *exec.Cmd
+	done chan error
+
+	mu      sync.Mutex
+	waited  bool
+	waitErr error
+}
+
+func startJetstreamForTest(t *testing.T, ctx context.Context, bin string, args []string, output *lockedBuffer) *jetstreamProcess {
+	t.Helper()
+
+	cmd := newJetstreamCmd(ctx, bin, args)
+	cmd.Stdout = output
+	cmd.Stderr = output
+	require.NoError(t, cmd.Start())
+
+	proc := &jetstreamProcess{
+		cmd:  cmd,
+		done: make(chan error, 1),
+	}
+	go func() {
+		proc.done <- cmd.Wait()
+	}()
+	return proc
+}
+
+func (p *jetstreamProcess) pollExit() (error, bool) {
+	p.mu.Lock()
+	if p.waited {
+		err := p.waitErr
+		p.mu.Unlock()
+		return err, true
+	}
+	p.mu.Unlock()
+
+	select {
+	case err := <-p.done:
+		p.mu.Lock()
+		p.waited = true
+		p.waitErr = err
+		p.mu.Unlock()
+		return err, true
+	default:
+		return nil, false
+	}
+}
+
+func (p *jetstreamProcess) stop() {
+	if _, exited := p.pollExit(); exited {
+		return
+	}
+	_ = p.cmd.Process.Kill()
+	err := <-p.done
+	p.mu.Lock()
+	p.waited = true
+	p.waitErr = err
+	p.mu.Unlock()
+}
+
+func waitForJetstreamSubscribeReady(t *testing.T, proc *jetstreamProcess, addr string, logs *lockedBuffer, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		if err, exited := proc.pollExit(); exited {
+			require.NoErrorf(t, err, "jetstream exited before /subscribe became ready; logs:\n%s", logs.String())
+			t.Fatalf("jetstream exited before /subscribe became ready; logs:\n%s", logs.String())
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		conn, resp, err := websocket.Dial(ctx, "ws://"+addr+"/subscribe", nil)
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		cancel()
+		if err == nil {
+			_ = conn.Close(websocket.StatusNormalClosure, "probe")
+			return
+		}
+
+		if time.Now().After(deadline) {
+			t.Fatalf("jetstream did not become ready; logs:\n%s", logs.String())
+		}
+
+		select {
+		case <-ticker.C:
+		case <-t.Context().Done():
+			t.Fatalf("test context ended before jetstream became ready: %v; logs:\n%s", t.Context().Err(), logs.String())
+		}
+	}
 }
 
 func freePortAddr(t *testing.T) string {

--- a/cmd/simulator/e2e_test.go
+++ b/cmd/simulator/e2e_test.go
@@ -82,7 +82,8 @@ func TestEndToEnd_JetstreamConsumesSimulator(t *testing.T) {
 	jetAddr := freePortAddr(t)
 	jetDebug := freePortAddr(t)
 
-	cmd := newJetstreamCmd(jetCtx, binPath, []string{
+	stderr := &lockedBuffer{}
+	proc := startJetstreamForTest(t, jetCtx, binPath, []string{
 		"serve",
 		"--addr", jetAddr,
 		"--debug-addr", jetDebug,
@@ -90,33 +91,13 @@ func TestEndToEnd_JetstreamConsumesSimulator(t *testing.T) {
 		"--relay-url", simSrv.URL,
 		"--plc-url", simSrv.URL,
 		"--shutdown-timeout=5s",
-	})
-	stderr := &lockedBuffer{}
-	cmd.Stdout = stderr
-	cmd.Stderr = stderr
-	require.NoError(t, cmd.Start())
-	defer func() {
-		_ = cmd.Process.Kill()
-		_ = cmd.Wait()
-	}()
+	}, stderr)
+	defer proc.stop()
 
 	// Wait for jetstream's /subscribe to start serving (backfill
 	// drained → steady-state). The handler returns 503 while not
 	// in steady-state; a successful websocket dial means we're in.
-	require.Eventually(t, func() bool {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-		defer cancel()
-		conn, resp, err := websocket.Dial(ctx, "ws://"+jetAddr+"/subscribe", nil)
-		if resp != nil && resp.Body != nil {
-			_ = resp.Body.Close()
-		}
-		if err != nil {
-			return false
-		}
-		_ = conn.Close(websocket.StatusNormalClosure, "probe")
-		return true
-	}, 45*time.Second, 250*time.Millisecond,
-		"jetstream did not become ready; logs:\n%s", stderr.String())
+	waitForJetstreamSubscribeReady(t, proc, jetAddr, stderr, 45*time.Second)
 
 	// Now consume one live event.
 	dialCtx, dialCancel := context.WithTimeout(context.Background(), 15*time.Second)

--- a/cmd/simulator/getblock_e2e_test.go
+++ b/cmd/simulator/getblock_e2e_test.go
@@ -19,7 +19,6 @@ import (
 	simhttp "github.com/bluesky-social/jetstream/internal/simulator/http"
 	"github.com/bluesky-social/jetstream/internal/simulator/world"
 	"github.com/bluesky-social/jetstream/segment"
-	"github.com/coder/websocket"
 	"github.com/stretchr/testify/require"
 )
 
@@ -108,7 +107,8 @@ func TestEndToEnd_GetBlockMatchesOracle(t *testing.T) {
 	jetAddr := freePortAddr(t)
 	jetDebug := freePortAddr(t)
 
-	cmd := newJetstreamCmd(jetCtx, binPath, []string{
+	stderr := &lockedBuffer{}
+	proc := startJetstreamForTest(t, jetCtx, binPath, []string{
 		"serve",
 		"--addr", jetAddr,
 		"--debug-addr", jetDebug,
@@ -116,33 +116,13 @@ func TestEndToEnd_GetBlockMatchesOracle(t *testing.T) {
 		"--relay-url", simSrv.URL,
 		"--plc-url", simSrv.URL,
 		"--shutdown-timeout=5s",
-	})
-	stderr := &lockedBuffer{}
-	cmd.Stdout = stderr
-	cmd.Stderr = stderr
-	require.NoError(t, cmd.Start())
-	defer func() {
-		_ = cmd.Process.Kill()
-		_ = cmd.Wait()
-	}()
+	}, stderr)
+	defer proc.stop()
 
 	// Wait for jetstream's /subscribe to start serving (backfill drained →
 	// steady-state). The getBlock/listSegments routes share the same readiness
 	// gate, so a successful websocket dial also means those routes are live.
-	require.Eventually(t, func() bool {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-		defer cancel()
-		conn, resp, err := websocket.Dial(ctx, "ws://"+jetAddr+"/subscribe", nil)
-		if resp != nil && resp.Body != nil {
-			_ = resp.Body.Close()
-		}
-		if err != nil {
-			return false
-		}
-		_ = conn.Close(websocket.StatusNormalClosure, "probe")
-		return true
-	}, 45*time.Second, 250*time.Millisecond,
-		"jetstream did not become ready; logs:\n%s", stderr.String())
+	waitForJetstreamSubscribeReady(t, proc, jetAddr, stderr, 45*time.Second)
 
 	segDir := filepath.Join(jetDir, "segments")
 	listURL := "http://" + jetAddr + "/xrpc/network.bsky.jetstream.listSegments?limit=1000"

--- a/justfile
+++ b/justfile
@@ -120,7 +120,9 @@ test-race-ci *ARGS="./...":
     #!/usr/bin/env bash
     set -euo pipefail
 
-    artifact_dir="${JETSTREAM_RACE_ARTIFACT_DIR:-race-artifacts}"
+    # Do not use the JETSTREAM_ prefix here. The jetstream binary reserves that
+    # namespace for runtime config and intentionally rejects unknown keys.
+    artifact_dir="${RACE_ARTIFACT_DIR:-race-artifacts}"
     mkdir -p "${artifact_dir}"
 
     echo "test-race-ci: writing diagnostics to ${artifact_dir}"


### PR DESCRIPTION
## Summary

- move the CI race artifact directory variable from `JETSTREAM_RACE_ARTIFACT_DIR` to `RACE_ARTIFACT_DIR` so spawned jetstream children do not reject an unknown runtime env var
- add a shared simulator E2E child-process helper that waits on the jetstream subprocess while polling `/subscribe`
- fail immediately with captured child output when jetstream exits before readiness instead of timing out with empty logs

## Root Cause

The CI race job exported `JETSTREAM_RACE_ARTIFACT_DIR`, and the simulator E2E tests spawn a real `jetstream` child that inherits the parent environment. `jetstream` intentionally rejects unknown `JETSTREAM_*` variables before runtime startup, so the child exited before `/subscribe` could become ready. The harness was only polling the websocket endpoint and deferred `cmd.Wait`, so CI reported a readiness timeout with no useful child error.

## Verification

- `GOCACHE=$(mktemp -d) RACE_ARTIFACT_DIR=/tmp/jetstream-fixed-race-e2e-both just test-race-ci ./cmd/simulator -run TestEndToEnd_`
- negative repro: `JETSTREAM_RACE_ARTIFACT_DIR=/tmp/jetstream-old-env-fastfail go test -race ./cmd/simulator -run TestEndToEnd_JetstreamConsumesSimulator -count=1` now fails fast with the true env-validation error
- `git diff --check`
- `yq e . .github/workflows/ci.yml >/dev/null`
- `just`

Closes #309