### PR TITLE
ci: shard long-running scheduled jobs

### DIFF
--- a/.github/workflows/ci-scheduled.yml
+++ b/.github/workflows/ci-scheduled.yml
@@ -62,11 +62,38 @@ jobs:
         run: ./dev.sh --command just vuln
 
   fuzz:
-    name: fuzz
+    name: fuzz (${{ matrix.target }})
     runs-on: ubuntu-24.04
-    timeout-minutes: 120
+    timeout-minutes: 20
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      max-parallel: 8
+      matrix:
+        include:
+          - { package: ".", target: FuzzDecodeLiveFrame }
+          - { package: ".", target: FuzzDecodeRecordMapEquivalence }
+          - { package: "./internal/ingest/live", target: FuzzLoadUpstreamCursor }
+          - { package: "./internal/ingest/live", target: FuzzUpstreamCursorRoundTrip }
+          - { package: "./internal/ingest/syncstate", target: FuzzChainStateRoundTrip }
+          - { package: "./internal/ingest/syncstate", target: FuzzDecodeChainState }
+          - { package: "./internal/ingest/syncstate", target: FuzzDecodeHostingState }
+          - { package: "./internal/ingest/syncstate", target: FuzzHostingStateRoundTrip }
+          - { package: "./internal/subscribe", target: FuzzEncode }
+          - { package: "./internal/subscribe", target: FuzzEncodeV2 }
+          - { package: "./internal/subscribe", target: FuzzParseQuery }
+          - { package: "./internal/subscribe", target: FuzzParseUpdatePayload }
+          - { package: "./internal/subscribe", target: FuzzResolveCursor }
+          - { package: "./internal/timestamp", target: FuzzParseRoundTrip }
+          - { package: "./internal/xrpcapi", target: FuzzValidatePlanCollections }
+          - { package: "./segment", target: FuzzDecodeBlock }
+          - { package: "./segment", target: FuzzDecodeBlockFromCompressed }
+          - { package: "./segment", target: FuzzPatch }
+          - { package: "./segment", target: FuzzReadBlockIndex }
+          - { package: "./segment", target: FuzzReadCollectionIndex }
+          - { package: "./segment", target: FuzzReadHeader }
+          - { package: "./segment", target: FuzzRewrite }
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
@@ -102,14 +129,16 @@ jobs:
           github-token: ""
 
       - name: Fuzz
