### PR TITLE
Add Some Simple, Human-Written Examples

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,6 +5,9 @@ issues:
   max-same-issues: 0
 
 linters:
+  exclusions:
+    paths:
+      - ^examples/
   enable:
     - bodyclose
     - durationcheck
@@ -27,6 +30,9 @@ linters:
       ignore-missing-subtests: true
 
 formatters:
+  exclusions:
+    paths:
+      - ^examples/
   enable:
     - gofmt
   settings:

--- a/README.md
+++ b/README.md
@@ -1,18 +1,28 @@
-# Jetstream
+# Jetstream 🛩️
 
-[![ci](https://github.com/bluesky-social/jetstream/actions/workflows/ci.yml/badge.svg)](https://github.com/bluesky-social/jetstream/actions/workflows/ci.yml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/bluesky-social/jetstream.svg)](https://pkg.go.dev/github.com/bluesky-social/jetstream)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/bluesky-social/jetstream)](https://github.com/bluesky-social/jetstream/blob/main/go.mod)
+[![Latest Release](https://img.shields.io/github/v/release/bluesky-social/jetstream)](https://github.com/bluesky-social/jetstream/releases/latest)
+[![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](https://github.com/bluesky-social/jetstream/blob/main/LICENSE-DUAL)
+[![CI](https://github.com/bluesky-social/jetstream/actions/workflows/ci.yml/badge.svg)](https://github.com/bluesky-social/jetstream/actions/workflows/ci.yml)
 
-Full-network archive and streaming service for atproto.
-
-The original jetstream codebase is available [here](https://github.com/bluesky-social/jetstream-legacy).
+Full-network archive, replay, and streaming service for atproto.
 
 Docker images are available [here](https://github.com/bluesky-social/jetstream/pkgs/container/jetstream).
 
-**NOTE:** This project is not yet deployed to production, and there will be backwards-incompatible changes to the on-disk format in the next few days. Do not run this yourself and expect it to remain stable until we tag a 1.0 release (coming soon!).
+The original jetstream codebase is available [here](https://github.com/bluesky-social/jetstream-legacy).
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
-## Getting started
+## Documentation
+
+Coming soon!
+
+## Examples
+
+See the [examples](https://github.com/bluesky-social/jetstream/tree/main/examples) directory of this repo for several minimal usage examples.
+
+## Developing Locally
 
 Jetstream development uses Nix for a pinned Go and toolchain environment. Install Nix, then enter the dev shell with either:
 
@@ -21,8 +31,6 @@ Jetstream development uses Nix for a pinned Go and toolchain environment. Instal
 # or
 just dev
 ```
-
-## Running Locally
 
 For development purposes, to run against the real production network in a setup that doesn't require a whole-network backfill:
 
@@ -53,8 +61,6 @@ To fully reset your local environment (warning: destructive action!):
 just clean  # removes all built binaries and all data directories
 ```
 
-## Testing and Linting
-
 To run the linter and tests, you can do things like:
 
 ```sh
@@ -68,21 +74,3 @@ just test-long                # full suite without -short
 
 just oracle                   # heavier simulator oracle (stress mode)
 ```
-
-## Inspecting segment files
-
-```sh
-# inspect all segment files
-just run inspect-all
-
-# inspect a single file
-just run inspect-segment ./data-prod/segments/seg_0000000000.jss
-```
-
-Dumps the header, footer, per-block stats, and collection event counts for a sealed segment.
-
-## Web Dashboard
-
-The jetstream server also offers a web dashboard with some basic read-only features.
-
-Start the server locally in your desired configuration, then open `http://localhost:8080/status` in your browser.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ Coming soon!
 
 See the [examples](https://github.com/bluesky-social/jetstream/tree/main/examples) directory of this repo for several minimal usage examples.
 
+You can run them like so:
+
+```
+# start the nix environment (see below)
+just dev
+
+# run any of the examples by name
+just run-example live-tail
+```
+
 ## Developing Locally
 
 Jetstream development uses Nix for a pinned Go and toolchain environment. Install Nix, then enter the dev shell with either:

--- a/cmd/jetstream/main.go
+++ b/cmd/jetstream/main.go
@@ -77,6 +77,9 @@ var knownForeignJetstreamEnvPrefixes = []string{
 
 	// cmd/simulator binary
 	"JETSTREAM_SIM_",
+
+	// client api keys, which might just be set ambiently in dev environments perhaps
+	"JETSTREAM_API_KEY",
 }
 
 func main() {

--- a/examples/full-replay/main.go
+++ b/examples/full-replay/main.go
@@ -1,11 +1,14 @@
 // Performs a full network replay with basic options, printing some sample events as it goes. This may take a while!
 //
+// Be sure to set the JETSTREAM_API_KEY environment variable if your server requires auth.
+//
 // See the documentation for more information https://pkg.go.dev/github.com/bluesky-social/jetstream
 package main
 
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -22,9 +25,10 @@ type CLIArgs struct {
 
 func main() {
 	args := CLIArgs{}
-	args.Host = *flag.String("host", "https://jetstream.us-east.bsky.network", "Jetstream host to which the process will connect")
-	args.APIKey = os.Getenv("JETSTREAM_API_KEY")
+	flag.StringVar(&args.Host, "host", "https://jetstream.us-east.bsky.network", "Jetstream host to which the process will connect")
 	flag.Parse()
+
+	args.APIKey = os.Getenv("JETSTREAM_API_KEY")
 
 	if err := run(context.Background(), &args); err != nil {
 		slog.Error("an error occurred while running the jetstream example", "err", err)
@@ -35,8 +39,11 @@ func main() {
 func run(ctx context.Context, args *CLIArgs) error {
 	// Declare our client connection options (see the docs for more)
 	opts := []jetstream.Option{
-		jetstream.WithAPIToken(args.APIKey), // pass our credential
-		jetstream.WithAfterSeq(0),           // start from the beginning of time
+		jetstream.WithAfterSeq(0), // start from the beginning of time
+	}
+
+	if args.APIKey != "" {
+		opts = append(opts, jetstream.WithAPIToken(args.APIKey))
 	}
 
 	client, err := jetstream.Subscribe(args.Host, opts...)
@@ -52,12 +59,18 @@ func run(ctx context.Context, args *CLIArgs) error {
 	var lastEvent jetstream.Event
 	for batch, err := range client.Events(ctx) {
 		if err != nil {
-			return fmt.Errorf("failed to receive batch: %w", err)
+			if errors.Is(err, jetstream.ErrFatal) {
+				return fmt.Errorf("received fatal error: %w", err)
+			}
+
+			// You should handle other errors gracefully
+			fmt.Printf("got an error: %v\n", err)
+			continue
 		}
 
+		// These are all the events that are downloaded throughout the course of the replay.
+		// Do with them what you wish!
 		for _, event := range batch.Events() {
-			// These are all the events that are downloaded throughout the course of the replay.
-			// Do with them what you wish!
 			lastEvent = event
 		}
 

--- a/examples/full-replay/main.go
+++ b/examples/full-replay/main.go
@@ -1,0 +1,89 @@
+// Performs a full network replay with basic options, printing some sample events as it goes. This may take a while!
+//
+// See the documentation for more information https://pkg.go.dev/github.com/bluesky-social/jetstream
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/bluesky-social/jetstream"
+)
+
+type CLIArgs struct {
+	Host   string
+	APIKey string
+}
+
+func main() {
+	args := CLIArgs{}
+	args.Host = *flag.String("host", "https://jetstream.us-east.bsky.network", "Jetstream host to which the process will connect")
+	args.APIKey = os.Getenv("JETSTREAM_API_KEY")
+	flag.Parse()
+
+	if err := run(context.Background(), &args); err != nil {
+		slog.Error("an error occurred while running the jetstream example", "err", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, args *CLIArgs) error {
+	// Declare our client connection options (see the docs for more)
+	opts := []jetstream.Option{
+		jetstream.WithAPIToken(args.APIKey), // pass our credential
+		jetstream.WithAfterSeq(0),           // start from the beginning of time
+	}
+
+	client, err := jetstream.Subscribe(args.Host, opts...)
+	if err != nil {
+		return fmt.Errorf("failed to subscribe: %w", err)
+	}
+	defer client.Close()
+
+	// Print an event every so often
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	var lastEvent jetstream.Event
+	for batch, err := range client.Events(ctx) {
+		if err != nil {
+			return fmt.Errorf("failed to receive batch: %w", err)
+		}
+
+		for _, event := range batch.Events() {
+			// These are all the events that are downloaded throughout the course of the replay.
+			// Do with them what you wish!
+			lastEvent = event
+		}
+
+		// You should persist this cursor to your database of choice
+		// so you can resume later if your process restarts
+		// batch.LastCursor()
+
+		// Print events every so often just to show we're doing something
+		select {
+		case <-ticker.C:
+			if err := printLastEvent(lastEvent); err != nil {
+				return fmt.Errorf("failed to marshal event: %w", err)
+			}
+		default:
+		}
+	}
+
+	return nil
+}
+
+func printLastEvent(event jetstream.Event) error {
+	buf, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%s\n", buf)
+	return nil
+}

--- a/examples/full-replay/main.go
+++ b/examples/full-replay/main.go
@@ -31,7 +31,7 @@ func main() {
 	args.APIKey = os.Getenv("JETSTREAM_API_KEY")
 
 	if err := run(context.Background(), &args); err != nil {
-		slog.Error("an error occurred while running the jetstream example", "err", err)
+		slog.Error("an error occurred while running the jetstream full-network example", "err", err)
 		os.Exit(1)
 	}
 }
@@ -46,24 +46,26 @@ func run(ctx context.Context, args *CLIArgs) error {
 		opts = append(opts, jetstream.WithAPIToken(args.APIKey))
 	}
 
+	// Create a client connection pool
 	client, err := jetstream.Subscribe(args.Host, opts...)
 	if err != nil {
 		return fmt.Errorf("failed to subscribe: %w", err)
 	}
-	defer client.Close()
+	defer client.Close() // Don't forget to clean up!
 
 	// Print an event every so often
+	var lastEvent jetstream.Event
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 
-	var lastEvent jetstream.Event
 	for batch, err := range client.Events(ctx) {
 		if err != nil {
 			if errors.Is(err, jetstream.ErrFatal) {
 				return fmt.Errorf("received fatal error: %w", err)
 			}
 
-			// You should handle other errors gracefully
+			// You should handle other errors gracefully, depending
+			// on what your application needs
 			fmt.Printf("got an error: %v\n", err)
 			continue
 		}
@@ -81,22 +83,12 @@ func run(ctx context.Context, args *CLIArgs) error {
 		// Print events every so often just to show we're doing something
 		select {
 		case <-ticker.C:
-			if err := printLastEvent(lastEvent); err != nil {
-				return fmt.Errorf("failed to marshal event: %w", err)
+			if err := json.NewEncoder(os.Stdout).Encode(lastEvent); err != nil {
+				return fmt.Errorf("failed to json encode lastEvent: %w", err)
 			}
 		default:
 		}
 	}
 
-	return nil
-}
-
-func printLastEvent(event jetstream.Event) error {
-	buf, err := json.Marshal(event)
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("%s\n", buf)
 	return nil
 }

--- a/examples/live-tail/main.go
+++ b/examples/live-tail/main.go
@@ -1,0 +1,66 @@
+// Connects to the live tip websocket and prints out all events as JSON.
+//
+// See the documentation for more information https://pkg.go.dev/github.com/bluesky-social/jetstream
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/bluesky-social/jetstream"
+)
+
+type CLIArgs struct {
+	Host string
+}
+
+func main() {
+	args := CLIArgs{}
+	flag.StringVar(&args.Host, "host", "https://jetstream.us-east.bsky.network", "Jetstream host to which the process will connect")
+	flag.Parse()
+
+	if err := run(context.Background(), &args); err != nil {
+		slog.Error("an error occurred while running the jetstream example", "err", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, args *CLIArgs) error {
+	client, err := jetstream.Subscribe(args.Host)
+	if err != nil {
+		return fmt.Errorf("failed to subscribe: %w", err)
+	}
+	defer client.Close()
+
+	for batch, err := range client.Events(ctx) {
+		if err != nil {
+			if errors.Is(err, jetstream.ErrFatal) {
+				return fmt.Errorf("received fatal error: %w", err)
+			}
+
+			// You should handle other errors gracefully, depending
+			// on what your application needs
+			fmt.Printf("got an error: %v\n", err)
+			continue
+		}
+
+		// These are all the events that are downloaded throughout the course
+		// of the replay. Do with them what you wish!
+		for _, event := range batch.Events() {
+			if err := json.NewEncoder(os.Stdout).Encode(event); err != nil {
+				return fmt.Errorf("failed to json encode event: %w", err)
+			}
+		}
+
+		// You should persist this cursor to your database of choice
+		// so you can resume later if your process restarts
+		// batch.LastCursor()
+	}
+
+	return nil
+}

--- a/examples/live-tail/main.go
+++ b/examples/live-tail/main.go
@@ -25,7 +25,7 @@ func main() {
 	flag.Parse()
 
 	if err := run(context.Background(), &args); err != nil {
-		slog.Error("an error occurred while running the jetstream example", "err", err)
+		slog.Error("an error occurred while running the jetstream live-tail example", "err", err)
 		os.Exit(1)
 	}
 }

--- a/examples/statusphere/main.go
+++ b/examples/statusphere/main.go
@@ -56,6 +56,13 @@ func run(ctx context.Context, args *CLIArgs) error {
 		opts = append(opts, jetstream.WithAPIToken(args.APIKey))
 	}
 
+	// Create a client connection pool
+	client, err := jetstream.Subscribe(args.Host, opts...)
+	if err != nil {
+		return fmt.Errorf("failed to subscribe: %w", err)
+	}
+	defer client.Close() // Don't forget to clean up!
+
 	// Start our client loop
 	for batch, err := range jetstream.TypedEvents[statusphere.StatusphereStatus](ctx, client, "xyz.statusphere.status") {
 		if err != nil {

--- a/examples/statusphere/main.go
+++ b/examples/statusphere/main.go
@@ -1,0 +1,91 @@
+// Performs a full replay of all the emojis from the statusphere example app.
+//
+// Be sure to set the JETSTREAM_API_KEY environment variable if your server requires auth.
+//
+// See the documentation for more information https://pkg.go.dev/github.com/bluesky-social/jetstream
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/bluesky-social/jetstream"
+	"github.com/jcalabro/atmos/api/statusphere"
+)
+
+type CLIArgs struct {
+	Host   string
+	APIKey string
+}
+
+func main() {
+	args := CLIArgs{}
+	flag.StringVar(&args.Host, "host", "https://jetstream.us-east.bsky.network", "Jetstream host to which the process will connect")
+	flag.Parse()
+
+	args.APIKey = os.Getenv("JETSTREAM_API_KEY")
+
+	if err := run(context.Background(), &args); err != nil {
+		slog.Error("an error occurred while running the jetstream statusphere example", "err", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, args *CLIArgs) error {
+	// Declare our client connection options (see the docs for more)
+	opts := []jetstream.Option{
+		// start from the beginning of time
+		jetstream.WithAfterSeq(0),
+
+		// Using TypedEvents can result in MUCH faster client decode performance,
+		// if you know the single collection you care about ahead of time. To do so,
+		// set `WithRawRecords` and use the alternate `TypedEvents` implementation
+		// like we do below.
+		jetstream.WithRawRecords(),
+	}
+
+	if args.APIKey != "" {
+		opts = append(opts, jetstream.WithAPIToken(args.APIKey))
+	}
+
+	// Create a client connection pool
+	client, err := jetstream.Subscribe(args.Host, opts...)
+	if err != nil {
+		return fmt.Errorf("failed to subscribe: %w", err)
+	}
+	defer client.Close() // Don't forget to clean up!
+
+	for batch, err := range jetstream.TypedEvents[statusphere.StatusphereStatus](ctx, client, "xyz.statusphere.status") {
+		if err != nil {
+			if errors.Is(err, jetstream.ErrFatal) {
+				return fmt.Errorf("received fatal error: %w", err)
+			}
+
+			// You should handle other errors gracefully, depending
+			// on what your application needs
+			fmt.Printf("got an error: %v\n", err)
+			continue
+		}
+
+		// Print the emojis folks have set
+		for _, event := range batch.Events() {
+			if err := event.DecodeErr; err != nil || event.Record == nil {
+				// You should handle these cases gracefully, but we'll skip it for this example
+				continue
+			}
+
+			// `event` now represents a strongly typed instance of xyz.statusphere.status
+			fmt.Printf("%s had the status %s\n", event.Event.DID, event.Record.Status)
+		}
+
+		// You should persist this cursor to your database of choice
+		// so you can resume later if your process restarts
+		// batch.LastCursor()
+	}
+
+	return nil
+}

--- a/examples/statusphere/main.go
+++ b/examples/statusphere/main.go
@@ -3,6 +3,8 @@
 // Be sure to set the JETSTREAM_API_KEY environment variable if your server requires auth.
 //
 // See the documentation for more information https://pkg.go.dev/github.com/bluesky-social/jetstream
+//
+// See also the statusphere example repo https://github.com/bluesky-social/statusphere-example-app/
 package main
 
 import (
@@ -44,7 +46,9 @@ func run(ctx context.Context, args *CLIArgs) error {
 		// Using TypedEvents can result in MUCH faster client decode performance,
 		// if you know the single collection you care about ahead of time. To do so,
 		// set `WithRawRecords` and use the alternate `TypedEvents` implementation
-		// like we do below.
+		// like we do below. This is a super specialized implementation and is pretty
+		// inflexible. If you are unsure what to use, don't use `TypedEvents`; just go
+		// with the basic `jetstream.Subscribe` implemenation.
 		jetstream.WithRawRecords(),
 	}
 
@@ -52,13 +56,7 @@ func run(ctx context.Context, args *CLIArgs) error {
 		opts = append(opts, jetstream.WithAPIToken(args.APIKey))
 	}
 
-	// Create a client connection pool
-	client, err := jetstream.Subscribe(args.Host, opts...)
-	if err != nil {
-		return fmt.Errorf("failed to subscribe: %w", err)
-	}
-	defer client.Close() // Don't forget to clean up!
-
+	// Start our client loop
 	for batch, err := range jetstream.TypedEvents[statusphere.StatusphereStatus](ctx, client, "xyz.statusphere.status") {
 		if err != nil {
 			if errors.Is(err, jetstream.ErrFatal) {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/cockroachdb/errors v1.14.0
 	github.com/cockroachdb/pebble v1.1.5
 	github.com/coder/websocket v1.8.15
-	github.com/jcalabro/atmos v0.3.4
+	github.com/jcalabro/atmos v0.3.6
 	github.com/jcalabro/gloom v0.1.0
 	github.com/jcalabro/gt v0.0.14
 	github.com/jcalabro/jttp v0.0.6

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF2
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/jcalabro/atmos v0.3.4 h1:oPxJf5X/hgBx8Fa3P/dgTu3vc5lIhjqbNoAu5CZq+z4=
 github.com/jcalabro/atmos v0.3.4/go.mod h1:Y4JMdKpw+fDp75ASvLVUAwA/dXDpbN1aNv/JzqsjfMk=
+github.com/jcalabro/atmos v0.3.6 h1:OCFAt/eshoU+SZR/HwmpyrrjTeeOWz/e6mnOgPBQqQ4=
+github.com/jcalabro/atmos v0.3.6/go.mod h1:Y4JMdKpw+fDp75ASvLVUAwA/dXDpbN1aNv/JzqsjfMk=
 github.com/jcalabro/gloom v0.1.0 h1:Z8VTAMrdRNXr11tt9c5pIpDDJxAHg3QIBrHFt5x2I2M=
 github.com/jcalabro/gloom v0.1.0/go.mod h1:6uAawINljQYLN3a2YsekJ8LDYT/SobmJyfeKrSjHVx0=
 github.com/jcalabro/gt v0.0.14 h1:m5Go+0xX+Atb3PbS1rLuNrFWiO0w1bdZlAoxbBITzXc=

--- a/justfile
+++ b/justfile
@@ -51,6 +51,8 @@ build:
         done
     fi
 
+    go build -o bin/ ./examples/...
+
 # Build the Docker image locally, stamping the same build info as `just build`.
 # `--load` intentionally keeps this to one platform so the image can be run
 # immediately for smoke checks (`docker run --rm jetstream:local version`).

--- a/justfile
+++ b/justfile
@@ -104,6 +104,9 @@ run-prod-race *ARGS:
 run-client *ARGS:
     go run ./cmd/client {{ARGS}}
 
+run-example PROGRAM *ARGS:
+    go run ./examples/{{PROGRAM}} {{ARGS}}
+
 # Run the local simulator (PLC + PDS + relay + firehose).
 simulator *ARGS:
     go run ./cmd/simulator {{ARGS}}


### PR DESCRIPTION
I wrote these examples by hand and did not use LLMs. They are dead-simple, but showcase some of the capabilities of the jetstream client library.

Also updates the README to give some info on how to run the examples, and simplifies and adds some badges while we're in there. Can't release without badges.