### PR TITLE
test: reduce short suite runtime

### DIFF
--- a/downloader_test.go
+++ b/downloader_test.go
@@ -1110,9 +1110,11 @@ func TestDownloadBlocksErrorStopsEntryNotPlan(t *testing.T) {
 	}
 
 	// Fail entry 0's block 1 (getBlock 500s it); everything else serves normally.
+	var failedReqs atomic.Int64
 	mux := http.NewServeMux()
 	mux.HandleFunc("/xrpc/network.bsky.jetstream.getBlock", func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Query().Get("segment") == segName(0) && r.URL.Query().Get("blockIndex") == "1" {
+			failedReqs.Add(1)
 			writeXRPCError(w, http.StatusInternalServerError, "InternalError")
 			return
 		}
@@ -1126,7 +1128,15 @@ func TestDownloadBlocksErrorStopsEntryNotPlan(t *testing.T) {
 		{SegmentName: segName(0), Index: 0, Mode: modeBlocks, Blocks: []blockRange{{First: 0, Last: 2}}},
 		{SegmentName: segName(1), Index: 1, Mode: modeBlocks, Blocks: []blockRange{{First: 0, Last: 2}}},
 	}
-	d := newDownloader(&xrpc.Client{Host: srv.URL}, 8, nil)
+	d := newDownloader(&xrpc.Client{
+		Host: srv.URL,
+		Retry: gt.Some(xrpc.RetryPolicy{
+			MaxAttempts: gt.Some(3),
+			BaseDelay:   gt.Some(time.Millisecond),
+			MaxDelay:    gt.Some(10 * time.Millisecond),
+			Jitter:      gt.Some(0.0),
+		}),
+	}, 8, nil)
 
 	var perEntry [2][]uint64
 	var entry0Err error
@@ -1143,6 +1153,7 @@ func TestDownloadBlocksErrorStopsEntryNotPlan(t *testing.T) {
 	require.NoError(t, err, "a per-block fetch failure is a per-entry error, not a Download failure")
 	require.Error(t, entry0Err, "entry 0's failing block must surface in order")
 	require.ErrorContains(t, entry0Err, "getBlock 1")
+	require.EqualValues(t, 3, failedReqs.Load(), "the failing block must exhaust its retry budget")
 	require.Equal(t, []uint64{1, 2}, perEntry[0], "entry 0 delivers only the good prefix before the error")
 	require.Equal(t, []uint64{101, 102, 103, 104, 105, 106}, perEntry[1], "entry 1 must complete despite entry 0's error")
 }

--- a/internal/ingest/orchestrator/bootstrap_test.go
+++ b/internal/ingest/orchestrator/bootstrap_test.go
@@ -89,13 +89,14 @@ func TestRunBootstrap_BackfillErrorPropagates(t *testing.T) {
 	verifier := newTestVerifier(t, unreachable)
 
 	o, err := New(Config{
-		DataDir:    dataDir,
-		Store:      st,
-		RelayURL:   unreachable,
-		HTTPClient: &http.Client{Timeout: 500 * time.Millisecond},
-		Directory:  testIdentityDirectory(),
-		Verifier:   verifier,
-		Logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		DataDir:                dataDir,
+		Store:                  st,
+		RelayURL:               unreachable,
+		HTTPClient:             &http.Client{Timeout: 500 * time.Millisecond},
+		Directory:              testIdentityDirectory(),
+		Verifier:               verifier,
+		Logger:                 slog.New(slog.NewTextHandler(io.Discard, nil)),
+		BackfillRetryBaseDelay: time.Millisecond,
 	})
 	require.NoError(t, err)
 
@@ -104,6 +105,8 @@ func TestRunBootstrap_BackfillErrorPropagates(t *testing.T) {
 
 	err = o.runBootstrap(ctx)
 	require.Error(t, err, "unreachable relay should surface as runBootstrap error")
+	require.NotErrorIs(t, err, context.DeadlineExceeded,
+		"the engine error, not the test safety deadline, must stop bootstrap")
 
 	// Phase must still be PhaseBootstrap — no cutover happened.
 	got, err := lifecycle.ReadPhase(st)

--- a/internal/ingest/orchestrator/config.go
+++ b/internal/ingest/orchestrator/config.go
@@ -179,6 +179,11 @@ type Config struct {
 	// production backoff per fault. Production leaves it 0.
 	BackfillRetryBaseDelay time.Duration
 
+	// MergeDiscoveryRetryBaseDelay, when > 0, overrides the merge discovery
+	// host-retry backoff base. Production leaves this zero for the 2s base;
+	// integration tests set it small while retaining all three attempts.
+	MergeDiscoveryRetryBaseDelay time.Duration
+
 	// FailedRepoRetryInterval controls steady-state retry scans for repos that
 	// exhausted bootstrap retry and remain StatusFailed. Zero disables the
 	// background retry loop; merge still runs its one-shot pending pass for
@@ -352,6 +357,9 @@ func (c *Config) validate() error {
 	}
 	if c.FailedRepoRetryMaxDelay < 0 {
 		return fmt.Errorf("%w: FailedRepoRetryMaxDelay must be >= 0", ErrInvalidConfig)
+	}
+	if c.MergeDiscoveryRetryBaseDelay < 0 {
+		return fmt.Errorf("%w: MergeDiscoveryRetryBaseDelay must be >= 0", ErrInvalidConfig)
 	}
 	if c.HTTPClient == nil {
 		return fmt.Errorf("%w: HTTPClient is required", ErrInvalidConfig)

--- a/internal/ingest/orchestrator/config_test.go
+++ b/internal/ingest/orchestrator/config_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/bluesky-social/jetstream/internal/store"
 	"github.com/jcalabro/atmos/identity"
@@ -31,6 +32,16 @@ func validBaseConfig(t *testing.T) Config {
 		Verifier:   &atmossync.Verifier{},
 		Logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
+}
+
+func TestConfig_Validate_NegativeMergeDiscoveryRetryBaseDelay(t *testing.T) {
+	t.Parallel()
+
+	cfg := validBaseConfig(t)
+	cfg.MergeDiscoveryRetryBaseDelay = -time.Nanosecond
+	err := cfg.validate()
+	require.ErrorIs(t, err, ErrInvalidConfig)
+	require.Contains(t, err.Error(), "MergeDiscoveryRetryBaseDelay")
 }
 
 func TestConfig_Validate_OK(t *testing.T) {

--- a/internal/ingest/orchestrator/merge.go
+++ b/internal/ingest/orchestrator/merge.go
@@ -151,7 +151,11 @@ func (o *Orchestrator) runMerge(ctx context.Context) error {
 		}
 
 		if !o.cfg.SkipMergeDiscovery {
-			limits := discoveryLimits{maxHosts: o.cfg.BackfillMaxHosts, maxActiveHosts: o.cfg.BackfillMaxActiveHosts}
+			limits := discoveryLimits{
+				maxHosts:       o.cfg.BackfillMaxHosts,
+				maxActiveHosts: o.cfg.BackfillMaxActiveHosts,
+				retryDelay:     o.cfg.MergeDiscoveryRetryBaseDelay,
+			}
 			if err := runner.runDiscoveryWithClient(ctx, o.cfg.RelayURL, o.cfg.HTTPClient, o.cfg.BackfillNewHostClient, limits); err != nil {
 				return err
 			}

--- a/internal/ingest/orchestrator/merge_discovery.go
+++ b/internal/ingest/orchestrator/merge_discovery.go
@@ -50,6 +50,7 @@ func (s discoveryStore) OnHostExhausted(ctx context.Context, hostname string, ca
 type discoveryLimits struct {
 	maxHosts       int
 	maxActiveHosts int
+	retryDelay     time.Duration
 }
 
 func (r *mergeRunner) runDiscovery(ctx context.Context, relayURL string, httpClient *http.Client) error {
@@ -85,6 +86,9 @@ func (r *mergeRunner) runDiscoveryWithClient(ctx context.Context, relayURL strin
 		}
 		if limits.maxActiveHosts > 0 {
 			opts.MaxActiveHosts = gt.Some(limits.maxActiveHosts)
+		}
+		if limits.retryDelay > 0 {
+			opts.HostBackoffBase = gt.Some(limits.retryDelay)
 		}
 		if err := atmosbackfill.NewEngine(opts).Run(ctx); err != nil {
 			return fmt.Errorf("orchestrator: merge: PDS discovery: %w", err)

--- a/internal/ingest/orchestrator/testfixtures_test.go
+++ b/internal/ingest/orchestrator/testfixtures_test.go
@@ -209,13 +209,14 @@ func newMergeFixture(t *testing.T, sources [][]segment.Event, repoRevs map[strin
 
 	relay := newFakeRelay(t, nil)
 	cfg := Config{
-		DataDir:    dataDir,
-		Store:      st,
-		RelayURL:   relay.URL(),
-		HTTPClient: &http.Client{Timeout: 5 * time.Second},
-		Directory:  testIdentityDirectory(),
-		Verifier:   newTestVerifier(t, relay.URL()),
-		Logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		DataDir:                      dataDir,
+		Store:                        st,
+		RelayURL:                     relay.URL(),
+		HTTPClient:                   &http.Client{Timeout: 5 * time.Second},
+		Directory:                    testIdentityDirectory(),
+		Verifier:                     newTestVerifier(t, relay.URL()),
+		Logger:                       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MergeDiscoveryRetryBaseDelay: time.Millisecond,
 	}
 	return &mergeFixture{dataDir: dataDir, store: st, cfg: cfg, relay: relay}
 }

--- a/live_zstd_test.go
+++ b/live_zstd_test.go
@@ -214,21 +214,33 @@ func TestLiveConsumerZstd_DecodeBoundedByReadLimit(t *testing.T) {
 	require.Contains(t, errs[0].Error(), "zstd frame decode")
 }
 
-// buildKPDict makes a small but valid structured zstd dictionary with the
-// given ID using klauspost's builder over synthetic JSON-ish samples.
+var kpDictTemplate struct {
+	once sync.Once
+	dict []byte
+	err  error
+}
+
+// buildKPDict returns a small valid structured zstd dictionary with the given
+// ID. Training is deliberately shared: the ID is an independent header field,
+// while every test uses the same corpus and dictionary body.
 func buildKPDict(t *testing.T, id uint32) []byte {
 	t.Helper()
-	samples := make([][]byte, 0, 128)
-	for i := range 128 {
-		frame := liveCommitFrame(t, uint64(i+1), "did:plc:traindata", "create", "app.bsky.feed.post", strings.Repeat("r", i%7+1), true)
-		samples = append(samples, frame)
-	}
-	d, err := kpdict.BuildZstdDict(samples, kpdict.Options{
-		MaxDictSize: 8 << 10,
-		HashBytes:   6,
-		ZstdDictID:  id,
+	kpDictTemplate.once.Do(func() {
+		samples := make([][]byte, 0, 128)
+		for i := range 128 {
+			frame := liveCommitFrameJSON(uint64(i+1), "did:plc:traindata", "app.bsky.feed.post", strings.Repeat("r", i%7+1))
+			samples = append(samples, []byte(frame))
+		}
+		kpDictTemplate.dict, kpDictTemplate.err = kpdict.BuildZstdDict(samples, kpdict.Options{
+			MaxDictSize: 8 << 10,
+			HashBytes:   6,
+			ZstdDictID:  1,
+		})
 	})
-	require.NoError(t, err)
+	require.NoError(t, kpDictTemplate.err)
+	require.GreaterOrEqual(t, len(kpDictTemplate.dict), 8)
+	d := append([]byte(nil), kpDictTemplate.dict...)
+	binary.LittleEndian.PutUint32(d[4:8], id)
 	gotID := binary.LittleEndian.Uint32(d[4:8])
 	require.Equal(t, id, gotID)
 	return d


### PR DESCRIPTION
Summary
- replace production-scale retry waits in short integration tests with injected millisecond backoffs while retaining the same attempt counts
- assert bootstrap failures beat the safety deadline and block downloads exhaust all three retries
- train the synthetic zstd dictionary once and clone it with per-test dictionary IDs

Results
- just test: 9.87s baseline, 1.79s after rebasing onto current main
- orchestrator package: 8.30s baseline, under 0.9s in the full suite

Verification
- just
- just test-race .