### PR TITLE
toolchain: upgrade Go to 1.26.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # ──────────────────────────────────────────────────────────────────────────────
 # Build stage
 # ──────────────────────────────────────────────────────────────────────────────
-FROM --platform=$BUILDPLATFORM golang:1.26.4-bookworm AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.5-bookworm AS build
 
 # Build-args set by `docker buildx build` (or stamped manually from CI).
 # VERSION/COMMIT/DATE are linked into internal/version via -ldflags.

--- a/flake.lock
+++ b/flake.lock
@@ -16,9 +16,26 @@
         "type": "github"
       }
     },
+    "nixpkgs-go": {
+      "locked": {
+        "lastModified": 1784432872,
+        "narHash": "sha256-n3gKTBIV4ZA5VQpUakffBe3KGu4+mhPoA34rrqS0GkA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fd1462031fdee08f65fd0b4c6b64e22239a77870",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-26.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
+        "nixpkgs-go": "nixpkgs-go",
         "systems": "systems"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,10 +3,11 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs-go.url = "github:NixOS/nixpkgs/nixos-26.05";
     systems.url = "github:nix-systems/default";
   };
 
-  outputs = { self, nixpkgs, systems }:
+  outputs = { self, nixpkgs, nixpkgs-go, systems }:
     let
       eachSystem = nixpkgs.lib.genAttrs (import systems);
     in
@@ -14,7 +15,11 @@
       devShells = eachSystem (system:
         let
           pkgs = import nixpkgs { inherit system; };
-          go = pkgs.go_1_26;
+          goPkgs = import nixpkgs-go { inherit system; };
+          goVersion = "1.26.5";
+          go = assert pkgs.lib.assertMsg (goPkgs.go_1_26.version == goVersion)
+            "nixpkgs-go must provide Go ${goVersion}, got ${goPkgs.go_1_26.version}";
+            goPkgs.go_1_26;
           golangci-lint = pkgs.buildGoModule {
             pname = "golangci-lint";
             version = "2.10.1";
@@ -63,7 +68,7 @@
 
             shellHook = ''
               export GOTOOLCHAIN=local
-              echo "jetstream dev shell: Go 1.26.4 ($(go version))"
+              echo "jetstream dev shell: Go ${goVersion} ($(go version))"
               echo "tools: just $(just --version | awk '{print $2}'), golangci-lint 2.10.1, gotestsum 1.13.0, govulncheck 1.5.0, modernize 0.20.0"
             '';
           };

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bluesky-social/jetstream
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/cockroachdb/errors v1.11.3


### PR DESCRIPTION
## Summary

- upgrade go.mod and the Docker build image to Go 1.26.5
- source Go from the nixos-26.05 package set while retaining nixpkgs-unstable for the other development tools
- assert the exact Go patch version during Nix evaluation so lock drift fails closed
- keep CI aligned through its existing dev.sh/Nix entrypoint

## Verification

- `./dev.sh --command go version` reports `go1.26.5`
- `nix flake check --no-build --all-systems`
- `golangci-lint run --timeout 5m ./...`: 0 issues
- 2,229 short tests pass when excluding the two pre-existing strict-memory wrappers tracked in #316
- `golang:1.26.5-bookworm` resolves for linux/amd64 and linux/arm64
- repository-wide scan contains no Go 1.26.4 or 1.25.4 references

The complete local `just` run reaches the pre-existing strict-memory oracle wedge tracked in #316. The exact deterministic case reproduces on an untouched HEAD archive under Go 1.26.4, so it is not an upgrade regression.

Closes #291