-        run: ./dev.sh --command just fuzz 300s
+        env:
+          FUZZ_PACKAGE: ${{ matrix.package }}
+          FUZZ_TARGET: ${{ matrix.target }}
+        run: ./dev.sh --command just fuzz-target 300s "$FUZZ_PACKAGE" "$FUZZ_TARGET"
 
       - name: Upload fuzz artifacts
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: fuzz-failure-corpus
-          path: |
-            **/testdata/fuzz/**
+          name: fuzz-failure-${{ matrix.target }}
+          path: ${{ matrix.package }}/testdata/fuzz/${{ matrix.target }}/**
           if-no-files-found: warn
           retention-days: 14

--- a/.github/workflows/oracle-scheduled.yml
+++ b/.github/workflows/oracle-scheduled.yml
@@ -1,9 +1,8 @@
 # Scheduled simulator oracle seed sweep.
 #
-# This workflow is intentionally separate from push CI. It is expensive enough
-# to be a bug-hunting job, not a per-commit gate. GitHub's built-in Actions
-# notifications handle failure emails for users who have Actions email
-# notifications enabled.
+# Each matrix job owns one pre-generated seed. A failed-job rerun therefore
+# repeats exactly the interrupted scenario instead of discarding completed work
+# or silently drawing a replacement seed.
 
 name: oracle-scheduled
 
@@ -28,29 +27,65 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
-env:
-  # The per-seed workload is fixed by JETSTREAM_ORACLE_MODE=stress inside the
-  # oracle-sweep recipe (see internal/oracle/config.go). Only the seed count is
-  # tunable here; do not reintroduce account/record/event overrides.
-  ORACLE_SWEEP_SEEDS: ${{ github.event.inputs.seeds || '10' }}
-  # The -race lane (#107) is far slower per seed (~5.5 min for one stress
-  # DefaultLifecycle + restart seed under the detector, vs. minutes without), so
-  # it sweeps a handful of seeds within the same 360m job budget rather than the
-  # full nightly count. The non-race lane stays at ORACLE_SWEEP_SEEDS.
-  ORACLE_RACE_SWEEP_SEEDS: ${{ github.event.inputs.race_seeds || '3' }}
-  # Per-seed diagnostic artifacts (JSONL trace + captured test output carrying
-  # the goroutine dump) are written here by the oracle-sweep recipe and uploaded
-  # on failure. Without this the trace lands in an ephemeral temp dir and every
-  # scheduled failure is diagnostically blind.
-  ORACLE_ARTIFACT_DIR: ${{ github.workspace }}/oracle-artifacts
-
 jobs:
-  oracle-sweep:
-    name: oracle seed sweep
+  plan:
+    name: plan oracle shards
     runs-on: ubuntu-24.04
-    timeout-minutes: 360
+    timeout-minutes: 5
+    outputs:
+      oracle: ${{ steps.seeds.outputs.oracle }}
+      race: ${{ steps.seeds.outputs.race }}
+    steps:
+      - name: Generate stable seeds
+        id: seeds
+        env:
+          ORACLE_SWEEP_SEEDS: ${{ github.event.inputs.seeds || '5' }}
+          ORACLE_RACE_SWEEP_SEEDS: ${{ github.event.inputs.race_seeds || '1' }}
+        run: |
+          set -euo pipefail
+
+          validate_count() {
+            local name="$1"
+            local count="$2"
+            local maximum="$3"
+            if [[ ! "$count" =~ ^[1-9][0-9]*$ ]] || (( count > maximum )); then
+              echo "${name} must be an integer from 1 through ${maximum}; got ${count}" >&2
+              exit 2
+            fi
+          }
+
+          matrix() {
+            local count="$1"
+            local output='{"include":['
+            local separator=''
+            local seed
+            for ((i = 0; i < count; i++)); do
+              seed="$(od -An -N8 -tu8 /dev/urandom | tr -d ' ')"
+              output+="${separator}{\"seed\":\"${seed}\"}"
+              separator=','
+            done
+            printf '%s]}' "$output"
+          }
+
+          validate_count seeds "$ORACLE_SWEEP_SEEDS" 100
+          validate_count race_seeds "$ORACLE_RACE_SWEEP_SEEDS" 25
+          echo "oracle=$(matrix "$ORACLE_SWEEP_SEEDS")" >> "$GITHUB_OUTPUT"
+          echo "race=$(matrix "$ORACLE_RACE_SWEEP_SEEDS")" >> "$GITHUB_OUTPUT"
+
+  oracle-sweep:
+    name: oracle seed (${{ matrix.seed }})
+    needs: plan
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      max-parallel: 10
+      matrix: ${{ fromJSON(needs.plan.outputs.oracle) }}
+    env:
+      ORACLE_SEED: ${{ matrix.seed }}
+      ORACLE_ARTIFACT_DIR: ${{ github.workspace }}/oracle-artifacts/${{ matrix.seed }}
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
@@ -85,17 +120,14 @@ jobs:
           diagnostic-endpoint: ""
           github-token: ""
 
-      - name: Oracle seed sweep
-        run: ./dev.sh --command just oracle-sweep "$ORACLE_SWEEP_SEEDS"
+      - name: Oracle seed
+        run: ./dev.sh --command just oracle-sweep 1 "" "$ORACLE_SEED"
 
       - name: Upload diagnostic artifacts
-        # The JSONL trace is the design's substitute for bit-reproducible
-        # scheduling; capturing it (plus the goroutine-dump-bearing test output)
-        # only matters when a seed fails, so this runs on failure only.
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: oracle-failure-traces
+          name: oracle-failure-${{ matrix.seed }}
           path: ${{ env.ORACLE_ARTIFACT_DIR }}
           if-no-files-found: warn
           retention-days: 14
@@ -106,27 +138,24 @@ jobs:
           {
             echo "## Scheduled oracle test failed"
             echo
-            echo 'The failing seed and exact local repro command are printed in the `Oracle seed sweep` step logs.'
-            echo
-            echo "Workload: JETSTREAM_ORACLE_MODE=stress (see internal/oracle/config.go)"
-            echo
-            echo "- seeds swept: ${ORACLE_SWEEP_SEEDS}"
+            echo "Seed: ${ORACLE_SEED}"
+            echo "Repro: just oracle-sweep 1 \"\" ${ORACLE_SEED}"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # The #107 race lane: the same stress/swarm + restart sweep under the data-race
-  # detector, at a low seed count. The repo's only other race coverage is
-  # ci.yml's `test (race)` job, which runs DEFAULT mode (25 accounts/1000
-  # records) and never the stress/swarm or restart interleavings where observed
-  # sweep failures actually reproduce. This closes that gap. It is a separate job
-  # (not extra seeds on the sweep above) so a race-detector data-race report is
-  # attributable on its own and the slower per-seed budget doesn't dilute the
-  # non-race seed count.
   oracle-sweep-race:
-    name: oracle seed sweep (race)
+    name: oracle race seed (${{ matrix.seed }})
+    needs: plan
     runs-on: ubuntu-24.04
-    timeout-minutes: 360
+    timeout-minutes: 110
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix: ${{ fromJSON(needs.plan.outputs.race) }}
+    env:
+      ORACLE_SEED: ${{ matrix.seed }}
+      ORACLE_ARTIFACT_DIR: ${{ github.workspace }}/oracle-race-artifacts/${{ matrix.seed }}
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
@@ -161,17 +190,14 @@ jobs:
           diagnostic-endpoint: ""
           github-token: ""
 
-      - name: Oracle seed sweep (race detector)
-        # A non-empty RACE arg turns on -race and widens the per-seed timeout to
-        # 90m inside the recipe; the restart tier re-execs the same test binary
-        # as its killed child, so the detector instruments both processes.
-        run: ./dev.sh --command just oracle-sweep "$ORACLE_RACE_SWEEP_SEEDS" race
+      - name: Oracle seed (race detector)
+        run: ./dev.sh --command just oracle-sweep 1 race "$ORACLE_SEED"
 
       - name: Upload diagnostic artifacts
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: oracle-race-failure-traces
+          name: oracle-race-failure-${{ matrix.seed }}
           path: ${{ env.ORACLE_ARTIFACT_DIR }}
           if-no-files-found: warn
           retention-days: 14
@@ -180,12 +206,8 @@ jobs:
         if: failure()
         run: |
           {
-            echo "## Scheduled oracle race lane failed"
+            echo "## Scheduled oracle race test failed"
             echo
-            echo 'A failure here is either a data race (the detector prints a `DATA RACE` report in the step logs) or an oracle assertion under -race.'
-            echo
-            echo "Workload: JETSTREAM_ORACLE_MODE=stress under -race (see internal/oracle/config.go)"
-            echo
-            echo "- seeds swept: ${ORACLE_RACE_SWEEP_SEEDS}"
-            echo "- the failing seed and exact local repro command are printed in the sweep step logs (add -race to the printed command)."
+            echo "Seed: ${ORACLE_SEED}"
+            echo "Repro: just oracle-sweep 1 race ${ORACLE_SEED}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/retry-infrastructure-failures.yml
+++ b/.github/workflows/retry-infrastructure-failures.yml
@@ -1,0 +1,113 @@
+# Retry failed scheduled jobs once, but only when every failure carries narrow,
+# positive evidence that a GitHub-hosted runner was lost. This privileged
+# workflow never checks out or executes repository code.
+
+name: retry-infrastructure-failures
+
+on:
+  workflow_run:
+    workflows:
+      - ci-scheduled
+      - oracle-scheduled
+    types:
+      - completed
+
+permissions:
+  actions: write
+  checks: read
+
+concurrency:
+  group: retry-infrastructure-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  retry:
+    name: classify and retry hosted-runner failures
+    if: >-
+      github.event.workflow_run.run_attempt == 1 &&
+      github.event.workflow_run.conclusion == 'failure' &&
+      (github.event.workflow_run.event == 'schedule' || github.event.workflow_run.event == 'workflow_dispatch') &&
+      github.event.workflow_run.repository.full_name == github.repository
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            pipelines.actions.githubusercontent.com:443
+            results-receiver.actions.githubusercontent.com:443
+            *.blob.core.windows.net:443
+
+      - name: Classify failed jobs and retry once
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+
+          job_pages="$(gh api --paginate --slurp "repos/${REPOSITORY}/actions/runs/${RUN_ID}/jobs?filter=all&per_page=100")"
+          failures="$(jq -c '[.[].jobs[] | select(.conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral")]' <<< "$job_pages")"
+          failure_count="$(jq 'length' <<< "$failures")"
+          if (( failure_count == 0 )); then
+            echo "The workflow failed without a failed job; refusing to retry." >&2
+            exit 1
+          fi
+
+          eligible=true
+          while IFS= read -r job; do
+            job_id="$(jq -r '.id' <<< "$job")"
+            job_name="$(jq -r '.name' <<< "$job")"
+            conclusion="$(jq -r '.conclusion // "missing"' <<< "$job")"
+            if [[ "$conclusion" != failure && "$conclusion" != startup_failure ]]; then
+              echo "Not retrying ${job_name}: unsupported conclusion ${conclusion}."
+              eligible=false
+              continue
+            fi
+
+            check_url="$(jq -r '.check_run_url' <<< "$job")"
+            check_endpoint="${check_url#https://api.github.com/}"
+            evidence_file="${RUNNER_TEMP}/job-${job_id}-evidence.txt"
+            gh api "$check_endpoint" \
+              --jq '[.output.title, .output.summary, .output.text] | map(select(. != null)) | .[]' \
+              > "$evidence_file"
+            gh api --paginate "${check_endpoint}/annotations?per_page=100" \
+              --jq '.[] | [.title, .message, .raw_details] | map(select(. != null)) | .[]' \
+              >> "$evidence_file"
+
+            # Job logs contain runner-control messages that are not guaranteed
+            # to appear in check annotations. Failure to download them is not a
+            # fallback: the remaining evidence must still independently match.
+            log_archive="${RUNNER_TEMP}/job-${job_id}-logs"
+            if gh api "repos/${REPOSITORY}/actions/jobs/${job_id}/logs" > "$log_archive" 2>/dev/null; then
+              if ! unzip -p "$log_archive" >> "$evidence_file" 2>/dev/null; then
+                cat "$log_archive" >> "$evidence_file"
+              fi
+            fi
+
+            if grep -Fqi 'has exceeded the maximum execution time' "$evidence_file"; then
+              echo "Not retrying ${job_name}: GitHub reports a job timeout."
+              eligible=false
+            elif grep -Fq 'The hosted runner lost communication with the server' "$evidence_file"; then
+              echo "Retrying ${job_name}: GitHub reports hosted-runner communication loss."
+            elif grep -Fq 'The job was not acquired by Runner of type hosted even after multiple attempts' "$evidence_file"; then
+              echo "Retrying ${job_name}: GitHub reports that no hosted runner acquired the job."
+            elif grep -Fq 'The runner has received a shutdown signal' "$evidence_file" && \
+                 grep -Eiq '(exit (code|status) 143|exited with (exit )?code 143)' "$evidence_file"; then
+              echo "Retrying ${job_name}: hosted-runner shutdown is corroborated by exit 143."
+            else
+              echo "Not retrying ${job_name}: no recognized hosted-runner failure evidence."
+              eligible=false
+            fi
+          done < <(jq -c '.[]' <<< "$failures")
+
+          if [[ "$eligible" != true ]]; then
+            echo "At least one failure was not infrastructure-only; leaving the workflow red."
+            exit 0
+          fi
+
+          gh api --method POST "repos/${REPOSITORY}/actions/runs/${RUN_ID}/rerun-failed-jobs"
+          echo "All ${failure_count} failed jobs were infrastructure-only; requested one failed-job rerun."

--- a/justfile
+++ b/justfile
@@ -159,8 +159,8 @@ oracle:
     JETSTREAM_ORACLE_MODE=stress gotestsum --format-hide-empty-pkg --format-icons hivis -- -count=1 ./internal/oracle -run TestOracle_DefaultLifecycle
 
 # Sweeps oracle stress mode across randomly-chosen seeds. Intended for the
-# scheduled CI job, which runs several smaller sweeps each day to reduce the
-# blast radius of ARC runner failures. The per-seed workload is governed
+# scheduled CI job, which runs one seed per matrix job to reduce the blast
+# radius of hosted-runner failures. The per-seed workload is governed
 # entirely by JETSTREAM_ORACLE_MODE=stress (see internal/oracle/config.go) so
 # there is a single source of truth: do not reintroduce account/record/event
 # overrides here. Pass SEEDS explicitly to grow or shrink a local run.
@@ -169,7 +169,7 @@ oracle:
 # fault injection is on by default (JETSTREAM_ORACLE_FAULT_MODE=swarm); the
 # sweep relies on it to exercise backfill retry/recovery and live reconnect/
 # resume recovery on every seed.
-oracle-sweep SEEDS="10" RACE="":
+oracle-sweep SEEDS="10" RACE="" FIXED_SEED="":
     #!/usr/bin/env bash
     set -euo pipefail
 
@@ -181,13 +181,29 @@ oracle-sweep SEEDS="10" RACE="":
     artifact_root="${ORACLE_ARTIFACT_DIR:-oracle-artifacts}"
     mkdir -p "${artifact_root}"
 
+    # CI supplies a fixed seed for each matrix shard so an infrastructure-only
+    # rerun repeats the interrupted workload rather than silently substituting
+    # a different random scenario. Local multi-seed sweeps continue to draw
+    # fresh seeds by default.
+    fixed_seed="{{FIXED_SEED}}"
+    if [[ -n "${fixed_seed}" ]]; then
+        if [[ "{{SEEDS}}" != "1" ]]; then
+            echo "oracle-sweep: FIXED_SEED requires SEEDS=1" >&2
+            exit 2
+        fi
+        if [[ ! "${fixed_seed}" =~ ^[0-9]+$ ]]; then
+            echo "oracle-sweep: FIXED_SEED must be an unsigned decimal integer" >&2
+            exit 2
+        fi
+    fi
+
     # RACE="" (default): no race detector, 30m per-seed timeout. Any non-empty
     # RACE arg enables `-race` and raises the timeout to 90m, because the race
     # detector slows execution ~5-15x and inflates memory; the #107 race lane
-    # runs FEW seeds within this larger budget rather than the full nightly
-    # count. The restart tier re-execs the SAME test binary as its child
-    # (os.Args[0]), so -race instruments both the parent harness and the killed
-    # child — the data-race coverage is real on both tiers, not just the parent.
+    # runs at a low seed count. The restart tier re-execs the SAME test binary
+    # as its child (os.Args[0]), so -race instruments both the parent harness and
+    # the killed child — the data-race coverage is real on both tiers, not just
+    # the parent.
     race_flag=()
     per_seed_timeout="30m"
     if [[ -n "{{RACE}}" ]]; then
@@ -201,7 +217,11 @@ oracle-sweep SEEDS="10" RACE="":
         # runs explore different points in the state space instead of replaying
         # a fixed 1..N. /dev/urandom is portable across the Linux CI runner and
         # macOS dev machines; the failing seed is printed below for exact repro.
-        seed="$(od -An -N8 -tu8 /dev/urandom | tr -d ' ')"
+        if [[ -n "${fixed_seed}" ]]; then
+            seed="${fixed_seed}"
+        else
+            seed="$(od -An -N8 -tu8 /dev/urandom | tr -d ' ')"
+        fi
         seed_dir="${artifact_root}/seed-${i}-${seed}"
         mkdir -p "${seed_dir}"
         echo "::group::oracle ${i}/{{SEEDS}} seed=${seed}"
@@ -209,7 +229,7 @@ oracle-sweep SEEDS="10" RACE="":
         # GOTRACEBACK=all makes the runtime print every goroutine's stack when
         # the test -timeout fires, so a hang is diagnosable instead of a bare
         # job kill. The per-seed -timeout (30m, matching the mutation campaign)
-        # is deliberately far below the job budget (timeout-minutes: 360) so the
+        # is deliberately below the corresponding 45m/110m CI job budget so the
         # dump prints and the artifact upload runs before the job is killed; a
         # healthy stress seed completes in minutes. JETSTREAM_ORACLE_TRACE_DIR
         # redirects the harness trace from an ephemeral t.ArtifactDir() into the
@@ -325,6 +345,25 @@ fuzz DURATION="10s" *ARGS="./...":
             go test "$pkg" -run='^$' -fuzz="^${t}$" -fuzztime={{DURATION}}
         done
     done
+
+# Runs exactly one fuzz target. Scheduled CI uses this entry point for matrix
+# shards so one runner loss cannot discard the other targets' completed work.
+fuzz-target DURATION PACKAGE TARGET:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    pkg="{{PACKAGE}}"
+    target="{{TARGET}}"
+    if [[ ! "${target}" =~ ^Fuzz[[:alnum:]_]+$ ]]; then
+        echo "fuzz-target: invalid target ${target}" >&2
+        exit 2
+    fi
+    listed="$(go test "${pkg}" -list "^${target}$" -run '^$' -count=1)"
+    if ! grep -Fxq -- "${target}" <<< "${listed}"; then
+        echo "fuzz-target: ${target} does not exist in ${pkg}" >&2
+        exit 2
+    fi
+    echo "=== FUZZ ${target} (${pkg}) ==="
+    go test "${pkg}" -run='^$' -fuzz="^${target}$" -fuzztime={{DURATION}}
 
 # Generate Go XRPC types from the lexicons in ./lexicons.
 # The com.atproto package mapping exists only so lexgen can resolve

--- a/testing/ci/workflows_test.go
+++ b/testing/ci/workflows_test.go
@@ -1,0 +1,129 @@
+package ci_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFuzzWorkflowShardsEveryTarget(t *testing.T) {
+	t.Parallel()
+
+	root := repoRoot(t)
+	workflow := readFile(t, filepath.Join(root, ".github/workflows/ci-scheduled.yml"))
+
+	re := regexp.MustCompile(`\{ package: "([^"]+)", target: (Fuzz[[:alnum:]_]+) \}`)
+	got := make([]string, 0)
+	for _, match := range re.FindAllStringSubmatch(workflow, -1) {
+		got = append(got, match[1]+"/"+match[2])
+	}
+	sort.Strings(got)
+
+	want := fuzzTargets(t, root)
+	require.Equal(t, want, got, "the scheduled fuzz matrix must contain every fuzz target exactly once")
+	require.NotContains(t, workflow, "just fuzz 300s", "scheduled fuzzing must not run every target on one runner")
+	require.Contains(t, workflow, "just fuzz-target 300s", "each matrix leg must run one target")
+}
+
+func TestOracleWorkflowUsesStableSingleSeedShards(t *testing.T) {
+	t.Parallel()
+
+	root := repoRoot(t)
+	workflow := readFile(t, filepath.Join(root, ".github/workflows/oracle-scheduled.yml"))
+	justfile := readFile(t, filepath.Join(root, "justfile"))
+
+	require.Contains(t, workflow, "fail-fast: false")
+	require.Contains(t, workflow, "matrix.seed")
+	require.Contains(t, workflow, `just oracle-sweep 1 "" "$ORACLE_SEED"`)
+	require.Contains(t, workflow, `just oracle-sweep 1 race "$ORACLE_SEED"`)
+	require.Contains(t, workflow, `github.event.inputs.seeds || '5'`)
+	require.Contains(t, workflow, `github.event.inputs.race_seeds || '1'`)
+	require.Contains(t, justfile, `oracle-sweep SEEDS="10" RACE="" FIXED_SEED=""`)
+	require.Contains(t, justfile, `fixed_seed="{{FIXED_SEED}}"`)
+}
+
+func TestInfrastructureRetryIsNarrowAndOneShot(t *testing.T) {
+	t.Parallel()
+
+	workflow := readFile(t, filepath.Join(repoRoot(t), ".github/workflows/retry-infrastructure-failures.yml"))
+
+	require.Contains(t, workflow, "workflow_run:")
+	require.Contains(t, workflow, "run_attempt == 1")
+	require.Contains(t, workflow, "workflow_run.event == 'schedule'")
+	require.Contains(t, workflow, "workflow_run.event == 'workflow_dispatch'")
+	require.Contains(t, workflow, "workflow_run.repository.full_name == github.repository")
+	require.Contains(t, workflow, "--paginate --slurp")
+	require.Contains(t, workflow, "rerun-failed-jobs")
+	require.Contains(t, workflow, "The hosted runner lost communication with the server")
+	require.Contains(t, workflow, "The runner has received a shutdown signal")
+	timeoutVeto := strings.Index(workflow, "has exceeded the maximum execution time")
+	runnerLoss := strings.Index(workflow, "The hosted runner lost communication with the server")
+	require.NotEqual(t, -1, timeoutVeto)
+	require.Less(t, timeoutVeto, runnerLoss, "job timeout evidence must veto infrastructure retry")
+	require.NotContains(t, workflow, "actions/checkout", "the privileged retry workflow must not execute repository code")
+	require.NotContains(t, workflow, "pull_request")
+}
+
+func fuzzTargets(t *testing.T, root string) []string {
+	t.Helper()
+	var targets []string
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			if path != root && strings.HasPrefix(entry.Name(), ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(entry.Name(), "_test.go") {
+			return nil
+		}
+
+		file, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+		if err != nil {
+			return err
+		}
+		dir, err := filepath.Rel(root, filepath.Dir(path))
+		if err != nil {
+			return err
+		}
+		pkg := "."
+		if dir != "." {
+			pkg = "./" + filepath.ToSlash(dir)
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if ok && fn.Recv == nil && strings.HasPrefix(fn.Name.Name, "Fuzz") {
+				targets = append(targets, pkg+"/"+fn.Name.Name)
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	sort.Strings(targets)
+	return targets
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	require.NoError(t, err)
+	return root
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	contents, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return string(contents)
+}


### PR DESCRIPTION
## Summary

- shard all fuzz targets into independent five-minute matrix jobs
- shard oracle and race sweeps into stable, single-seed jobs
- retry failed jobs once only when every failure has positive GitHub-hosted runner-loss evidence
- keep timeouts, cancellations, test failures, races, fuzz findings, and mixed failures red
- add contract tests that prevent workflow and fuzz-matrix drift

## Security

The retry workflow is restricted to trusted scheduled/manual runs from this repository. It never checks out or executes repository code and has only actions write and checks read permissions.

## Validation

- just: lint clean; 2,404 tests passed
- one-second single-target fuzz smoke test
- workflow YAML parsing
- generated oracle matrix validation
- git diff --check