### PR TITLE
subscribe: avoid quadratic active cold replay

### DIFF
--- a/internal/ingest/writer.go
+++ b/internal/ingest/writer.go
@@ -726,6 +726,31 @@ func (w *Writer) ActiveIndex() uint64 {
 	return w.activeIdx
 }
 
+// ActiveFlushedRange is a coherent snapshot of one active segment generation's
+// frame-aligned flushed byte range. It excludes the pending in-memory block.
+type ActiveFlushedRange struct {
+	Index       uint64
+	StartOffset uint64
+	EndOffset   uint64
+}
+
+// ActiveFlushedRange returns the active flushed range containing startSeq and
+// every later flushed block in the same active generation. Segment index and
+// offsets are captured together under the writer lock; disk I/O must happen
+// after this method returns.
+func (w *Writer) ActiveFlushedRange(startSeq uint64) (ActiveFlushedRange, bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed || w.active == nil {
+		return ActiveFlushedRange{}, false
+	}
+	start, end, ok := w.active.FlushedRangeFromSeq(startSeq)
+	if !ok {
+		return ActiveFlushedRange{}, false
+	}
+	return ActiveFlushedRange{Index: w.activeIdx, StartOffset: start, EndOffset: end}, true
+}
+
 // SegmentsDir returns the configured segments directory. The cfg is
 // read-only after Open, so no mutex is needed.
 func (w *Writer) SegmentsDir() string {

--- a/internal/ingest/writer_test.go
+++ b/internal/ingest/writer_test.go
@@ -77,6 +77,31 @@ func newTestWriter(t *testing.T, overrides Config) *Writer {
 	return w
 }
 
+func TestActiveFlushedRangeExcludesPendingAndAdvancesByBlock(t *testing.T) {
+	t.Parallel()
+	w := newTestWriter(t, Config{MaxEventsPerBlock: 2, MaxSegmentBytes: 1 << 30})
+
+	require.NoError(t, w.Append(t.Context(), &segment.Event{Kind: segment.KindCreate, DID: "did:plc:range"}))
+	_, ok := w.ActiveFlushedRange(1)
+	require.False(t, ok, "pending memory must not be cold-readable")
+
+	require.NoError(t, w.Append(t.Context(), &segment.Event{Kind: segment.KindCreate, DID: "did:plc:range"}))
+	r1, ok := w.ActiveFlushedRange(1)
+	require.True(t, ok)
+	require.Equal(t, uint64(0), r1.Index)
+	require.Equal(t, uint64(segment.ReservedHeaderBytes), r1.StartOffset)
+	require.Greater(t, r1.EndOffset, r1.StartOffset)
+
+	require.NoError(t, w.Append(t.Context(), &segment.Event{Kind: segment.KindCreate, DID: "did:plc:range"}))
+	_, ok = w.ActiveFlushedRange(3)
+	require.False(t, ok, "the next pending block must remain excluded")
+	require.NoError(t, w.Append(t.Context(), &segment.Event{Kind: segment.KindCreate, DID: "did:plc:range"}))
+	r2, ok := w.ActiveFlushedRange(3)
+	require.True(t, ok)
+	require.Equal(t, r1.EndOffset, r2.StartOffset)
+	require.Greater(t, r2.EndOffset, r2.StartOffset)
+}
+
 type fakeTimestampStamper struct {
 	indexedAt int64
 	err       error

--- a/internal/subscribe/coldreader_test.go
+++ b/internal/subscribe/coldreader_test.go
@@ -2,9 +2,16 @@ package subscribe_test
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"log/slog"
 	"path/filepath"
 	"sync/atomic"
 	"testing"
+
+	"github.com/bluesky-social/jetstream/internal/store"
+	"github.com/bluesky-social/jetstream/segment"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/bluesky-social/jetstream/internal/ingest"
 	"github.com/bluesky-social/jetstream/internal/subscribe"
@@ -40,6 +47,94 @@ func TestColdReadBatch_BoundedAndResumes(t *testing.T) {
 	batch2, _, err := rd.Read(context.Background(), next, 10)
 	require.NoError(t, err)
 	require.Equal(t, uint64(15), batch2[0].Event.Seq)
+}
+
+func TestColdReadActiveMultiBatchAdvancesRangeWithoutPrefixRescan(t *testing.T) {
+	t.Parallel()
+	const blocks, perBlock = 12, 4
+	_, w, rd := openActiveColdReader(t, blocks, perBlock)
+
+	cursor := uint64(1)
+	var priorStart uint64
+	var got []uint64
+	for range blocks {
+		rng, ok := w.ActiveFlushedRange(cursor)
+		require.True(t, ok)
+		if priorStart != 0 {
+			require.Greater(t, rng.StartOffset, priorStart,
+				"each resumed cold batch must seek to a later active block")
+		}
+		priorStart = rng.StartOffset
+
+		batch, next, err := rd.Read(context.Background(), cursor, perBlock)
+		require.NoError(t, err)
+		require.Len(t, batch, perBlock)
+		for _, e := range batch {
+			got = append(got, e.Event.Seq)
+		}
+		require.Greater(t, next, cursor)
+		cursor = next
+	}
+	want := make([]uint64, blocks*perBlock)
+	for i := range want {
+		want[i] = uint64(i + 1)
+	}
+	require.Equal(t, want, got)
+}
+
+func BenchmarkColdReadActiveRange(b *testing.B) {
+	for _, blocks := range []int{16, 64, 256} {
+		b.Run(fmt.Sprintf("blocks=%d", blocks), func(b *testing.B) {
+			_, _, rd := openActiveColdReader(b, blocks, 16)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				cursor := uint64(1)
+				for cursor <= uint64(blocks*16) {
+					batch, next, err := rd.Read(context.Background(), cursor, 64)
+					if err != nil {
+						b.Fatal(err)
+					}
+					if len(batch) == 0 || next <= cursor {
+						b.Fatalf("non-advancing active replay at %d", cursor)
+					}
+					cursor = next
+				}
+			}
+			b.ReportMetric(float64(blocks*16), "events/op")
+		})
+	}
+}
+
+func openActiveColdReader(tb testing.TB, blocks, perBlock int) (*store.Store, *ingest.Writer, *subscribe.ColdReader) {
+	tb.Helper()
+	dir := tb.TempDir()
+	st, err := store.Open(dir, store.NewMetrics(prometheus.NewRegistry()))
+	require.NoError(tb, err)
+	w, err := ingest.Open(ingest.Config{
+		SegmentsDir:           filepath.Join(dir, "segments"),
+		Store:                 st,
+		Logger:                slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Metrics:               ingest.NewMetrics(prometheus.NewRegistry()),
+		MaxEventsPerBlock:     perBlock,
+		MaxSegmentBytes:       1 << 30,
+		ReadLogRetentionBytes: 0,
+	})
+	require.NoError(tb, err)
+	for range blocks {
+		events := make([]segment.Event, perBlock)
+		for i := range events {
+			events[i] = segment.Event{Kind: segment.KindCreate, DID: "did:plc:active", Collection: "app.bsky.feed.post", Payload: []byte{0xa0}}
+		}
+		require.NoError(tb, w.AppendBatch(context.Background(), events))
+	}
+	require.NoError(tb, w.Flush(context.Background()))
+
+	var writerPtr atomic.Pointer[ingest.Writer]
+	writerPtr.Store(w)
+	rd := subscribe.NewColdReader(subscribe.ColdReaderConfig{WriterRef: &writerPtr, BlockCacheBytes: 1 << 20})
+	tb.Cleanup(func() { _ = w.Close(); _ = st.Close() })
+	return st, w, rd
 }
 
 func TestColdReadBatch_ExhaustsBeforeMax(t *testing.T) {

--- a/internal/subscribe/coldreader_test.go
+++ b/internal/subscribe/coldreader_test.go
@@ -55,7 +55,10 @@ func TestColdReadBatch_BoundedAndResumes(t *testing.T) {
 
 func TestColdReadActiveMultiBatchAdvancesRangeWithoutPrefixRescan(t *testing.T) {
 	t.Parallel()
-	const blocks, perBlock = 12, 4
+	// Production's default read batch is 1,024 events. Use the same total here,
+	// split across enough flushed blocks to exercise many resume boundaries
+	// without relying on a wall-clock performance threshold.
+	const blocks, perBlock = 32, 32
 	_, w, rd, rec := openActiveColdReader(t, blocks, perBlock)
 
 	cursor := uint64(1)

--- a/internal/subscribe/coldreader_test.go
+++ b/internal/subscribe/coldreader_test.go
@@ -2,15 +2,19 @@ package subscribe_test
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"log/slog"
+	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
 
 	"github.com/bluesky-social/jetstream/internal/store"
 	"github.com/bluesky-social/jetstream/segment"
+	"github.com/cockroachdb/pebble/vfs"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/bluesky-social/jetstream/internal/ingest"
@@ -52,7 +56,7 @@ func TestColdReadBatch_BoundedAndResumes(t *testing.T) {
 func TestColdReadActiveMultiBatchAdvancesRangeWithoutPrefixRescan(t *testing.T) {
 	t.Parallel()
 	const blocks, perBlock = 12, 4
-	_, w, rd := openActiveColdReader(t, blocks, perBlock)
+	_, w, rd, rec := openActiveColdReader(t, blocks, perBlock)
 
 	cursor := uint64(1)
 	var priorStart uint64
@@ -66,9 +70,19 @@ func TestColdReadActiveMultiBatchAdvancesRangeWithoutPrefixRescan(t *testing.T) 
 		}
 		priorStart = rng.StartOffset
 
+		rec.reset()
 		batch, next, err := rd.Read(context.Background(), cursor, perBlock)
 		require.NoError(t, err)
 		require.Len(t, batch, perBlock)
+		// The load-bearing assertion for issue #300: the batch's disk reads in
+		// the framed region must start at (or after) the snapshot's block
+		// offset. The quadratic WalkActiveFS path rescans from byte
+		// ReservedHeaderBytes every batch and trips this on batch 2.
+		for _, off := range rec.framedReads() {
+			require.GreaterOrEqual(t, off, int64(rng.StartOffset),
+				"cold batch at cursor %d rescanned the active prefix (read at %d, snapshot start %d)",
+				cursor, off, rng.StartOffset)
+		}
 		for _, e := range batch {
 			got = append(got, e.Event.Seq)
 		}
@@ -82,10 +96,89 @@ func TestColdReadActiveMultiBatchAdvancesRangeWithoutPrefixRescan(t *testing.T) 
 	require.Equal(t, want, got)
 }
 
+// TestColdReadActiveNilManifestSealedFileFailsLoud pins the no-manifest error
+// contract: when the snapshotted active generation turns out to be sealed at
+// open (rotation seam), a walker WITHOUT a manifest has no second source to
+// converge on, so the read must fail loud with the cursor unchanged — never
+// return an empty success that lets the caller jump the cursor to the floor
+// past unread durable events.
+func TestColdReadActiveNilManifestSealedFileFailsLoud(t *testing.T) {
+	t.Parallel()
+	const blocks, perBlock = 3, 4
+	_, w, rd, _ := openActiveColdReader(t, blocks, perBlock)
+
+	// Finalize the active file's header checksum out-of-band, simulating a
+	// seal landing between the writer snapshot and the range walk's open.
+	path := filepath.Join(w.SegmentsDir(), ingest.SegmentFilename(w.ActiveIndex()))
+	f, err := os.OpenFile(path, os.O_RDWR, 0)
+	require.NoError(t, err)
+	var checksum [8]byte
+	binary.LittleEndian.PutUint64(checksum[:], 0xdeadbeef)
+	_, err = f.WriteAt(checksum[:], 4)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	batch, next, err := rd.Read(context.Background(), 1, perBlock)
+	require.ErrorIs(t, err, segment.ErrSegmentSealed,
+		"nil-manifest cold read of a sealed active file must fail loud")
+	require.Empty(t, batch)
+	require.Equal(t, uint64(1), next, "cursor must not advance past unread events")
+}
+
+// recordingFS wraps a vfs.FS and records the offset of every ReadAt issued
+// through files it opened, so tests can assert on the byte ranges a cold
+// read actually touched.
+type recordingFS struct {
+	vfs.FS
+	mu      sync.Mutex
+	offsets []int64
+}
+
+func (r *recordingFS) Open(name string, opts ...vfs.OpenOption) (vfs.File, error) {
+	f, err := r.FS.Open(name, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &recordingFile{File: f, rec: r}, nil
+}
+
+func (r *recordingFS) reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.offsets = r.offsets[:0]
+}
+
+// framedReads returns the recorded offsets that landed in the framed-block
+// region (at or past the reserved header). Header/checksum probes below
+// ReservedHeaderBytes are expected on every open and excluded.
+func (r *recordingFS) framedReads() []int64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var out []int64
+	for _, off := range r.offsets {
+		if off >= int64(segment.ReservedHeaderBytes) {
+			out = append(out, off)
+		}
+	}
+	return out
+}
+
+type recordingFile struct {
+	vfs.File
+	rec *recordingFS
+}
+
+func (f *recordingFile) ReadAt(p []byte, off int64) (int, error) {
+	f.rec.mu.Lock()
+	f.rec.offsets = append(f.rec.offsets, off)
+	f.rec.mu.Unlock()
+	return f.File.ReadAt(p, off)
+}
+
 func BenchmarkColdReadActiveRange(b *testing.B) {
 	for _, blocks := range []int{16, 64, 256} {
 		b.Run(fmt.Sprintf("blocks=%d", blocks), func(b *testing.B) {
-			_, _, rd := openActiveColdReader(b, blocks, 16)
+			_, _, rd, _ := openActiveColdReader(b, blocks, 16)
 			b.ReportAllocs()
 			b.ResetTimer()
 			for b.Loop() {
@@ -106,7 +199,7 @@ func BenchmarkColdReadActiveRange(b *testing.B) {
 	}
 }
 
-func openActiveColdReader(tb testing.TB, blocks, perBlock int) (*store.Store, *ingest.Writer, *subscribe.ColdReader) {
+func openActiveColdReader(tb testing.TB, blocks, perBlock int) (*store.Store, *ingest.Writer, *subscribe.ColdReader, *recordingFS) {
 	tb.Helper()
 	dir := tb.TempDir()
 	st, err := store.Open(dir, store.NewMetrics(prometheus.NewRegistry()))
@@ -130,11 +223,15 @@ func openActiveColdReader(tb testing.TB, blocks, perBlock int) (*store.Store, *i
 	}
 	require.NoError(tb, w.Flush(context.Background()))
 
+	// The writer writes through the host OS filesystem; the recording FS wraps
+	// vfs.Default so the cold reader sees the same files while every ReadAt
+	// offset is captured for prefix-rescan assertions.
+	rec := &recordingFS{FS: vfs.Default}
 	var writerPtr atomic.Pointer[ingest.Writer]
 	writerPtr.Store(w)
-	rd := subscribe.NewColdReader(subscribe.ColdReaderConfig{WriterRef: &writerPtr, BlockCacheBytes: 1 << 20})
+	rd := subscribe.NewColdReader(subscribe.ColdReaderConfig{WriterRef: &writerPtr, FS: rec, BlockCacheBytes: 1 << 20})
 	tb.Cleanup(func() { _ = w.Close(); _ = st.Close() })
-	return st, w, rd
+	return st, w, rd, rec
 }
 
 func TestColdReadBatch_ExhaustsBeforeMax(t *testing.T) {

--- a/internal/subscribe/replay.go
+++ b/internal/subscribe/replay.go
@@ -210,13 +210,10 @@ func walkSealedRegion(ctx context.Context, input WalkInput, start uint64, emit f
 // walkActiveRegion emits events with Seq >= start from the active segment's
 // flushed blocks, in seq order, and returns the next unemitted seq.
 //
-// A concurrent seal of the active file is benign: segment.Seal only appends
-// the footer and patches the fixed header, never rewriting the frame region,
-// so the flushed frames stay byte-intact. If WalkActive runs past them into
-// footer bytes it fails loud (the footer's leading bytes don't decode as a
-// zstd frame) and emits nothing partial; that error propagates here and the
-// subscriber reconnects, by which point the file is a normal sealed segment
-// the sealed sweep will serve. See segment/walkactive_seal_test.go.
+// A concurrent seal of the active file is benign: the writer snapshot provides
+// an exact end offset before any footer, and Seal never rewrites frame bytes.
+// If the range opens after the header is finalized it returns ErrSegmentSealed;
+// the outer convergence loop re-enters the freshly published sealed region.
 func walkActiveRegion(input WalkInput, start uint64, emit func(*Entry) error) (next uint64, err error) {
 	current := start
 
@@ -261,9 +258,12 @@ func walkActiveRegion(input WalkInput, start uint64, emit func(*Entry) error) (n
 		}
 	}
 
-	activeIdx := input.Writer.ActiveIndex()
-	activePath := filepath.Join(input.Writer.SegmentsDir(), ingest.SegmentFilename(activeIdx))
-	walkErr := segment.WalkActiveFS(input.FS, activePath, func(events []segment.Event) error {
+	rng, ok := input.Writer.ActiveFlushedRange(current)
+	if !ok {
+		return current, nil
+	}
+	activePath := filepath.Join(input.Writer.SegmentsDir(), ingest.SegmentFilename(rng.Index))
+	walkErr := segment.WalkActiveRangeFS(input.FS, activePath, rng.StartOffset, rng.EndOffset, func(events []segment.Event) error {
 		for i := range events {
 			if emitOne(&events[i]) {
 				return errStopWalk
@@ -277,7 +277,7 @@ func walkActiveRegion(input WalkInput, start uint64, emit func(*Entry) error) (n
 		return current, emitErr
 	case errors.Is(walkErr, errStopWalk):
 		return current, nil
-	case walkErr != nil && !errors.Is(walkErr, os.ErrNotExist):
+	case walkErr != nil && !errors.Is(walkErr, os.ErrNotExist) && !errors.Is(walkErr, segment.ErrSegmentSealed):
 		return current, fmt.Errorf("walk active: %w", walkErr)
 	}
 

--- a/internal/subscribe/replay.go
+++ b/internal/subscribe/replay.go
@@ -213,7 +213,10 @@ func walkSealedRegion(ctx context.Context, input WalkInput, start uint64, emit f
 // A concurrent seal of the active file is benign: the writer snapshot provides
 // an exact end offset before any footer, and Seal never rewrites frame bytes.
 // If the range opens after the header is finalized it returns ErrSegmentSealed;
-// the outer convergence loop re-enters the freshly published sealed region.
+// with a manifest the outer convergence loop re-enters the freshly published
+// sealed region. Without a manifest there is no second source to converge on,
+// so a sealed-or-missing active file propagates loud — swallowing it would let
+// the cold reader silently jump its cursor past the sealed events.
 func walkActiveRegion(input WalkInput, start uint64, emit func(*Entry) error) (next uint64, err error) {
 	current := start
 
@@ -277,11 +280,18 @@ func walkActiveRegion(input WalkInput, start uint64, emit func(*Entry) error) (n
 		return current, emitErr
 	case errors.Is(walkErr, errStopWalk):
 		return current, nil
-	case walkErr != nil && !errors.Is(walkErr, os.ErrNotExist) && !errors.Is(walkErr, segment.ErrSegmentSealed):
+	case walkErr == nil:
+		return current, nil
+	case input.Manifest != nil &&
+		(errors.Is(walkErr, os.ErrNotExist) || errors.Is(walkErr, segment.ErrSegmentSealed)):
+		// Rotation seam: the snapshotted generation was sealed (or renamed
+		// away) between the range snapshot and the open. The sealed sweep's
+		// fresh manifest read serves it next pass; the no-progress guard in
+		// WalkFromCursor fails loud if it never appears.
+		return current, nil
+	default:
 		return current, fmt.Errorf("walk active: %w", walkErr)
 	}
-
-	return current, nil
 }
 
 // errStopWalk is an internal sentinel used to halt segment.WalkActive. It never

--- a/segment/scan.go
+++ b/segment/scan.go
@@ -147,3 +147,60 @@ func WalkActiveFS(fs vfs.FS, path string, fn func([]Event) error) error {
 	}
 	return nil
 }
+
+// WalkActiveRange opens path as an active segment and decodes the exact
+// frame-aligned byte range [startOffset, endOffset). Unlike WalkActive it does
+// not scan the prefix before startOffset or observe bytes appended after the
+// caller's end snapshot.
+func WalkActiveRange(path string, startOffset, endOffset uint64, fn func([]Event) error) error {
+	return WalkActiveRangeFS(nil, path, startOffset, endOffset, fn)
+}
+
+// WalkActiveRangeFS is WalkActiveRange against fs. Nil fs uses the host OS
+// filesystem. The range must begin and end on frame boundaries and fit in int64.
+// A file that was already sealed when opened returns ErrSegmentSealed; a seal
+// racing after open is harmless because its footer lies beyond endOffset.
+func WalkActiveRangeFS(fs vfs.FS, path string, startOffset, endOffset uint64, fn func([]Event) error) error {
+	if startOffset < ReservedHeaderBytes || startOffset > endOffset || endOffset > math.MaxInt64 {
+		return fmt.Errorf("%w: invalid active range [%d,%d)", ErrCorruptSegment, startOffset, endOffset)
+	}
+	f, err := openSegmentReadOnly(fs, path)
+	if err != nil {
+		return err // pass through os.PathError; caller may errors.Is
+	}
+	defer func() { _ = f.Close() }()
+
+	var checksumBuf [8]byte
+	if _, err := f.ReadAt(checksumBuf[:], 4); err != nil {
+		return fmt.Errorf("segment: read active checksum: %w", err)
+	}
+	if binary.LittleEndian.Uint64(checksumBuf[:]) != 0 {
+		return fmt.Errorf("%w: %s", ErrSegmentSealed, path)
+	}
+
+	off, end := int64(startOffset), int64(endOffset)
+	for block := 0; off < end; block++ {
+		if end-off < 8 {
+			return fmt.Errorf("%w: active range has %d trailing bytes at offset %d", ErrCorruptSegment, end-off, off)
+		}
+		frame, frameLen, err := readFrameAt(f, off, end)
+		if err != nil {
+			return fmt.Errorf("segment: read active range block %d: %w", block, err)
+		}
+		events, _, err := decodeBlockCompressedSized(frame)
+		if err != nil {
+			return fmt.Errorf("segment: decode active range block %d: %w", block, err)
+		}
+		if len(events) == 0 {
+			return fmt.Errorf("%w: empty active block at offset %d", ErrCorruptSegment, off)
+		}
+		if err := fn(events); err != nil {
+			return err
+		}
+		off += int64(frameLen)
+	}
+	if off != end {
+		return fmt.Errorf("%w: active range ended at %d, want %d", ErrCorruptSegment, off, end)
+	}
+	return nil
+}

--- a/segment/scan_test.go
+++ b/segment/scan_test.go
@@ -99,6 +99,84 @@ func TestScanMaxSeq_MultipleBlocks(t *testing.T) {
 // TestScanMaxSeq_IgnoresTornTail confirms that bytes past the last
 // fully-written frame are skipped — same recovery semantics as
 // lastGoodOffset/resumeExistingSegment.
+func TestWalkActiveRange_MiddleSuffixAndExactEnd(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "seg.jss")
+	w, err := New(Config{Path: path, MaxEventsPerBlock: 2})
+	require.NoError(t, err)
+	for seq := uint64(1); seq <= 6; seq++ {
+		full, err := w.Append(Event{Seq: seq, Kind: KindCreate, DID: "did:plc:range"})
+		require.NoError(t, err)
+		if full {
+			require.NoError(t, w.Flush())
+		}
+	}
+	blocks := w.Blocks()
+	require.Len(t, blocks, 3)
+
+	var got []uint64
+	err = WalkActiveRange(path, blocks[1].Offset, blocks[2].Offset, func(events []Event) error {
+		for i := range events {
+			got = append(got, events[i].Seq)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, []uint64{3, 4}, got)
+	require.NoError(t, w.Close())
+}
+
+func TestWalkActiveRange_ConcurrentSealAfterOpenUsesSnapshottedEnd(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "seg.jss")
+	w, err := New(Config{Path: path, MaxEventsPerBlock: 2})
+	require.NoError(t, err)
+	for seq := uint64(1); seq <= 6; seq++ {
+		full, err := w.Append(Event{Seq: seq, Kind: KindCreate, DID: "did:plc:sealrange"})
+		require.NoError(t, err)
+		if full {
+			require.NoError(t, w.Flush())
+		}
+	}
+	blocks := w.Blocks()
+	end := w.nextBlockOffset
+	var got []uint64
+	calls := 0
+	err = WalkActiveRange(path, blocks[0].Offset, end, func(events []Event) error {
+		calls++
+		for i := range events {
+			got = append(got, events[i].Seq)
+		}
+		if calls == 1 {
+			_, sealErr := w.Seal()
+			require.NoError(t, sealErr)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, []uint64{1, 2, 3, 4, 5, 6}, got)
+}
+
+func TestWalkActiveRange_RejectsMisalignedAndSealed(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "seg.jss")
+	w, err := New(Config{Path: path, MaxEventsPerBlock: 1})
+	require.NoError(t, err)
+	_, err = w.Append(Event{Seq: 1, Kind: KindCreate, DID: "did:plc:range"})
+	require.NoError(t, err)
+	require.NoError(t, w.Flush())
+	blocks := w.Blocks()
+	require.Len(t, blocks, 1)
+
+	err = WalkActiveRange(path, blocks[0].Offset+1, w.nextBlockOffset, func([]Event) error { return nil })
+	require.ErrorIs(t, err, ErrCorruptSegment)
+
+	_, err = w.Seal()
+	require.NoError(t, err)
+	err = WalkActiveRange(path, blocks[0].Offset, blocks[0].Offset+8+uint64(blocks[0].CompressedSize), func([]Event) error { return nil })
+	require.ErrorIs(t, err, ErrSegmentSealed)
+}
+
 func TestScanMaxSeq_IgnoresTornTail(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/segment/writer.go
+++ b/segment/writer.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"sort"
 
 	"github.com/cockroachdb/pebble/vfs"
 )
@@ -822,4 +823,21 @@ func (w *Writer) Blocks() []BlockInfo {
 	out := make([]BlockInfo, len(w.flushedBlocks))
 	copy(out, w.flushedBlocks)
 	return out
+}
+
+// FlushedRangeFromSeq returns the frame-aligned byte range covering flushed
+// blocks from the first block whose MaxSeq is at least seq through the current
+// flushed end. Pending in-memory rows are excluded. Like every Writer method,
+// the caller must serialize this query against append, flush, seal, and close.
+func (w *Writer) FlushedRangeFromSeq(seq uint64) (startOffset, endOffset uint64, ok bool) {
+	if w.closed || len(w.flushedBlocks) == 0 {
+		return 0, 0, false
+	}
+	i := sort.Search(len(w.flushedBlocks), func(i int) bool {
+		return w.flushedBlocks[i].MaxSeq >= seq
+	})
+	if i == len(w.flushedBlocks) {
+		return 0, 0, false
+	}
+	return w.flushedBlocks[i].Offset, w.nextBlockOffset, true
 }

--- a/segment/writer_test.go
+++ b/segment/writer_test.go
@@ -31,6 +31,63 @@ func (f *opOrdinalIOFault) BeforeSegmentIO(_ string, op IOOp) error {
 	return nil
 }
 
+func TestFlushedRangeFromSeq(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "seg.jss")
+	w, err := New(Config{Path: path, MaxEventsPerBlock: 2})
+	require.NoError(t, err)
+	_, _, ok := w.FlushedRangeFromSeq(1)
+	require.False(t, ok)
+
+	for seq := uint64(1); seq <= 6; seq++ {
+		full, err := w.Append(Event{Seq: seq, Kind: KindCreate, DID: "did:plc:range"})
+		require.NoError(t, err)
+		if full {
+			require.NoError(t, w.Flush())
+		}
+	}
+	blocks := w.Blocks()
+	require.Len(t, blocks, 3)
+	for _, tc := range []struct {
+		seq   uint64
+		block int
+	}{
+		{0, 0}, {1, 0}, {2, 0}, {3, 1}, {4, 1}, {5, 2}, {6, 2},
+	} {
+		start, end, ok := w.FlushedRangeFromSeq(tc.seq)
+		require.True(t, ok, "seq=%d", tc.seq)
+		require.Equal(t, blocks[tc.block].Offset, start, "seq=%d", tc.seq)
+		require.Equal(t, w.nextBlockOffset, end, "seq=%d", tc.seq)
+	}
+	_, _, ok = w.FlushedRangeFromSeq(7)
+	require.False(t, ok)
+	require.NoError(t, w.Close())
+}
+
+func TestFlushedRangeFromSeq_RebuiltOnResume(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "seg.jss")
+	w, err := New(Config{Path: path, MaxEventsPerBlock: 2})
+	require.NoError(t, err)
+	for seq := uint64(1); seq <= 4; seq++ {
+		full, err := w.Append(Event{Seq: seq, Kind: KindCreate, DID: "did:plc:resume"})
+		require.NoError(t, err)
+		if full {
+			require.NoError(t, w.Flush())
+		}
+	}
+	wantBlocks := w.Blocks()
+	require.NoError(t, w.Close())
+
+	resumed, err := New(Config{Path: path, MaxEventsPerBlock: 2})
+	require.NoError(t, err)
+	start, end, ok := resumed.FlushedRangeFromSeq(3)
+	require.True(t, ok)
+	require.Equal(t, wantBlocks[1].Offset, start)
+	require.Equal(t, wantBlocks[1].Offset+8+uint64(wantBlocks[1].CompressedSize), end)
+	require.NoError(t, resumed.Close())
+}
+
 func TestNewCreatesEmpty256ByteFile(t *testing.T) {
 	t.Parallel()
 

--- a/specs/notes/2026-08-10-active-cold-replay-range-scan.md
+++ b/specs/notes/2026-08-10-active-cold-replay-range-scan.md
@@ -1,0 +1,131 @@
+# Active cold replay: offset-bounded range scanning
+
+Issue: https://github.com/bluesky-social/jetstream/issues/300
+
+## Problem
+
+A client that finishes sealed archive backfill cuts over to the v2 websocket at
+`sealedTipSeq`. If that cursor is below the writer readable-log floor, subscribe
+uses `ColdReader` to replay durable disk data. For rows in the active, unsealed
+segment, every bounded `ColdReader.Read` currently calls `segment.WalkActiveFS`,
+which starts at byte 256 and reconstructs/decodes the whole active frame prefix
+before returning at most `DefaultReadBatch` events. The next batch starts from
+byte 256 again.
+
+Across N batches this repeats progressively longer prefixes and produces
+quadratic work. Sparse DID/collection filters make the failure look like an idle
+client because filtering occurs after the global batch is read.
+
+### Production evidence
+
+On pop2 on 2026-08-10:
+
+- planner cutover: `24,588,338,585`
+- writer tip: `24,589,902,470`
+- readable-log floor: `24,589,351,106`
+- cutover was 1,012,521 seqs below the hot floor
+- active segment was about 192 MiB; readable log about 256 MiB / 551k events
+- at 21:33 UTC Grafana showed 38,980 filtered events/s and 38.06 cold reads/s
+- at 21:46 UTC those decayed to 572 filtered events/s and 0.56 cold reads/s
+- `filtered events/s ~= cold reads/s * 1024`, exactly the current read batch
+- hot reads, adversarial drops, and encode errors stayed at zero
+
+The full evidence is recorded on issue #300.
+
+## Design
+
+### Bounded segment scanner
+
+Add `segment.WalkActiveRangeFS(path, startOffset, endOffset, fn)` plus the host-FS
+wrapper. It opens an active file, rejects a file already sealed at open, validates
+an exact frame-aligned `[start,end)` range, and decodes only frames in that range.
+It must not stat or scan to current EOF. The snapshotted end excludes concurrent
+appends and a footer appended by a concurrent seal.
+
+Keep `WalkActiveFS` unchanged for recovery/inspection callers.
+
+### Existing active block index
+
+`segment.Writer` already owns `flushedBlocks []BlockInfo` and
+`nextBlockOffset`. It updates them after each successful block write and rebuilds
+them when reopening an active file. Add `FlushedRangeFromSeq(seq)` that binary
+searches for the first block whose `MaxSeq >= seq` and returns that block offset
+plus `nextBlockOffset`. Do not copy the full block slice or duplicate this index
+in `ingest.Writer`.
+
+### Coherent ingest snapshot
+
+Add `ingest.Writer.ActiveFlushedRange(startSeq)`. Under `Writer.mu`, capture the
+active segment index and its `[start,end)` offsets in one value. Hold the lock
+only for the query/value copy, never for disk I/O. This prevents mixing an old
+segment index with a new segment's offsets during rotation.
+
+### Subscribe integration
+
+Replace `ActiveIndex` + `WalkActiveFS` in `walkActiveRegion` with the coherent
+snapshot + `WalkActiveRangeFS`. Preserve all existing cursor, stop-floor, hole,
+batch-full, and pending-memory behavior. Treat `ErrSegmentSealed` and a missing
+active path as a no-progress rotation seam when a manifest is present; the
+existing sealed/active convergence loop re-sweeps the freshly published sealed
+segment and fails loud after two genuinely non-advancing passes.
+
+## Invariants
+
+- No segment format change.
+- Pending/unflushed rows are never in the searchable index or cold replay.
+- Readable-log floor movement still depends on completed durability ordering;
+  the range scanner cannot make non-durable rows required by a cold read.
+- A range snapshot contains one active generation: index, start, and end are
+  captured under the ingest writer lock.
+- Concurrent append is excluded by the snapshotted end and picked up later.
+- Concurrent seal never exposes footer bytes. Open-after-seal returns
+  `ErrSegmentSealed`; open-before-seal reads the unchanged frame region only.
+- Restart requires no sidecar: active block metadata is reconstructed from the
+  durable complete-frame prefix.
+- Cursor delivery remains contiguous and at-least-once across rotation seams.
+
+## Non-goals
+
+- No DID/collection filter pushdown in this change. V1 filters are mutable,
+  filtered reads need a scan-cursor contract even for empty output, and active
+  blocks do not currently carry DID/collection indexes.
+- No active decoded-block cache.
+- No reader-triggered flush or seal.
+- No per-subscriber byte-offset state.
+
+## Work checklist
+
+- [x] Record design, evidence, invariants, and verification plan.
+- [x] Add exact offset-bounded active range scanner in `segment`.
+- [x] Add binary-search flushed range lookup on `segment.Writer`.
+- [x] Add coherent active flushed range snapshot on `ingest.Writer`.
+- [x] Switch subscribe active cold replay to range snapshots.
+- [x] Add segment range/rotation/error tests.
+- [x] Add segment and ingest flushed-range lookup tests.
+- [x] Add subscribe multi-batch active replay linear-work regression test.
+- [x] Add active cold replay benchmark.
+- [x] Run targeted segment/ingest/subscribe tests and affected race tests.
+- [x] Run `just`.
+- [x] Run long oracle and oracle sweep.
+- [x] Run segment fuzz targets.
+- [x] Record verification results and remaining risks below.
+
+## Verification results
+
+All checks passed on 2026-08-10:
+
+- `just test ./segment ./internal/ingest ./internal/subscribe`: 753 tests.
+- `go test -race ./internal/ingest ./internal/subscribe`: passed.
+- `BenchmarkColdReadActiveRange` at 16/64/256 blocks: about 60 us for 256
+  events, 209 us for 1,024 events, and 781 us for 4,096 events. Cost per event
+  remains approximately constant as active history grows.
+- `just`: lint reported 0 issues; 2,328 short tests passed (24 skipped).
+- `just test-long ./internal/oracle`: 211 passed (1 skipped).
+- `just oracle-sweep`: all 10 deterministic seeds and restart sub-runs passed.
+- `just fuzz 30s ./segment`: every segment fuzz target passed.
+
+Remaining risk: filter pushdown remains intentionally out of scope, so sparse
+subscribers must still decode/filter every global active row. This change makes
+that scan linear and resumable by block offset rather than quadratic. Production
+validation should compare pop2 cold reads/s over a backfill-to-live cutover and
+confirm the rate no longer decays with cursor depth.


### PR DESCRIPTION
## Summary

- seek active-segment cold replay to the flushed block containing the requested seq instead of rescanning from byte zero for every bounded batch
- snapshot a coherent active segment generation and exact `[startOffset, endOffset)` range under the ingest writer lock
- keep concurrent append/seal/rotation safe without changing the segment format
- add a deterministic work-invariant test using 1,024 events across 32 flushed blocks; each resumed batch must not read framed bytes before its expected block offset

Fixes #300.

## Problem

A backfill client cuts over to the websocket at `sealedTipSeq`. When that cursor is below the readable-log floor but lies in the active segment, `ColdReader.Read` previously called `segment.WalkActiveFS` once per bounded batch. Each call started at byte 256 and decoded the whole active prefix again. Across many batches this became quadratic.

Sparse DID/collection filters made the issue look like an idle cutover because the server performed the global scan and discarded unrelated rows before writing any frames.

Pop2 production evidence is recorded on #300. During a controlled reproduction, `events_filtered/s ~= cold_reads/s * 1024` while the cold-read rate decayed from about 38 reads/s to 0.56 reads/s, with zero hot reads, adversarial drops, or encode errors.

## Implementation

- `segment.WalkActiveRangeFS` decodes only an exact frame-aligned byte range. Its snapshotted end excludes concurrent appends and a footer appended by a concurrent seal.
- `segment.Writer.FlushedRangeFromSeq` binary-searches the existing in-memory flushed block index; no duplicate index or sidecar is introduced.
- `ingest.Writer.ActiveFlushedRange` captures segment index and offsets coherently under the existing writer lock.
- subscribe uses that snapshot for active cold replay. If rotation seals or removes the snapshotted file, a manifest-backed walk converges through the sealed sweep; without a manifest it fails loud rather than silently advancing past unread events.

There is no on-disk format change. DID/collection filter pushdown remains intentionally separate; this PR makes the existing global active scan linear rather than quadratic.

## Testing

- [x] targeted segment, ingest, and subscribe suites
- [x] race tests for `internal/ingest` and `internal/subscribe`
- [x] deterministic `ReadAt` work-invariant regression test (1,024 events, 32 resume boundaries; focused runtime ~10 ms)
- [x] active cold replay benchmark: approximately constant cost per event at 16/64/256 active blocks
- [x] `just`: 0 lint issues; 2,328 tests passed
- [x] `just test-long ./internal/oracle`: 211 passed
- [x] `just oracle-sweep`: all 10 seeds and restart sub-runs passed
- [x] `just fuzz 30s ./segment`: all segment fuzz targets passed

## Production validation after deploy

Repeat a filtered backfill-to-live cutover on pop2 and confirm cold reads/s remains approximately stable with cursor depth instead of decaying as progressively longer prefixes are rescanned.