### PR TITLE
client: enable zstd compression by default

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -55,6 +55,19 @@ func TestNormalizeHost(t *testing.T) {
 	}
 }
 
+func TestZstdCompressionDefaultsOnAndCanBeDisabled(t *testing.T) {
+	t.Parallel()
+
+	cfg := defaultConfig()
+	require.True(t, cfg.zstdCompression, "live dictionary compression should be enabled by default")
+
+	WithZstdCompression(false)(&cfg)
+	require.False(t, cfg.zstdCompression)
+
+	WithZstdCompression(true)(&cfg)
+	require.True(t, cfg.zstdCompression, "options are applied in order; explicit enable should restore the default")
+}
+
 func TestOptionsRejectNonPositive(t *testing.T) {
 	t.Parallel()
 	cfg := defaultConfig()
@@ -407,7 +420,7 @@ func TestSubscribeLiveTailEndToEnd(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	c, err := Subscribe(srv.URL)
+	c, err := Subscribe(srv.URL, WithZstdCompression(false))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = c.Close() })
 
@@ -459,7 +472,7 @@ func TestCloseStopsRunningEventsWithoutCtxCancel(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	c, err := Subscribe(srv.URL)
+	c, err := Subscribe(srv.URL, WithZstdCompression(false))
 	require.NoError(t, err)
 
 	first := make(chan struct{})

--- a/cmd/client/subscribe.go
+++ b/cmd/client/subscribe.go
@@ -73,7 +73,8 @@ func subscribeCommand() *cli.Command {
 			},
 			&cli.BoolFlag{
 				Name:  "zstd",
-				Usage: "Compress the live tail with the server's zstd dictionary (fetched automatically); cuts bandwidth ~2.5x",
+				Usage: "Compress the live tail with the server's zstd dictionary (default true; use --zstd=false to disable)",
+				Value: true,
 			},
 			&cli.BoolFlag{
 				Name:  "typed-likes-client",
@@ -131,9 +132,7 @@ func runSubscribe(ctx context.Context, cmd *cli.Command) error {
 	opts := []jetstream.Option{
 		jetstream.WithBatchSize(cmd.Int("batch-size")),
 	}
-	if cmd.Bool("zstd") {
-		opts = append(opts, jetstream.WithZstdCompression())
-	}
+	opts = append(opts, jetstream.WithZstdCompression(cmd.Bool("zstd")))
 	// --download-concurrency=0 (the default) means "let the library auto-size
 	// from the CPU count"; only forward an explicit positive override so the
 	// library default applies otherwise.

--- a/doc.go
+++ b/doc.go
@@ -33,7 +33,10 @@
 // archive-negotiation path: the client pages planSnapshot over the sealed
 // archive (downloading every matching sealed segment), then connects /subscribe
 // once at the sealed tip to pick up the active segment and the live tail. There
-// is no client-side buffer and no record suppression.
+// is no client-side buffer and no record suppression. The live tail uses the
+// server's dictionary-zstd compression by default; use
+// WithZstdCompression(false) to opt out. Dictionary fetch or rotation failure
+// degrades to an uncompressed tail rather than failing delivery.
 //
 // Delivery is at-least-once and the contract is eventually-consistent: the
 // caller must process events idempotently and FOLD the stream (creates/updates

--- a/options.go
+++ b/options.go
@@ -41,8 +41,8 @@ type config struct {
 	rawRecords       bool
 	rawRecordsCopied bool
 	rawRecordCIDs    bool
-	// zstdCompression opts the live tail into the dict-zstd
-	// scheme (see WithZstdCompression).
+	// zstdCompression controls the live tail's default dict-zstd scheme
+	// (see WithZstdCompression).
 	zstdCompression bool
 }
 
@@ -81,8 +81,9 @@ func defaultDownloadConc() int {
 
 func defaultConfig() config {
 	return config{
-		batchSize:    defaultBatchSize,
-		downloadConc: defaultDownloadConc(),
+		batchSize:       defaultBatchSize,
+		downloadConc:    defaultDownloadConc(),
+		zstdCompression: true,
 	}
 }
 
@@ -309,19 +310,12 @@ func WithRawRecordCIDs() Option {
 	return func(c *config) { c.rawRecordCIDs = true }
 }
 
-// WithZstdCompression opts the live tail into the server's dict-zstd
-// compression scheme: the client fetches the server's current dictionary
-// (getZstdDictionary) before the first live dial, negotiates it with
-// zstdDictionary=<id>, and transparently decompresses the binary frames.
-// This is the only compression the live endpoint offers; it substantially cuts
-// live-tail bandwidth (~2.5x on typical firehose traffic) at ~3µs/event of
-// client-side decode. A dictionary fetch failure degrades to an
-// uncompressed tail (logged) rather than failing the stream. If the server
-// rotates its dictionary mid-stream (retrain + redeploy), the client
-// refetches the current dictionary and reconnects compressed; if the
-// refetch fails it likewise degrades to uncompressed.
-func WithZstdCompression() Option {
-	return func(c *config) {
-		c.zstdCompression = true
-	}
+// WithZstdCompression controls live-tail dictionary-zstd compression, which is
+// enabled by default. The client fetches the server's current dictionary before
+// the first live dial, negotiates zstdDictionary=<id>, and transparently
+// decompresses binary frames. Fetch or rotation recovery failure degrades to an
+// uncompressed tail rather than failing the stream. Pass false to opt out;
+// archive segment compression is unaffected.
+func WithZstdCompression(enabled bool) Option {
+	return func(c *config) { c.zstdCompression = enabled }
 }

--- a/specs/client.md
+++ b/specs/client.md
@@ -223,9 +223,11 @@ dial deliberately doesn't offer it — see the measured rationale in
    uncompressed tail with a logged warning. Compression is an optimization;
    the tail must keep flowing.
 
-Opt-in: `WithZstdCompression()` (Go client), `--zstd` (CLI subscribe and
-loadtest; loadtest is v2-URL-only since the v1 endpoint uses the legacy
-embedded dictionary).
+Compression is enabled by default in the Go client and normal CLI subscribe
+command. Opt out with `WithZstdCompression(false)` or `--zstd=false`;
+`WithZstdCompression(true)` explicitly selects the default.
+The raw `loadtest` command remains opt-in with `--zstd` because its default URL
+is the legacy `/subscribe` endpoint, which uses a different dictionary.
 
 ## Public Go API (module root)
 


### PR DESCRIPTION
## Summary

- enable dictionary-zstd compression by default for the top-level Go client live tail
- default the normal `cmd/client` subscribe command to `--zstd=true`
- change `WithZstdCompression` to accept a boolean, so callers can opt out with `WithZstdCompression(false)`
- keep the raw `loadtest` command opt-in because its default target is legacy `/subscribe`
- document the default and graceful uncompressed fallback

## Verification

- `just test . ./cmd/client ./internal/client`
- `just` (2,332 tests passed; 24 skipped; lint clean)